### PR TITLE
Mark constants as aggregate values

### DIFF
--- a/pypika/terms.py
+++ b/pypika/terms.py
@@ -216,7 +216,7 @@ class Term(object):
 
 
 class ValueWrapper(Term):
-    is_aggregate = None
+    is_aggregate = True
 
     def __init__(self, value, alias=None):
         super(ValueWrapper, self).__init__(alias)

--- a/pypika/tests/test_aggregate.py
+++ b/pypika/tests/test_aggregate.py
@@ -10,13 +10,13 @@ class IsAggregateTests(unittest.TestCase):
         v = Field('foo')
         self.assertFalse(v.is_aggregate)
 
-    def test__constant_is_neither_aggr_or_not(self):
+    def test__constant_is_aggregate(self):
         v = ValueWrapper(100)
-        self.assertIsNone(v.is_aggregate)
+        self.assertTrue(v.is_aggregate)
 
-    def test__constant_arithmetic_is_neither_aggr_or_not(self):
+    def test__constant_arithmetic_is_aggregate(self):
         v = ValueWrapper(100) + ValueWrapper(100)
-        self.assertIsNone(v.is_aggregate)
+        self.assertTrue(v.is_aggregate)
 
     def test__field_arithmetic_is_not_aggregate(self):
         v = Field('foo') + Field('bar')
@@ -73,10 +73,10 @@ class IsAggregateTests(unittest.TestCase):
 
         self.assertTrue(v.is_aggregate)
 
-    def test__case_all_constants_is_neither_aggr_or_not(self):
+    def test__case_all_constants_is_aggregate(self):
         v = Case() \
             .when(Field('foo') == 1, 1) \
             .when(Field('foo') == 2, 2) \
             .else_(3)
 
-        self.assertIsNone(v.is_aggregate)
+        self.assertTrue(v.is_aggregate)


### PR DESCRIPTION
Changing the denotation of constants and expressions composed of only constants to aggregate.

The purpose of this flag is to know if an expression can be used in a group by query, which constants can.