### PR TITLE
Changed `Not` to inherit from Criterion

### DIFF
--- a/pypika/terms.py
+++ b/pypika/terms.py
@@ -622,7 +622,7 @@ class Case(Term):
         return fields
 
 
-class Not(object):
+class Not(Criterion):
     def __init__(self, term):
         self.term = term
 

--- a/pypika/tests/test_selects.py
+++ b/pypika/tests/test_selects.py
@@ -188,6 +188,18 @@ class WhereTests(unittest.TestCase):
 
         self.assertEqual('SELECT * FROM "abc" WHERE "foo"=1 AND "bar"="baz"', str(q))
 
+    def test_where_field_equals_where_not(self):
+        q = Query.from_(self.t).select('*').where((self.t.foo == 1).negate()).where(self.t.bar == self.t.baz)
+
+        self.assertEqual('SELECT * FROM "abc" WHERE NOT "foo"=1 AND "bar"="baz"', str(q))
+
+    def test_where_field_equals_where_two_not(self):
+        q = Query.from_(self.t).select('*').where(
+            (self.t.foo == 1).negate()
+        ).where((self.t.bar == self.t.baz).negate())
+
+        self.assertEqual('SELECT * FROM "abc" WHERE NOT "foo"=1 AND NOT "bar"="baz"', str(q))
+
     def test_where_single_quote(self):
         q1 = Query.from_(self.t).select('*').where(self.t.foo == "bar'foo")
 


### PR DESCRIPTION
Currently `Not` does not inherit from `Criterion`, and because of it you can't build complex criterion from negated term, even though it is valid in sql