### PR TITLE
Added syntax for limits and offset

### DIFF
--- a/pypika/queries.py
+++ b/pypika/queries.py
@@ -516,6 +516,12 @@ class QueryBuilder(Selectable, Term):
         if self._orderbys:
             querystring += self._orderby_sql(**kwargs)
 
+        if self._offset:
+            querystring += self._offset_sql()
+
+        if self._limit:
+            querystring += self._limit_sql()
+
         if subquery:
             querystring = '({query})'.format(
                 query=querystring,
@@ -526,12 +532,6 @@ class QueryBuilder(Selectable, Term):
 
         if with_unions:
             querystring += self._union_sql(querystring)
-
-        if self._offset:
-            querystring += self._offset_sql()
-
-        if self._limit:
-            querystring += self._limit_sql()
 
         return querystring
 

--- a/pypika/tests/test_selects.py
+++ b/pypika/tests/test_selects.py
@@ -88,6 +88,31 @@ class SelectTests(unittest.TestCase):
         with self.assertRaises(AttributeError):
             Query.select(1).from_('abc').from_('efg')
 
+    def test_select_with_limit(self):
+        q1 = Query.from_('abc').select('foo')[:10]
+
+        self.assertEqual('SELECT "foo" FROM "abc" LIMIT 10', str(q1))
+
+    def test_select_with_limit__func(self):
+        q1 = Query.from_('abc').select('foo').limit(10)
+
+        self.assertEqual('SELECT "foo" FROM "abc" LIMIT 10', str(q1))
+
+    def test_select_with_offset(self):
+        q1 = Query.from_('abc').select('foo')[10:]
+
+        self.assertEqual('SELECT "foo" FROM "abc" OFFSET 10', str(q1))
+
+    def test_select_with_offset__func(self):
+        q1 = Query.from_('abc').select('foo').offset(10)
+
+        self.assertEqual('SELECT "foo" FROM "abc" OFFSET 10', str(q1))
+
+    def test_select_with_limit_and_offset(self):
+        q1 = Query.from_('abc').select('foo')[10:10]
+
+        self.assertEqual('SELECT "foo" FROM "abc" OFFSET 10 LIMIT 10', str(q1))
+
 
 class WhereTests(unittest.TestCase):
     t = Table('abc')


### PR DESCRIPTION
Added syntax for setting limits and offsets.

```
    def test_select_with_limit(self):
        q1 = Query.from_('abc').select('foo')[:10]

        self.assertEqual('SELECT "foo" FROM "abc" LIMIT 10', str(q1))

    def test_select_with_limit__func(self):
        q1 = Query.from_('abc').select('foo').limit(10)

        self.assertEqual('SELECT "foo" FROM "abc" LIMIT 10', str(q1))

    def test_select_with_offset(self):
        q1 = Query.from_('abc').select('foo')[10:]

        self.assertEqual('SELECT "foo" FROM "abc" OFFSET 10', str(q1))

    def test_select_with_offset__func(self):
        q1 = Query.from_('abc').select('foo').offset(10)

        self.assertEqual('SELECT "foo" FROM "abc" OFFSET 10', str(q1))

    def test_select_with_limit_and_offset(self):
        q1 = Query.from_('abc').select('foo')[10:10]

        self.assertEqual('SELECT "foo" FROM "abc" OFFSET 10 LIMIT 10', str(q1))
```