### PR TITLE
Empty Criterion

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -257,6 +257,33 @@ XOR
     SELECT id,fname,lname,phone FROM customers WHERE age>=18 XOR is_registered
 
 
+Convenience Methods
+"""""""""""""""""""
+
+In the `Criterion` class, there are static methods that allow building chains AND and OR expressions with a list of
+terms.
+
+.. code-block:: python
+
+    from pypika import Criterion
+
+    customers = Table('customers')
+    q = Query.from_(customers).select(
+        customers.id,
+        customers.fname
+    ).where(
+        Criterion.all(
+            customers.is_registered,
+            customers.age >= 18,
+            customers.lname == "Jones",
+        )
+    )
+
+.. code-block:: sql
+
+    SELECT id,fname FROM customers WHERE is_registered AND age>=18 AND lname = "Jones"
+
+
 Grouping and Aggregating
 """"""""""""""""""""""""
 

--- a/README.rst
+++ b/README.rst
@@ -260,8 +260,7 @@ XOR
 Convenience Methods
 """""""""""""""""""
 
-In the `Criterion` class, there are static methods that allow building chains AND and OR expressions with a list of
-terms.
+In the `Criterion` class, there are the static methods `any` and `all` that allow building chains AND and OR expressions with a list of terms.
 
 .. code-block:: python
 
@@ -272,11 +271,11 @@ terms.
         customers.id,
         customers.fname
     ).where(
-        Criterion.all(
+        Criterion.all([
             customers.is_registered,
             customers.age >= 18,
             customers.lname == "Jones",
-        )
+        ])
     )
 
 .. code-block:: sql

--- a/pypika/__init__.py
+++ b/pypika/__init__.py
@@ -58,6 +58,8 @@ from .queries import (
 # noinspection PyUnresolvedReferences
 from .terms import (
     Case,
+    Criterion,
+    EmptyCriterion,
     Field,
     Interval,
     Not,

--- a/pypika/enums.py
+++ b/pypika/enums.py
@@ -38,6 +38,8 @@ class Boolean(Comparator):
     and_ = 'AND'
     or_ = 'OR'
     xor_ = 'XOR'
+    true = 'TRUE'
+    false = 'FALSE'
 
 
 class Order(Enum):

--- a/pypika/queries.py
+++ b/pypika/queries.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 from functools import reduce
 
 from .enums import (
@@ -7,6 +6,7 @@ from .enums import (
 )
 from .terms import (
     ArithmeticExpression,
+    EmptyCriterion,
     Field,
     Function,
     Rollup,
@@ -517,6 +517,9 @@ class QueryBuilder(Selectable, Term):
 
     @builder
     def where(self, criterion):
+        if isinstance(criterion, EmptyCriterion):
+            return
+
         self._validate_term(criterion)
 
         if self._wheres:

--- a/pypika/terms.py
+++ b/pypika/terms.py
@@ -293,7 +293,7 @@ class Criterion(Term):
         return ComplexCriterion(Boolean.xor_, self, other)
 
     @staticmethod
-    def any(*terms):
+    def any(terms=()):
         crit = EmptyCriterion()
 
         for term in terms:
@@ -302,14 +302,13 @@ class Criterion(Term):
         return crit
 
     @staticmethod
-    def all(*terms):
+    def all(terms=()):
         crit = EmptyCriterion()
 
         for term in terms:
             crit &= term
 
         return crit
-
 
     def fields(self):
         raise NotImplementedError()

--- a/pypika/terms.py
+++ b/pypika/terms.py
@@ -292,6 +292,25 @@ class Criterion(Term):
     def __xor__(self, other):
         return ComplexCriterion(Boolean.xor_, self, other)
 
+    @staticmethod
+    def any(*terms):
+        crit = EmptyCriterion()
+
+        for term in terms:
+            crit |= term
+
+        return crit
+
+    @staticmethod
+    def all(*terms):
+        crit = EmptyCriterion()
+
+        for term in terms:
+            crit &= term
+
+        return crit
+
+
     def fields(self):
         raise NotImplementedError()
 
@@ -299,20 +318,23 @@ class Criterion(Term):
         raise NotImplementedError()
 
 
+class EmptyCriterion:
+    def __and__(self, other):
+        return other
+
+    def __or__(self, other):
+        return other
+
+    def __xor__(self, other):
+        return other
+
+
+
 class Field(Criterion):
     def __init__(self, name, alias=None, table=None):
         super(Field, self).__init__(alias)
         self.name = name
         self.table = table
-
-    def __and__(self, other):
-        return ComplexCriterion(Boolean.and_, self, other)
-
-    def __or__(self, other):
-        return ComplexCriterion(Boolean.or_, self, other)
-
-    def __xor__(self, other):
-        return ComplexCriterion(Boolean.xor_, self, other)
 
     def fields(self):
         return [self]
@@ -747,7 +769,10 @@ class Function(Criterion):
                 for table in param.tables_}
 
     def fields(self):
-        return self.args
+        return [field
+                for param in self.args
+                if hasattr(param, 'fields')
+                for field in param.fields()]
 
     @property
     def is_aggregate(self):
@@ -799,12 +824,6 @@ class Function(Criterion):
             return function_sql
 
         return alias_sql(function_sql, self.alias, quote_char)
-
-    def fields(self):
-        return [field
-                for param in self.args
-                if hasattr(param, 'fields')
-                for field in param.fields()]
 
 
 class AggregateFunction(Function):

--- a/pypika/tests/test_criterions.py
+++ b/pypika/tests/test_criterions.py
@@ -659,11 +659,16 @@ class AnyTests(unittest.TestCase):
 
     def test_single_arg_returns_self(self):
         f = Field('a')
-        crit = Criterion.any(f)
+        crit = Criterion.any([f])
         self.assertEqual(str(f), str(crit))
 
     def test_multiple_args_returned_in_chain_of_ors(self):
-        crit = Criterion.any(Field('a'), Field('b'), Field('c'), Field('d'))
+        crit = Criterion.any([Field('a'), Field('b'), Field('c'), Field('d')])
+        self.assertEqual(str(crit), '"a" OR "b" OR "c" OR "d"')
+
+    def test_with_generator(self):
+        crit = Criterion.any(Field(letter)
+                             for letter in 'abcd')
         self.assertEqual(str(crit), '"a" OR "b" OR "c" OR "d"')
 
 
@@ -674,9 +679,14 @@ class AllTests(unittest.TestCase):
 
     def test_single_arg_returns_self(self):
         f = Field('a')
-        crit = Criterion.all(f)
+        crit = Criterion.all([f])
         self.assertEqual(str(f), str(crit))
 
     def test_multiple_args_returned_in_chain_of_ors(self):
-        crit = Criterion.all(Field('a'), Field('b'), Field('c'), Field('d'))
+        crit = Criterion.all([Field('a'), Field('b'), Field('c'), Field('d')])
+        self.assertEqual(str(crit), '"a" AND "b" AND "c" AND "d"')
+
+    def test_with_generator(self):
+        crit = Criterion.all(Field(letter)
+                             for letter in 'abcd')
         self.assertEqual(str(crit), '"a" AND "b" AND "c" AND "d"')

--- a/pypika/tests/test_criterions.py
+++ b/pypika/tests/test_criterions.py
@@ -1,12 +1,12 @@
-# coding: utf-8
 import unittest
-
 from datetime import (
     date,
     datetime,
 )
 
 from pypika import (
+    Criterion,
+    EmptyCriterion,
     Field,
     Table,
     functions as fn,
@@ -650,3 +650,33 @@ class CriterionOperationsTests(unittest.TestCase):
         f = self.table_abc.foo.isnull().for_(self.table_efg)
 
         self.assertEqual('"cx1"."foo" IS NULL', str(f))
+
+
+class AnyTests(unittest.TestCase):
+    def test_zero_args_returns_empty_criterion(self):
+        crit = Criterion.any()
+        self.assertIsInstance(crit, EmptyCriterion)
+
+    def test_single_arg_returns_self(self):
+        f = Field('a')
+        crit = Criterion.any(f)
+        self.assertEqual(str(f), str(crit))
+
+    def test_multiple_args_returned_in_chain_of_ors(self):
+        crit = Criterion.any(Field('a'), Field('b'), Field('c'), Field('d'))
+        self.assertEqual(str(crit), '"a" OR "b" OR "c" OR "d"')
+
+
+class AllTests(unittest.TestCase):
+    def test_zero_args_returns_empty_criterion(self):
+        crit = Criterion.all()
+        self.assertIsInstance(crit, EmptyCriterion)
+
+    def test_single_arg_returns_self(self):
+        f = Field('a')
+        crit = Criterion.all(f)
+        self.assertEqual(str(f), str(crit))
+
+    def test_multiple_args_returned_in_chain_of_ors(self):
+        crit = Criterion.all(Field('a'), Field('b'), Field('c'), Field('d'))
+        self.assertEqual(str(crit), '"a" AND "b" AND "c" AND "d"')

--- a/pypika/tests/test_selects.py
+++ b/pypika/tests/test_selects.py
@@ -4,6 +4,7 @@ import unittest
 from pypika import (
     AliasedQuery,
     Case,
+    EmptyCriterion,
     Field as F,
     MSSQLQuery,
     MySQLQuery,
@@ -300,6 +301,11 @@ class WhereTests(unittest.TestCase):
         q = Query.from_(self.t).select(self.t.star).where(self.t.foo.regex(r'^b'))
 
         self.assertEqual("SELECT * FROM \"abc\" WHERE \"foo\" REGEX '^b'", str(q))
+
+    def test_ignore_empty_criterion(self):
+        q1 = Query.from_(self.t).select('*').where(EmptyCriterion())
+
+        self.assertEqual('SELECT * FROM "abc"', str(q1))
 
 
 class PreWhereTests(WhereTests):


### PR DESCRIPTION
Fixes #196 Added an EmptyCriterion class which allows the user to build up boolean clauses using lists of constituents. Added any and all static methods to Criterion to give an easy syntax for using this.