### PR TITLE
Fix star tables

### DIFF
--- a/pypika/enums.py
+++ b/pypika/enums.py
@@ -116,7 +116,6 @@ class SqlTypes:
     LONG_VARBINARY = SqlType('LONG VARBINARY')
 
 
-
 class Dialects(Enum):
     VERTICA = 'vertica'
     CLICKHOUSE = 'clickhouse'

--- a/pypika/terms.py
+++ b/pypika/terms.py
@@ -340,7 +340,6 @@ class EmptyCriterion:
         return other
 
 
-
 class Field(Criterion):
     def __init__(self, name, alias=None, table=None):
         super(Field, self).__init__(alias)

--- a/pypika/terms.py
+++ b/pypika/terms.py
@@ -390,6 +390,12 @@ class Star(Field):
     def __init__(self, table=None):
         super(Star, self).__init__('*', table=table)
 
+    @property
+    def tables_(self):
+        if self.table is None:
+            return {}
+        return {self.table}
+
     def get_sql(self, with_alias=False, with_namespace=False, quote_char=None, **kwargs):
         if self.table and (with_namespace or self.table.alias):
             return "{quote}{namespace}{quote}.*".format(

--- a/pypika/tests/test_internals.py
+++ b/pypika/tests/test_internals.py
@@ -5,6 +5,7 @@ from pypika import (
     Field,
     Table,
 )
+from pypika.terms import Star
 
 
 class TablesTests(unittest.TestCase):
@@ -22,3 +23,14 @@ class TablesTests(unittest.TestCase):
         c = Case().when(table.a == 1, 2 * table.a)
         self.assertIsInstance(c.tables_, set)
         self.assertSetEqual(c.tables_, {table})
+
+    def test__star_tables(self):
+        star = Star()
+
+        self.assertEqual(star.tables_, {})
+
+    def test__table_star_tables(self):
+        table = Table('a')
+        star = Star(table=table)
+
+        self.assertEqual(star.tables_, {table})


### PR DESCRIPTION
`tables_` function returns `{None}` on `Star()`, fixed to return `{}` for no tables and to return `{self.table}` when there is a table