### PR TITLE
Added VARCHAR to SqlTypes enum

### DIFF
--- a/pypika/enums.py
+++ b/pypika/enums.py
@@ -72,3 +72,4 @@ class SqlTypes(Enum):
     utf8 = 'utf8'
     DATE = 'DATE'
     TIMESTAMP = 'TIMESTAMP'
+    VARCHAR = 'VARCHAR'

--- a/pypika/tests/test_functions.py
+++ b/pypika/tests/test_functions.py
@@ -391,6 +391,11 @@ class CastTests(unittest.TestCase):
         self.assertEqual("SELECT TIMESTAMP(\"foo\") FROM \"abc\"", str(q1))
         self.assertEqual("SELECT CAST(\"foo\" AS TIMESTAMP) FROM \"abc\"", str(q2))
 
+    def test__cast__varchar(self):
+        q = Q.from_(self.t).select(fn.Cast(self.t.foo, SqlTypes.VARCHAR))
+
+        self.assertEqual("SELECT CAST(\"foo\" AS VARCHAR) FROM \"abc\"", str(q))
+
     def test__tochar__(self):
         q = Q.from_(self.t).select(fn.ToChar(self.t.foo, "SomeFormat"))
 


### PR DESCRIPTION
Casting e.g. from int to str using 'VARCHAR' (as a regular Python variable) doesn't work because PyPika wraps it in quotes which leads to Vertica not accepting it as a type. Type stings in the enum class SqlTypes aren't wrapped and thus can be used with CAST.

I added 'VARCHAR' to the SqlTypes enumerate to allow usage with CAST. 