### PR TITLE
[RFC] Added option to not use aliases in groupby and orderby

### DIFF
--- a/pypika/queries.py
+++ b/pypika/queries.py
@@ -892,7 +892,7 @@ class QueryBuilder(Selectable, Term):
     def _where_sql(self, quote_char=None, **kwargs):
         return ' WHERE {where}'.format(where=self._wheres.get_sql(quote_char=quote_char, subquery=True, **kwargs))
 
-    def _group_sql(self, quote_char=None, **kwargs):
+    def _group_sql(self, quote_char=None, groupby_alias=False, **kwargs):
         """
         Produces the GROUP BY part of the query.  This is a list of fields. The clauses are stored in the query under
         self._groupbys as a list fields.
@@ -903,7 +903,7 @@ class QueryBuilder(Selectable, Term):
         clauses = []
         selected_aliases = {s.alias for s in self._selects}
         for field in self._groupbys:
-            if field.alias and field.alias in selected_aliases:
+            if groupby_alias and field.alias and field.alias in selected_aliases:
                 clauses.append("{quote}{alias}{quote}".format(
                       alias=field.alias,
                       quote=quote_char or '',

--- a/pypika/queries.py
+++ b/pypika/queries.py
@@ -892,13 +892,15 @@ class QueryBuilder(Selectable, Term):
     def _where_sql(self, quote_char=None, **kwargs):
         return ' WHERE {where}'.format(where=self._wheres.get_sql(quote_char=quote_char, subquery=True, **kwargs))
 
-    def _group_sql(self, quote_char=None, groupby_alias=False, **kwargs):
+    def _group_sql(self, quote_char=None, groupby_alias=True, **kwargs):
         """
         Produces the GROUP BY part of the query.  This is a list of fields. The clauses are stored in the query under
         self._groupbys as a list fields.
 
-        If an groupby field is used in the select clause, determined by a matching alias, then the GROUP BY clause will
-        use the alias, otherwise the entire field will be rendered as SQL.
+        If an groupby field is used in the select clause,
+        determined by a matching alias, and the groupby_alias is set True
+        then the GROUP BY clause will use the alias,
+        otherwise the entire field will be rendered as SQL.
         """
         clauses = []
         selected_aliases = {s.alias for s in self._selects}
@@ -916,20 +918,22 @@ class QueryBuilder(Selectable, Term):
             return sql + ' WITH TOTALS'
         return sql
 
-    def _orderby_sql(self, quote_char=None, **kwargs):
+    def _orderby_sql(self, quote_char=None, orderby_alias=True, **kwargs):
         """
         Produces the ORDER BY part of the query.  This is a list of fields and possibly their directionality, ASC or
         DESC. The clauses are stored in the query under self._orderbys as a list of tuples containing the field and
         directionality (which can be None).
 
-        If an order by field is used in the select clause, determined by a matching , then the ORDER BY clause will use
+        If an order by field is used in the select clause,
+        determined by a matching, and the orderby_alias
+        is set True then the ORDER BY clause will use
         the alias, otherwise the field will be rendered as SQL.
         """
         clauses = []
         selected_aliases = {s.alias for s in self._selects}
         for field, directionality in self._orderbys:
             term = "{quote}{alias}{quote}".format(alias=field.alias, quote=quote_char or '') \
-                if field.alias and field.alias in selected_aliases \
+                if orderby_alias and field.alias and field.alias in selected_aliases \
                 else field.get_sql(quote_char=quote_char, **kwargs)
 
             clauses.append('{term} {orient}'.format(term=term, orient=directionality.value)


### PR DESCRIPTION
The GROUP BY and ORDER BY clauses were using the aliases defined in the SELECT statement, this is not ANSI SQL and hence it does not work with every SQL implementation. Now in order to not parse the query with aliases in the `group by` and `order by` one could use `get_sql(groupby_alias=False, orderby_alias=False)`. Since not using this aliases is ANSI, I think that False should be the default behavior, but I'm keeping it as True in order to don't break things.