### PR TITLE
No alias when using GROUPBY on a Function

### DIFF
--- a/pypika/queries.py
+++ b/pypika/queries.py
@@ -542,7 +542,7 @@ class QueryBuilder(Selectable, Term):
     def _where_sql(self, quote_char=None, **kwargs):
         return ' WHERE {where}'.format(where=self._wheres.get_sql(quote_char=quote_char, subquery=True, **kwargs))
 
-    def _group_sql(self, quote_char=None, **kwargs):
+    def _group_sql(self, quote_char=None, with_alias=None, **kwargs):
         return ' GROUP BY {groupby}'.format(
             groupby=','.join(term.get_sql(quote_char=quote_char, **kwargs)
                              for term in self._groupbys)

--- a/pypika/terms.py
+++ b/pypika/terms.py
@@ -618,7 +618,7 @@ class Function(Term):
 
         function_sql = self.get_function_sql(with_namespace=with_namespace, quote_char=quote_char)
 
-        if self.alias is None:
+        if not with_alias or self.alias is None:
             return function_sql
 
         return alias_sql(function_sql, self.alias, quote_char)

--- a/pypika/tests/test_selects.py
+++ b/pypika/tests/test_selects.py
@@ -210,6 +210,15 @@ class GroupByTests(unittest.TestCase):
 
         self.assertEqual('SELECT "foo",COUNT(DISTINCT *) FROM "abc" GROUP BY "foo"', str(q))
 
+    def test_groupby__alias(self):
+        q = Query.from_(self.t).select(
+            fn.Sum(self.t.foo).as_('bar'),
+        ).groupby(
+            fn.Sum(self.t.foo).as_('bar'),
+        )
+
+        self.assertEqual('SELECT SUM("foo") "bar" FROM "abc" GROUP BY SUM("foo")', str(q))
+
 
 class HavingTests(unittest.TestCase):
     table_abc, table_efg = Tables('abc', 'efg')
@@ -353,7 +362,7 @@ class AliasTests(unittest.TestCase):
     def test_case_using_constructor_param(self):
         q = Query.from_(self.t).select(Case(alias='bar').when(self.t.foo == 1, 'a').else_('b'))
 
-        self.assertEqual("SELECT CASE WHEN \"foo\"=1 THEN 'a' ELSE 'b' END \"bar\" FROM \"abc\"", str(q)) \
+        self.assertEqual("SELECT CASE WHEN \"foo\"=1 THEN 'a' ELSE 'b' END \"bar\" FROM \"abc\"", str(q))
 
     def test_select__multiple_tables(self):
         table_abc, table_efg = Table('abc', alias='q0'), Table('efg', alias='q1')


### PR DESCRIPTION
This PR fixes a bug where using GROUP BY on a Function creates an invalid Vertica query if the Function has an alias set. 