### PR TITLE
Fixed single quote escaping

### DIFF
--- a/pypika/terms.py
+++ b/pypika/terms.py
@@ -222,7 +222,8 @@ class ValueWrapper(Term):
         if isinstance(self.value, date):
             return "'%s'" % self.value.isoformat()
         if isinstance(self.value, basestring):
-            return "'%s'" % self.value
+            value = self.value.replace("'", "''")
+            return "'%s'" % value
         if isinstance(self.value, bool):
             return str.lower(str(self.value))
         if self.value is None:

--- a/pypika/tests/test_selects.py
+++ b/pypika/tests/test_selects.py
@@ -188,6 +188,11 @@ class WhereTests(unittest.TestCase):
 
         self.assertEqual('SELECT * FROM "abc" WHERE "foo"=1 AND "bar"="baz"', str(q))
 
+    def test_where_single_quote(self):
+        q1 = Query.from_(self.t).select('*').where(self.t.foo == "bar'foo")
+
+        self.assertEqual('SELECT * FROM "abc" WHERE "foo"=\'bar\'\'foo\'', str(q1))
+
     def test_where_field_equals_and(self):
         q = Query.from_(self.t).select('*').where((self.t.foo == 1) & (self.t.bar == self.t.baz))
 

--- a/pypika/tests/test_updates.py
+++ b/pypika/tests/test_updates.py
@@ -20,6 +20,11 @@ class UpdateTests(unittest.TestCase):
 
         self.assertEqual('UPDATE "abc" SET "foo"=\'bar\'', str(q))
 
+    def test_single_quote_escape_in_set(self):
+        q = Query.update(self.table_abc).set('foo', "bar'foo")
+
+        self.assertEqual('UPDATE "abc" SET "foo"=\'bar\'\'foo\'', str(q))
+
     def test_update__table_schema(self):
         table = Table('abc', 'schema1')
         q = Query.update(table).set(table.foo, 1).where(table.foo == 0)


### PR DESCRIPTION
I looked through supported dialects and it looks like all of them escape single quote by doubling it, so it should be okay without any dialect passing to .get_sql() shenanigans