### PR TITLE
Reverted is_aggregate for ValueWrapper to be None

### DIFF
--- a/pypika/terms.py
+++ b/pypika/terms.py
@@ -216,7 +216,7 @@ class Term(object):
 
 
 class ValueWrapper(Term):
-    is_aggregate = True
+    is_aggregate = None
 
     def __init__(self, value, alias=None):
         super(ValueWrapper, self).__init__(alias)
@@ -667,7 +667,6 @@ class Case(Term):
                        for table in self._else.tables_}
 
         return tables
-
 
 
 class Not(Criterion):

--- a/pypika/tests/test_aggregate.py
+++ b/pypika/tests/test_aggregate.py
@@ -10,13 +10,13 @@ class IsAggregateTests(unittest.TestCase):
         v = Field('foo')
         self.assertFalse(v.is_aggregate)
 
-    def test__constant_is_aggregate(self):
+    def test__constant_is_aggregate_none(self):
         v = ValueWrapper(100)
-        self.assertTrue(v.is_aggregate)
+        self.assertIsNone(v.is_aggregate)
 
-    def test__constant_arithmetic_is_aggregate(self):
+    def test__constant_arithmetic_is_aggregate_none(self):
         v = ValueWrapper(100) + ValueWrapper(100)
-        self.assertTrue(v.is_aggregate)
+        self.assertIsNone(v.is_aggregate)
 
     def test__field_arithmetic_is_not_aggregate(self):
         v = Field('foo') + Field('bar')
@@ -73,10 +73,10 @@ class IsAggregateTests(unittest.TestCase):
 
         self.assertTrue(v.is_aggregate)
 
-    def test__case_all_constants_is_aggregate(self):
+    def test__case_all_constants_is_aggregate_none(self):
         v = Case() \
             .when(Field('foo') == 1, 1) \
             .when(Field('foo') == 2, 2) \
             .else_(3)
 
-        self.assertTrue(v.is_aggregate)
+        self.assertIsNone(v.is_aggregate)


### PR DESCRIPTION
This flag is used to determine if a pypika expression can be or must be part of the group by clause. There are cases where it is ambiguous, as with constants, and that needs to be modeled as well. I had forgotten this and set `is_aggregate=True` when it can be used in the group by clause. Since I need to be able to determine if it can also not be aggregatable in these cases, setting it back to `None`