### PR TITLE
Adds support for correlated subqueries

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -406,6 +406,25 @@ Example of a join using `USING`
     SELECT "history".* FROM "history" JOIN "customers" USING "customer_id" WHERE "customers"."id"=5
 
 
+Example of a correlated subquery in the `SELECT`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: python
+    history, customers = Tables('history', 'customers')
+    last_purchase_at = Query.from_(history, correlated_table=customers).select(
+        history.purchase_at
+    ).where(history.customer_id==customers.customer_id).orderby(
+        history.purchase_at, order=Order.desc
+    ).limit(1)
+
+    q = Query.from_(customers).select(
+        customers.id, last_purchase_at._as('last_purchase_at')
+    )
+
+.. code-block:: sql
+    SELECT "customers"."id", (SELECT "history"."purchase_at" FROM "history" WHERE "history"."customer_id" = "customers"."customer_id" ORDER BY "history"."purchase_at" DESC LIMIT 1) AS "last_purchase_at" FROM "customers"
+
+
 Unions
 """"""
 

--- a/README.rst
+++ b/README.rst
@@ -410,6 +410,7 @@ Example of a correlated subquery in the `SELECT`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: python
+
     history, customers = Tables('history', 'customers')
     last_purchase_at = Query.from_(history, correlated_table=customers).select(
         history.purchase_at
@@ -422,7 +423,15 @@ Example of a correlated subquery in the `SELECT`
     )
 
 .. code-block:: sql
-    SELECT "customers"."id", (SELECT "history"."purchase_at" FROM "history" WHERE "history"."customer_id" = "customers"."customer_id" ORDER BY "history"."purchase_at" DESC LIMIT 1) AS "last_purchase_at" FROM "customers"
+
+    SELECT
+      "customers"."id",
+      (SELECT "history"."purchase_at"
+       FROM "history"
+       WHERE "history"."customer_id" = "customers"."customer_id"
+       ORDER BY "history"."purchase_at" DESC
+       LIMIT 1) "last_purchase_at"
+    FROM "customers"
 
 
 Unions

--- a/pypika/tests/test_selects.py
+++ b/pypika/tests/test_selects.py
@@ -157,6 +157,22 @@ class SelectTests(unittest.TestCase):
                          'FROM (SELECT "sq0"."foo","sq0"."bar" '
                          'FROM (SELECT * FROM "abc") "sq0") "sq1") "sq2"', str(q))
 
+    def test_correlated_subquery(self):
+        subquery = Query.from_(
+            self.table_abc, correlated_table=self.table_efg
+        ).select(self.table_abc.foo).where(
+            self.table_abc.efg_id == self.table_efg.id
+        ).limit(1)
+
+        q = Query.from_(self.table_efg).select(
+            self.table_efg.id, subquery.as_('foo')
+        )
+
+        self.assertEqual('SELECT "id",'
+                         '(SELECT "abc"."foo" FROM "abc" WHERE '
+                         '"abc"."efg_id"="efg"."id" LIMIT 1) "foo" '
+                         'FROM "efg"', str(q))
+
     def test_select__no_table(self):
         q = Query.select(1, 2, 3)
 


### PR DESCRIPTION
Correlated subqueries [1] were prevented by validation which asserted
that the field filtered existed in the `_from` tables. There was a work
around which was to temporarily add the table to the _from list, then
create the correlated subquery, then later remove it.

This approach introduces a way to specifically highlight that the query
being built is a correlated subquery, and as such include the outer
table at the time of creation with `from_`.

An alternate approach may have been to introduce a flag which disabled
table based validation on fields when creating new WHERE clauses. This
approach was decided against because a correlated subquery requires
namespaces lest there be a clash when filtering "id" against "id" in the
outer table.

[1] https://en.wikipedia.org/wiki/Correlated_subquery