### PR TITLE
Replaced the usage of deepcopy

### DIFF
--- a/pypika/queries.py
+++ b/pypika/queries.py
@@ -9,7 +9,7 @@ from pypika.utils import (
     UnionException,
     alias_sql,
     builder,
-    ignoredeepcopy,
+    ignore_copy,
 )
 from .terms import (
     ArithmeticExpression,
@@ -37,7 +37,7 @@ class Selectable(object):
     def star(self):
         return Star(self)
 
-    @ignoredeepcopy
+    @ignore_copy
     def __getattr__(self, name):
         return self.field(name)
 
@@ -332,6 +332,14 @@ class QueryBuilder(Selectable, Term):
         self.quote_char = quote_char
         self.dialect = dialect
         self.wrap_union_queries = wrap_union_queries
+
+    def __copy__(self):
+        newone = type(self)()
+        newone.__dict__.update(self.__dict__)
+        for key, value in self.__dict__.items():
+            if isinstance(value, (set, list)):
+                newone.__dict__[key] = type(value)(x for x in value)
+        return newone
 
     @builder
     def from_(self, selectable):

--- a/pypika/terms.py
+++ b/pypika/terms.py
@@ -16,7 +16,7 @@ from pypika.utils import (
     CaseException,
     alias_sql,
     builder,
-    ignoredeepcopy,
+    ignore_copy,
     resolve_is_aggregate,
 )
 
@@ -704,7 +704,7 @@ class Not(Criterion):
     def __str__(self):
         return self.get_sql(quote_char='"')
 
-    @ignoredeepcopy
+    @ignore_copy
     def __getattr__(self, name):
         """
         Delegate method calls to the class wrapped by Not().

--- a/pypika/tests/test_immutability.py
+++ b/pypika/tests/test_immutability.py
@@ -1,0 +1,27 @@
+import unittest
+
+from pypika import (
+    Query,
+    Tables,
+)
+
+
+class ImmutabilityTests(unittest.TestCase):
+    table_a, table_b = Tables('a', 'b')
+
+    def test_select_returns_new_query_instance(self):
+        query_a = Query.from_(self.table_a).select(self.table_a.foo)
+        query_b = query_a.select(self.table_a.bar)
+
+        self.assertNotEqual(str(query_a), str(query_b))
+
+    def test_queries_after_join(self):
+        query1 = Query.from_(self.table_a) \
+            .select(self.table_a.foo)
+        query2 = query1 \
+            .join(self.table_b).on(self.table_a.foo == self.table_b.bar) \
+            .select(self.table_b.buz)
+
+        self.assertEqual('SELECT "foo" FROM "a"', str(query1))
+        self.assertEqual('SELECT "a"."foo","b"."buz" FROM "a" '
+                         'JOIN "b" ON "a"."foo"="b"."bar"', str(query2))

--- a/pypika/tests/test_joins.py
+++ b/pypika/tests/test_joins.py
@@ -264,19 +264,12 @@ class JoinBehaviorTests(unittest.TestCase):
         with self.assertRaises(ValueError):
             Query.from_(self.table_abc).join('this is a string')
 
-    def test_immutable__queries_after_join(self):
-        query1 = Query.from_(self.table_abc).select(self.table_abc.foo)
-        query2 = query1.join(self.table_efg).on(self.table_abc.foo == self.table_efg.bar).select(self.table_efg.buz)
-
-        self.assertEqual('SELECT "foo" FROM "abc"', str(query1))
-        self.assertEqual('SELECT "abc"."foo","efg"."buz" FROM "abc" '
-                         'JOIN "efg" ON "abc"."foo"="efg"."bar"', str(query2))
-
     def test_immutable__tables(self):
-        query1 = Query.from_(self.table_abc).select(self.table_abc.foo)
-        query2 = Query.from_(self.table_abc).join(self.table_efg).on(self.table_abc.foo == self.table_efg.bar).select(
-            self.table_abc.foo,
-            self.table_efg.buz)
+        query1 = Query.from_(self.table_abc)\
+            .select(self.table_abc.foo)
+        query2 = Query.from_(self.table_abc) \
+            .join(self.table_efg).on(self.table_abc.foo == self.table_efg.bar) \
+            .select(self.table_abc.foo, self.table_efg.buz)
 
         self.assertEqual('SELECT "abc"."foo","efg"."buz" FROM "abc" '
                          'JOIN "efg" ON "abc"."foo"="efg"."bar"', str(query2))

--- a/pypika/utils.py
+++ b/pypika/utils.py
@@ -42,7 +42,7 @@ def builder(func):
     import copy
 
     def _copy(self, *args, **kwargs):
-        self_copy = copy.deepcopy(self)
+        self_copy = copy.copy(self)
         result = func(self_copy, *args, **kwargs)
 
         # Return self if the inner function returns None.  This way the inner function can return something
@@ -55,7 +55,7 @@ def builder(func):
     return _copy
 
 
-def ignoredeepcopy(func):
+def ignore_copy(func):
     """
     Decorator for wrapping the __getattr__ function for classes that are copied via deepcopy.  This prevents infinite
     recursion caused by deepcopy looking for magic functions in the class. Any class implementing __getattr__ that is
@@ -66,7 +66,7 @@ def ignoredeepcopy(func):
     """
 
     def _getattr(self, name):
-        if name in ['__deepcopy__', '__getstate__', '__setstate__', '__getnewargs__']:
+        if name in ['__copy__','__deepcopy__', '__getstate__', '__setstate__', '__getnewargs__']:
             raise AttributeError("'%s' object has no attribute '%s'" % (self.__class__.__name__, name))
 
         return func(self, name)


### PR DESCRIPTION
Replaced the usage of deepcopy in the @builder decorator with copy and overrode __copy__ in QueryBuilder

Fixes #160 