### PR TITLE
Infinite Recursion when using Not criterion

### DIFF
--- a/pypika/__init__.py
+++ b/pypika/__init__.py
@@ -45,6 +45,7 @@ from .queries import (Query,
                       Tuple)
 from .terms import (Field,
                     Case,
+                    Not,
                     Interval,
                     Rollup)
 from .utils import (JoinException,

--- a/pypika/queries.py
+++ b/pypika/queries.py
@@ -1,5 +1,4 @@
 # coding: utf8
-
 from pypika.enums import (
     Dialects,
     JoinType,
@@ -11,6 +10,7 @@ from pypika.utils import (
     UnionException,
     alias_sql,
     builder,
+    ignoredeepcopy,
 )
 from .terms import (
     ArithmeticExpression,
@@ -37,11 +37,8 @@ class Selectable(object):
     def star(self):
         return Star(self)
 
+    @ignoredeepcopy
     def __getattr__(self, name):
-        # This prevents Fields being when deepcopy functions are called
-        if name in ['__deepcopy__', '__getstate__', '__setstate__', '__getnewargs__']:
-            raise AttributeError("'Table' object has no attribute '%s'" % name)
-
         return self.field(name)
 
 

--- a/pypika/tests/test_utils.py
+++ b/pypika/tests/test_utils.py
@@ -1,0 +1,25 @@
+# coding: utf8
+import unittest
+
+from pypika import utils
+
+__author__ = "Timothy Heys"
+__email__ = "theys@kayak.com"
+
+
+class ImmutabilityTests(unittest.TestCase):
+    def test_raise_attribute_error_for_deepcopy(self):
+        with self.assertRaises(AttributeError):
+            utils.raise_attribute_for_copy('Test', '__deepcopy__')
+
+    def test_raise_attribute_error_for_getstate(self):
+        with self.assertRaises(AttributeError):
+            utils.raise_attribute_for_copy('Test', '__getstate__')
+
+    def test_raise_attribute_error_for_setstate(self):
+        with self.assertRaises(AttributeError):
+            utils.raise_attribute_for_copy('Test', '__setstate__')
+
+    def test_raise_attribute_error_for_getnewargs(self):
+        with self.assertRaises(AttributeError):
+            utils.raise_attribute_for_copy('Test', '__getnewargs__')


### PR DESCRIPTION
Added a catch for deepycopy function calls to the __getattr__ function in the Not class to fix an infinite recursion issue.