### PR TITLE
Optimize QueryBuilder.__copy__ some more

### DIFF
--- a/pypika/dialects.py
+++ b/pypika/dialects.py
@@ -1,3 +1,5 @@
+from copy import copy
+
 from pypika.enums import Dialects
 from pypika.queries import (
     Query,
@@ -20,6 +22,11 @@ class MySQLQueryBuilder(QueryBuilder):
     def __init__(self):
         super(MySQLQueryBuilder, self).__init__(quote_char='`', dialect=Dialects.MYSQL, wrap_union_queries=False)
         self._duplicate_updates = []
+
+    def __copy__(self):
+        newone = super(MySQLQueryBuilder, self).__copy__()
+        newone._duplicate_updates = copy(self._duplicate_updates)
+        return newone
 
     @builder
     def on_duplicate_key_update(self, field, value):
@@ -100,6 +107,12 @@ class PostgreQueryBuilder(QueryBuilder):
         self._on_conflict_field = None
         self._on_conflict_do_nothing = False
         self._on_conflict_updates = []
+
+    def __copy__(self):
+        newone = super(PostgreQueryBuilder, self).__copy__()
+        newone._returns = copy(self._returns)
+        newone._on_conflict_updates = copy(self._on_conflict_updates)
+        return newone
 
     @builder
     def on_conflict(self, target_field):

--- a/pypika/queries.py
+++ b/pypika/queries.py
@@ -1,3 +1,4 @@
+from copy import copy
 from functools import reduce
 
 from .enums import (
@@ -396,11 +397,19 @@ class QueryBuilder(Selectable, Term):
         self._wrapper_cls = wrapper_cls
 
     def __copy__(self):
-        newone = type(self)()
+        newone = type(self).__new__(type(self))
         newone.__dict__.update(self.__dict__)
-        for key, value in self.__dict__.items():
-            if isinstance(value, (set, list)):
-                newone.__dict__[key] = type(value)(x for x in value)
+        newone._select_star_tables = copy(self._select_star_tables)
+        newone._from = copy(self._from)
+        newone._with = copy(self._with)
+        newone._selects = copy(self._selects)
+        newone._columns = copy(self._columns)
+        newone._values = copy(self._values)
+        newone._groupbys = copy(self._groupbys)
+        newone._orderbys = copy(self._orderbys)
+        newone._joins = copy(self._joins)
+        newone._unions = copy(self._unions)
+        newone._updates = copy(self._updates)
         return newone
 
     @builder


### PR DESCRIPTION
## Original: Tests run in 87ms
```py
newone = type(self)()
newone.__dict__.update(self.__dict__)
for key, value in self.__dict__.items():
    if isinstance(value, (set, list)):
        newone.__dict__[key] = type(value)(x for x in value)
```

## Optimization 1: Tests run in 73ms (~19% speedup)
Use `__new__` instead of `__init__` because we are going to clobber its state
Use `copy()` (shallow copy) which is supported on both sets and lists and faster than a comprehension
```py
newone = type(self).__new__(type(self))
newone.__dict__.update(self.__dict__)
for key, value in self.__dict__.items():
    if isinstance(value, (set, list)):
        newone.__dict__[key] = copy(value)
```

## ~Optimization 2: Tests run in 67ms (30% speedup) INVALID~
Unroll the loop
```py
newone = type(self).__new__(type(self))
newone.__dict__.update(self.__dict__)
newone._select_star_tables = copy(self._select_star_tables)
newone._from = copy(self._from)
newone._with = copy(self._with)
newone._selects = copy(self._selects)
newone._columns = copy(self._columns)
newone._values = copy(self._values)
newone._groupbys = copy(self._groupbys)
newone._orderbys = copy(self._orderbys)
newone._joins = copy(self._joins)
newone._unions = copy(self._unions)
newone._updates = copy(self._updates)
```
Invalid due to subclasses do define extra lists. And the unrolled variant doesn't copy everything it needs.

## Optimization 2b: Tests run in 67ms (~30% speedup)
Same as Opt2, but subclasses that define lists (`MySQLQueryBuilder` & `PostgreQueryBuilder` only)
```py
newone = super(MySQLQueryBuilder, self).__copy__()
newone._duplicate_updates = copy(self._duplicate_updates)
```

For Opt 1:
When running the benchmark suite for Tortoise ORM, two of the benchmarks get a 6% and 9% performance increase respectively.

For Opt2b:
When running the benchmark suite for Tortoise ORM, two of the benchmarks get a 12% and 15% performance increase respectively.

Due to the perf increase for Opt2a being noticeably better than Opt1, I opted to go with that

I had to use `copy.copy()` instead of `<list/set>.copy()` for Py2.7 compatibility reasons.