### PR TITLE
Fixed Query.select('field') with no from table.

### DIFF
--- a/pypika/__init__.py
+++ b/pypika/__init__.py
@@ -68,6 +68,7 @@ from .utils import (
     CaseException,
     GroupingException,
     JoinException,
+    QueryException,
     RollupException,
     UnionException,
 )

--- a/pypika/queries.py
+++ b/pypika/queries.py
@@ -1,18 +1,9 @@
 # coding: utf-8
 from functools import reduce
 
-from pypika.enums import (
+from .enums import (
     JoinType,
     UnionType,
-)
-from pypika.utils import (
-    JoinException,
-    RollupException,
-    UnionException,
-    alias_sql,
-    builder,
-    format_quotes,
-    ignore_copy,
 )
 from .terms import (
     ArithmeticExpression,
@@ -23,6 +14,16 @@ from .terms import (
     Term,
     Tuple,
     ValueWrapper,
+)
+from .utils import (
+    JoinException,
+    QueryException,
+    RollupException,
+    UnionException,
+    alias_sql,
+    builder,
+    format_quotes,
+    ignore_copy,
 )
 
 __author__ = "Timothy Heys"
@@ -636,6 +637,10 @@ class QueryBuilder(Selectable, Term):
                 for field in field_set]
 
     def _select_field_str(self, term):
+        if 0 == len(self._from):
+            raise QueryException('Cannot select {term}, no FROM table specified.'
+                                 .format(term=term))
+
         if term == '*':
             self._select_star = True
             self._selects = [Star()]

--- a/pypika/tests/test_selects.py
+++ b/pypika/tests/test_selects.py
@@ -11,6 +11,7 @@ from pypika import (
     Order,
     PostgreSQLQuery,
     Query,
+    QueryException,
     RedshiftQuery,
     Table,
     Tables,
@@ -29,6 +30,15 @@ class SelectTests(unittest.TestCase):
         q = Query.from_('abc')
 
         self.assertEqual('', str(q))
+
+    def test_select_no_from(self):
+        q = Query.select(1)
+
+        self.assertEqual('SELECT 1', str(q))
+
+    def test_select_no_from_with_field_raises_exception(self):
+        with self.assertRaises(QueryException):
+            Query.select('asdf')
 
     def test_select__star(self):
         q = Query.from_('abc').select('*')


### PR DESCRIPTION
Fixes #140 Added a check when selecting from a field using a string argument for the field name when there are no tables currently being selected from in the query