### PR TITLE
Added SQL to description

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     # Details
     url="https://github.com/kayak/pypika",
 
-    description="A query builder API for Python",
+    description="A SQL query builder API for Python",
     long_description=readme(),
 
     classifiers=[


### PR DESCRIPTION
"A query builder API" was too vague. The pika AMPQ client library also uses the term query.

This addition solves two issues:

1) clarity that this package is about SQL queries and the SQL API, and avoiding false positives for "pip search pika" and other potential searches for APIs that use "query."

2) PyPika will show up with a "pip search sql"/"SQL" search, improving pip's search results and visibility for potential users.