### PR TITLE
implement ON DUPLICATE KEY UPDATE for MySQL

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -581,6 +581,25 @@ Multiple rows of data can be inserted either by chaining the ``insert`` function
     q = Query.into(customers).insert((1, 'Jane', 'Doe', 'jane@example.com'),
                                      (2, 'John', 'Doe', 'john@example.com'))
 
+Insert with on Duplicate Key Update
+"""""""""""""""""""""""""""""""""""
+
+.. code-block:: python
+
+    customers = Table('customers')
+
+    q = Query.into(customers)\
+        .insert(1, 'Jane', 'Doe', 'jane@example.com')\
+        .on_duplicate_key_update(customers.email, Values(customers.email))
+
+.. code-block:: sql
+
+    INSERT INTO customers VALUES (1,'Jane','Doe','jane@example.com') ON DUPLICATE KEY UPDATE `email`=VALUES(`email`)
+
+``.on_duplicate_key_update`` works similar to ``.set`` for updating rows, additionally it provides the ``Values``
+wrapper to update to the value specified in the ``INSERT`` clause.
+
+
 Insert with a SELECT Query
 """"""""""""""""""""""""""
 

--- a/pypika/queries.py
+++ b/pypika/queries.py
@@ -519,6 +519,7 @@ class QueryBuilder(Selectable, Term):
     def union(self, other):
         return _UnionQuery(self, other, UnionType.distinct)
 
+    @builder
     def union_all(self, other):
         return _UnionQuery(self, other, UnionType.all)
 

--- a/pypika/terms.py
+++ b/pypika/terms.py
@@ -210,13 +210,15 @@ class ValueWrapper(Term):
         return []
 
     def get_sql(self, quote_char=None, **kwargs):
-        sql = self._get_value_sql()
+        sql = self._get_value_sql(quote_char=quote_char, **kwargs)
         if self.alias is None:
             return sql
         return alias_sql(sql, self.alias, quote_char)
 
-    def _get_value_sql(self):
+    def _get_value_sql(self, quote_char=None, **kwargs):
         # FIXME escape values
+        if isinstance(self.value, Term):
+            return self.value.get_sql(quote_char=quote_char, **kwargs)
         if isinstance(self.value, Enum):
             return self.value.value
         if isinstance(self.value, date):
@@ -229,6 +231,15 @@ class ValueWrapper(Term):
         if self.value is None:
             return 'null'
         return str(self.value)
+
+
+class Values(Term):
+    def __init__(self, field,):
+        super(Values, self).__init__(None)
+        self.field = Field(field) if not isinstance(field, Field) else field
+
+    def get_sql(self, quote_char=None, **kwargs):
+        return 'VALUES({value})'.format(value=self.field.get_sql(quote_char=quote_char, **kwargs))
 
 
 class NullValue(Term):

--- a/pypika/tests/test_updates.py
+++ b/pypika/tests/test_updates.py
@@ -36,7 +36,7 @@ class UpdateTests(unittest.TestCase):
         self.assertEqual('UPDATE "abc" SET "foo"=null', str(q))
 
 
-class PostgesUpdateTests(unittest.TestCase):
+class PostgresUpdateTests(unittest.TestCase):
     table_abc = Table('abc')
 
     def test_update_returning_str(self):
@@ -45,10 +45,6 @@ class PostgesUpdateTests(unittest.TestCase):
         ).set('foo', 'bar').returning('id')
 
         self.assertEqual('UPDATE "abc" SET "foo"=\'bar\' WHERE "foo"=0 RETURNING id', str(q))
-
-
-class PostgresUpdateTests(unittest.TestCase):
-    table_abc = Table('abc')
 
     def test_update_returning(self):
         q = PostgreSQLQuery.update(self.table_abc).where(


### PR DESCRIPTION
* I've chosen to have a similar syntax to `.set` for `.on_duplicate_key_update` to keep updating values consistent
* there's a new `Values` wrapper to represent the `VALUES` term in the new clause
