### PR TITLE
Fix NULLIF syntax so it generates functional SQL

### DIFF
--- a/pypika/functions.py
+++ b/pypika/functions.py
@@ -157,8 +157,8 @@ class Ascii(Function):
 
 
 class NullIf(Function):
-    def __init__(self, criterion, alias=None):
-        super(NullIf, self).__init__('NULLIF', criterion, alias=alias)
+    def __init__(self, term, condition, **kwargs):
+        super(NullIf, self).__init__('NULLIF', term, condition, **kwargs)
 
 
 class Bin(Function):

--- a/pypika/tests/test_functions.py
+++ b/pypika/tests/test_functions.py
@@ -607,9 +607,9 @@ class NullFunctionsTests(unittest.TestCase):
         self.assertEqual('SELECT COALESCE(\"foo\",0) FROM \"abc\"', str(q))
 
     def test_nullif(self):
-        q = Q.from_('abc').select(fn.NullIf(F('foo') == 0))
+        q = Q.from_('abc').select(fn.NullIf(F('foo'), 0))
 
-        self.assertEqual('SELECT NULLIF(\"foo\"=0) FROM \"abc\"', str(q))
+        self.assertEqual('SELECT NULLIF(\"foo\",0) FROM \"abc\"', str(q))
 
     def test_nvl(self):
         q = Q.from_('abc').select(fn.NVL(F('foo'), 0))


### PR DESCRIPTION
The correct syntax for NULLIF is:
```
SELECT NULLIF("foo",0) FROM "abc"
```
Instead of:
```
SELECT NULLIF("foo"=0) FROM "abc"
```