### PR TITLE
Removes exception raising validate_term

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -414,6 +414,31 @@ Example of a join using `USING`
     SELECT "history".* FROM "history" JOIN "customers" USING "customer_id" WHERE "customers"."id"=5
 
 
+Example of a correlated subquery in the `SELECT`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: python
+    history, customers = Tables('history', 'customers')
+    last_purchase_at = Query.from_(history).select(
+        history.purchase_at
+    ).where(history.customer_id==customers.customer_id).orderby(
+        history.purchase_at, order=Order.desc
+    ).limit(1)
+    q = Query.from_(customers).select(
+        customers.id, last_purchase_at._as('last_purchase_at')
+    )
+.. code-block:: sql
+
+    SELECT
+      "id",
+      (SELECT "history"."purchase_at"
+       FROM "history"
+       WHERE "history"."customer_id" = "customers"."customer_id"
+       ORDER BY "history"."purchase_at" DESC
+       LIMIT 1) "last_purchase_at"
+    FROM "customers"
+
+
 Unions
 """"""
 


### PR DESCRIPTION
Fixes #227 to allow correlated subqueries.

Removing table validation was not enough. Because most subqueries which reference a parent table would result in an ambiguous query and need the full namespace when referring to the fields. (e.g. imaging joining on "id" without the full table namespace)

The only mechanism for invoking the full namespace previously was an entry in the `from_` field or `joins` field and neither fit this.

So I retained the validation, and used it to determine when to switch table namespaces on.

An alternative I considered was to always use table namespaces - for every query, but I figured that is outside the scope of this PR.