### PR TITLE
Support instantiate many tables with alias

### DIFF
--- a/pypika/queries.py
+++ b/pypika/queries.py
@@ -150,7 +150,19 @@ class Table(Selectable):
 
 
 def make_tables(*names, **kwargs):
-    return [Table(name, schema=kwargs.get('schema')) for name in names]
+    """
+        Shortcut to create many tables. If `names` param is a tuple, the first
+        position will refer to the `_table_name` while the second will be its `alias`.
+        Any other data structure will be treated as a whole as the `_table_name`
+    """
+    tables = []
+    for name in names:
+        if isinstance(name, tuple) and len(name) == 2:
+            t = Table(name=name[0], alias=name[1], schema=kwargs.get('schema'))
+        else:
+            t = Table(name=name, schema=kwargs.get('schema'))
+        tables.append(t)
+    return tables
 
 
 class Query(object):

--- a/pypika/tests/test_tables.py
+++ b/pypika/tests/test_tables.py
@@ -3,8 +3,8 @@ import unittest
 from pypika import (
     Schema,
     Table,
+    Tables
 )
-from pypika.queries import make_tables
 
 __author__ = "Timothy Heys"
 __email__ = "theys@kayak.com"
@@ -60,19 +60,19 @@ class TableEqualityTests(unittest.TestCase):
 
     def test_many_tables_with_alias(self):
         tables_data = [('table1', 't1'), ('table2', 't2'), ('table3', 't3')]
-        tables = make_tables(*tables_data)
+        tables = Tables(*tables_data)
         for el in tables:
             self.assertIsNotNone(el.alias)
 
     def test_many_tables_without_alias(self):
         tables_data = ['table1', 'table2', 'table3']
-        tables = make_tables(*tables_data)
+        tables = Tables(*tables_data)
         for el in tables:
             self.assertIsNone(el.alias)
 
     def test_many_tables_with_or_not_alias(self):
         tables_data = [('table1', 't1'), ('table2'), 'table3']
-        tables = make_tables(*tables_data)
+        tables = Tables(*tables_data)
         for i in range(len(tables)):
             if isinstance(tables_data[i], tuple):
                 self.assertIsNotNone(tables[i].alias)

--- a/pypika/tests/test_tables.py
+++ b/pypika/tests/test_tables.py
@@ -4,6 +4,7 @@ from pypika import (
     Schema,
     Table,
 )
+from pypika.queries import make_tables
 
 __author__ = "Timothy Heys"
 __email__ = "theys@kayak.com"
@@ -56,3 +57,24 @@ class TableEqualityTests(unittest.TestCase):
         t2 = Table("q", schema='a')
 
         self.assertNotEqual(t1, t2)
+
+    def test_many_tables_with_alias(self):
+        tables_data = [('table1', 't1'), ('table2', 't2'), ('table3', 't3')]
+        tables = make_tables(*tables_data)
+        for el in tables:
+            self.assertIsNotNone(el.alias)
+
+    def test_many_tables_without_alias(self):
+        tables_data = ['table1', 'table2', 'table3']
+        tables = make_tables(*tables_data)
+        for el in tables:
+            self.assertIsNone(el.alias)
+
+    def test_many_tables_with_or_not_alias(self):
+        tables_data = [('table1', 't1'), ('table2'), 'table3']
+        tables = make_tables(*tables_data)
+        for i in range(len(tables)):
+            if isinstance(tables_data[i], tuple):
+                self.assertIsNotNone(tables[i].alias)
+            else:
+                self.assertIsNone(tables[i].alias)


### PR DESCRIPTION
In order to be faster and easier to instantiate many tables with an alias, `make_tables` shortcut function has been modified to support tuples with two elements which the first represents the `_table_name` and the second is the `alias`.