### PR TITLE
Fixes #43 Added support for pairs with rollup

### DIFF
--- a/pypika/queries.py
+++ b/pypika/queries.py
@@ -2,7 +2,7 @@
 
 from pypika.enums import JoinType, UnionType
 from pypika.utils import JoinException, UnionException, RollupException, builder, alias_sql
-from .terms import Field, Star, Term, Function, ArithmeticExpression, Rollup
+from .terms import Field, Star, Term, Function, ArithmeticExpression, Rollup, ListField
 
 __author__ = "Timothy Heys"
 __email__ = "theys@kayak.com"
@@ -286,6 +286,10 @@ class QueryBuilder(Selectable, Term):
 
         if self._mysql_rollup:
             raise AttributeError("'Query' object has no attribute '%s'" % 'rollup')
+
+        terms = [ListField(term) if isinstance(term, (list, tuple, set))
+                 else term
+                 for term in terms]
 
         if for_mysql:
             if not terms and not self._groupbys:

--- a/pypika/terms.py
+++ b/pypika/terms.py
@@ -256,8 +256,9 @@ class Star(Field):
         return '*'
 
 
-class ListField(object):
+class ListField(Term):
     def __init__(self, values):
+        super(ListField, self).__init__()
         self.values = values
 
     def __str__(self):
@@ -265,7 +266,7 @@ class ListField(object):
 
     def get_sql(self, **kwargs):
         return '({})'.format(
-            ','.join(term.get_sql()
+            ','.join(term.get_sql(**kwargs)
                      for term in self.values)
         )
 

--- a/pypika/tests/test_groupby_modifiers.py
+++ b/pypika/tests/test_groupby_modifiers.py
@@ -142,3 +142,13 @@ class RollupTests(unittest.TestCase):
         )
 
         self.assertEqual('SELECT "foo","fiz",SUM("bar") FROM "abc" GROUP BY ROLLUP("foo"),ROLLUP("fiz")', str(q))
+
+    def test_verticaoracle_rollups_with_parity(self):
+        q = Query.from_(self.table).select(
+            self.table.buz,
+        ).rollup(
+            [self.table.foo, self.table.bar],
+            self.table.fiz,
+        )
+
+        self.assertEqual('SELECT "buz" FROM "abc" GROUP BY ROLLUP(("foo","bar"),"fiz")', str(q))


### PR DESCRIPTION
Fixed rollup to work with pairs of group by fields.  Now passing a list/tuple/set of dimension keys as a parameter to rollup will roll up pairs of the dimension.  This is useful when items in the group by clause which have a 1:1 relationship need to be included in the roll up, such as an ID and a display name for a table where every instance of ID matches one instance of display name.