### PR TITLE
Added an is_aggregate flag to Term

### DIFF
--- a/pypika/functions.py
+++ b/pypika/functions.py
@@ -3,7 +3,7 @@
 Package for SQL functions wrappers
 """
 from pypika.enums import SqlTypes
-from pypika.terms import Function, Star
+from pypika.terms import Function, Star, AggregateFunction
 from pypika.utils import builder
 
 __author__ = "Timothy Heys"
@@ -29,32 +29,32 @@ class Count(Function):
 
 
 # Arithmetic Functions
-class Sum(Function):
+class Sum(AggregateFunction):
     def __init__(self, term, alias=None):
         super(Sum, self).__init__('SUM', term, alias=alias)
 
 
-class Avg(Function):
+class Avg(AggregateFunction):
     def __init__(self, term, alias=None):
         super(Avg, self).__init__('AVG', term, alias=alias)
 
 
-class Min(Function):
+class Min(AggregateFunction):
     def __init__(self, term, alias=None):
         super(Min, self).__init__('MIN', term, alias=alias)
 
 
-class Max(Function):
+class Max(AggregateFunction):
     def __init__(self, term, alias=None):
         super(Max, self).__init__('MAX', term, alias=alias)
 
 
-class Std(Function):
+class Std(AggregateFunction):
     def __init__(self, term, alias=None):
         super(Std, self).__init__('STD', term, alias=alias)
 
 
-class StdDev(Function):
+class StdDev(AggregateFunction):
     def __init__(self, term, alias=None):
         super(StdDev, self).__init__('STDDEV', term, alias=alias)
 

--- a/pypika/tests/test_aggregate.py
+++ b/pypika/tests/test_aggregate.py
@@ -1,0 +1,50 @@
+# coding: utf-8
+import unittest
+
+from pypika import Case
+from pypika import Field, functions as fn
+
+
+class IsAggregateTests(unittest.TestCase):
+    def test__field_is_not_aggregate(self):
+        v = Field('foo')
+        self.assertFalse(v.is_aggregate)
+
+    def test__field_arithmetic_is_not_aggregate(self):
+        v = Field('foo') + Field('bar')
+        self.assertFalse(v.is_aggregate)
+
+    def test__agg_func_is_aggregate(self):
+        v = fn.Sum(Field('foo'))
+        self.assertTrue(v.is_aggregate)
+
+    def test__agg_func_arithmetic_is_aggregate(self):
+        v = fn.Sum(Field('foo')) / fn.Sum(Field('foo'))
+        self.assertTrue(v.is_aggregate)
+
+    def test__mixed_func_arithmetic_is_not_aggregate(self):
+        v = Field('foo') / fn.Sum(Field('foo'))
+        self.assertFalse(v.is_aggregate)
+
+    def test__agg_case_is_aggregate(self):
+        v = Case() \
+            .when(Field('foo') == 1, fn.Sum(Field('bar'))) \
+            .when(Field('foo') == 2, fn.Sum(Field('fiz'))) \
+            .else_(fn.Sum(Field('fiz')))
+
+        self.assertTrue(v.is_aggregate)
+
+    def test__mixed_case_is_not_aggregate(self):
+        v = Case() \
+            .when(Field('foo') == 1, fn.Sum(Field('bar'))) \
+            .when(Field('foo') == 2, Field('fiz'))
+
+        self.assertFalse(v.is_aggregate)
+
+    def test__case_mixed_else_is_not_aggregate(self):
+        v = Case() \
+            .when(Field('foo') == 1, fn.Sum(Field('bar'))) \
+            .when(Field('foo') == 2, fn.Sum(Field('fiz'))) \
+            .else_(Field('fiz'))
+
+        self.assertFalse(v.is_aggregate)


### PR DESCRIPTION
Created an is_aggregate flag so that any term or expression can be evaluated.  This flag is always False unless the term is composed of all aggregate functions.  This is helpful when determining whether an expression is valid or not when it is required to be aggregated (not in the group by clause).