### PR TITLE
Unions used in FROM clause

### DIFF
--- a/pypika/queries.py
+++ b/pypika/queries.py
@@ -1,6 +1,5 @@
 # coding: utf8
 from pypika.enums import (
-    Dialects,
     JoinType,
     UnionType,
 )
@@ -563,14 +562,14 @@ class QueryBuilder(Selectable, Term):
         if self._offset:
             querystring += self._offset_sql()
 
+        if with_unions:
+            querystring = self._union_sql(querystring, **kwargs)
+
         if subquery:
             querystring = '({query})'.format(query=querystring)
 
         if with_alias:
             return alias_sql(querystring, self.alias or self.table_name, kwargs.get('quote_char'))
-
-        if with_unions:
-            querystring = self._union_sql(querystring, **kwargs)
 
         return querystring
 
@@ -620,9 +619,9 @@ class QueryBuilder(Selectable, Term):
             table=self._insert_table.get_sql(with_alias=False, **kwargs),
         )
 
-    def _from_sql(self, **kwargs):
+    def _from_sql(self, subquery=None, with_alias=None, with_unions=None, **kwargs):
         return ' FROM {selectable}'.format(selectable=','.join(
-            clause.get_sql(subquery=True, with_alias=kwargs['with_namespace'], **kwargs)
+            clause.get_sql(subquery=True, with_alias=kwargs['with_namespace'], with_unions=True, **kwargs)
             for clause in self._from
         ))
 

--- a/pypika/tests/test_joins.py
+++ b/pypika/tests/test_joins.py
@@ -7,6 +7,7 @@ from pypika import (
     Tables,
     JoinException,
     functions as fn,
+    analytics as an,
     JoinType,
     UnionException,
     Interval,
@@ -319,3 +320,11 @@ class UnionTests(unittest.TestCase):
         query2 = Query.from_(self.table2).select(self.table2.bar)
 
         self.assertEqual('SELECT `foo` FROM `abc` UNION SELECT `bar` FROM `efg`', str(query1 + query2))
+
+    def test_union_as_subquery(self):
+        abc, efg = Tables('abc', 'efg')
+        hij = Query.from_(abc).select(abc.t).union(Query.from_(efg).select(efg.t))
+        q = Query.from_(hij).select(fn.Avg(hij.t))
+
+        self.assertEqual('SELECT AVG("sq0"."t") FROM ((SELECT "t" FROM "abc") UNION (SELECT "t" FROM "efg")) "sq0"',
+                         str(q))


### PR DESCRIPTION
Fixes #79 Fixed an issue where unions were not rendered in the query when used as a from clause