### PR TITLE
Add for_ to base term class.

### DIFF
--- a/pypika/terms.py
+++ b/pypika/terms.py
@@ -69,6 +69,17 @@ class Term(object):
 
         return ValueWrapper(val)
 
+    def for_(self, table):
+        """
+        Replaces the tables of this term for the table parameter provided.  The base implementation returns self because not all terms have a table property.
+
+        :param table:
+            The table to replace with.
+        :return:
+            Self.
+        """
+        return self
+
     def fields(self):
         return [self]
 
@@ -678,9 +689,7 @@ class Function(Term):
         :return:
             A copy of the field with it's table value replaced.
         """
-        self.args = [param.for_(table) if hasattr(param, 'for_')
-                     else param
-                     for param in self.args]
+        self.args = [param.for_(table) for param in self.args]
 
     def get_special_params_sql(self, **kwargs):
         pass

--- a/pypika/tests/test_criterions.py
+++ b/pypika/tests/test_criterions.py
@@ -237,6 +237,11 @@ class CriterionTests(unittest.TestCase):
         self.assertEqual('"foo">=1', str(c1))
         self.assertEqual('"crit"."foo">=-1', str(c2))
 
+    def test__criterion_for_with_value(self):
+        c = (Field('foo') > 1).for_(self.t)
+        self.assertEqual(c.left, self.t)
+        self.assertEqual(c.tables_, {self.t})
+
 
 class NotTests(unittest.TestCase):
     table_abc = Table('abc', alias='cx0')


### PR DESCRIPTION
for_ is not defined for all terms, like ValueWrapper. This adds a noop
to the base for_ definition for convenience.

When running for_ on a criterion, Field("x") > 1, this crashes due to
ValueWrapper not having it implemented.