### PR TITLE
Add support for APPROX_COUNT_DISTINCT

### DIFF
--- a/pypika/functions.py
+++ b/pypika/functions.py
@@ -47,6 +47,11 @@ class Sum(DistinctOptionFunction):
         super(Sum, self).__init__('SUM', term, alias=alias)
 
 
+class ApproxCountDistinct(AggregateFunction):
+    def __init__(self, term, alias=None):
+        super(ApproxCountDistinct, self).__init__('APPROX_COUNT_DISTINCT', term, alias=alias)
+
+
 class Avg(AggregateFunction):
     def __init__(self, term, alias=None):
         super(Avg, self).__init__('AVG', term, alias=alias)

--- a/pypika/tests/test_functions.py
+++ b/pypika/tests/test_functions.py
@@ -250,6 +250,11 @@ class AggregationTests(unittest.TestCase):
 
         self.assertEqual('SELECT SUM(\"foo\") FROM \"abc\"', str(q))
 
+    def test__approx_count_distinct(self):
+        q = Q.from_('abc').select(fn.ApproxCountDistinct(F('foo')))
+
+        self.assertEqual('SELECT APPROX_COUNT_DISTINCT(\"foo\") FROM \"abc\"', str(q))
+
     def test__avg(self):
         q = Q.from_('abc').select(fn.Avg(F('foo')))
 
@@ -290,7 +295,8 @@ class ConditionTests(unittest.TestCase):
     def test__case__field(self):
         q = Q.from_('abc').select(Case().when(F('foo') == 1, F('bar')).else_(F('buz')))
 
-        self.assertEqual('SELECT CASE WHEN \"foo\"=1 THEN \"bar\" ELSE \"buz\" END FROM \"abc\"', str(q))
+        self.assertEqual(
+            'SELECT CASE WHEN \"foo\"=1 THEN \"bar\" ELSE \"buz\" END FROM \"abc\"', str(q))
 
     def test__case__multi(self):
         q = Q.from_('abc').select(


### PR DESCRIPTION
Some SQL engines have a HyperLogLog implementation of count distinct.

This PR adds support for this function. 

See [this article](https://www.red-gate.com/simple-talk/sql/t-sql-programming/there-is-a-new-count-in-town/) for more details.