### PR TITLE
Fixes #85 Bundle requirements.txt in the dist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include README.rst
+include requirements.txt

--- a/pypika/__init__.py
+++ b/pypika/__init__.py
@@ -68,4 +68,4 @@ from .utils import (
 
 __author__ = "Timothy Heys"
 __email__ = "theys@kayak.com"
-__version__ = "0.9.2"
+__version__ = "0.9.3"


### PR DESCRIPTION
The 0.9.2 version was broken as setup.py now installs requirements from requirements.txt, but this was not included in the manifest file.