### PR TITLE
Fixes for #270, #271 and #272

### DIFF
--- a/pypika/__init__.py
+++ b/pypika/__init__.py
@@ -31,7 +31,7 @@ This contains all of the utility classes such as exceptions and decorators.
 
 """
 # noinspection PyUnresolvedReferences
-from .dialects import (
+from pypika.dialects import (
     ClickHouseQuery,
     Dialects,
     MSSQLQuery,
@@ -43,13 +43,13 @@ from .dialects import (
     VerticaQuery,
 )
 # noinspection PyUnresolvedReferences
-from .enums import (
+from pypika.enums import (
     DatePart,
     JoinType,
     Order,
 )
 # noinspection PyUnresolvedReferences
-from .queries import (
+from pypika.queries import (
     AliasedQuery,
     Query,
     Schema,
@@ -57,7 +57,7 @@ from .queries import (
     make_tables as Tables,
 )
 # noinspection PyUnresolvedReferences
-from .terms import (
+from pypika.terms import (
     Array,
     Bracket,
     Case,
@@ -72,7 +72,7 @@ from .terms import (
     Tuple,
 )
 # noinspection PyUnresolvedReferences
-from .utils import (
+from pypika.utils import (
     CaseException,
     GroupingException,
     JoinException,

--- a/pypika/queries.py
+++ b/pypika/queries.py
@@ -757,6 +757,7 @@ class QueryBuilder(Selectable, Term):
 
     def get_sql(self, with_alias=False, subquery=False, **kwargs):
         kwargs.setdefault('quote_char', self.quote_char)
+        kwargs.setdefault('dialect', self.dialect)
 
         if not (self._selects or self._insert_table or self._delete_from or self._update_table):
             return ''

--- a/pypika/queries.py
+++ b/pypika/queries.py
@@ -1,11 +1,11 @@
 from copy import copy
 from functools import reduce
 
-from .enums import (
+from pypika.enums import (
     JoinType,
     UnionType,
 )
-from .terms import (
+from pypika.terms import (
     ArithmeticExpression,
     EmptyCriterion,
     Field,
@@ -16,7 +16,7 @@ from .terms import (
     Tuple,
     ValueWrapper,
 )
-from .utils import (
+from pypika.utils import (
     JoinException,
     QueryException,
     RollupException,

--- a/pypika/terms.py
+++ b/pypika/terms.py
@@ -855,13 +855,13 @@ class Function(Criterion):
               special=(' ' + special_params_sql) if special_params_sql else '',
         )
 
-    def get_sql(self, with_alias=False, with_namespace=False, quote_char=None, **kwargs):
+    def get_sql(self, with_alias=False, with_namespace=False, quote_char=None, dialect=None, **kwargs):
         # FIXME escape
-        function_sql = self.get_function_sql(with_namespace=with_namespace, quote_char=quote_char)
+        function_sql = self.get_function_sql(with_namespace=with_namespace, quote_char=quote_char, dialect=dialect)
 
         if self.schema is not None:
             function_sql = '{schema}.{function}' \
-                .format(schema=self.schema.get_sql(quote_char=quote_char, **kwargs),
+                .format(schema=self.schema.get_sql(quote_char=quote_char, dialect=dialect, **kwargs),
                         function=function_sql)
 
         if not with_alias or self.alias is None:

--- a/pypika/tests/test_functions.py
+++ b/pypika/tests/test_functions.py
@@ -12,10 +12,16 @@ from pypika import (
     VerticaQuery,
     functions as fn,
 )
-from pypika.enums import SqlTypes
+from pypika.enums import SqlTypes, Dialects
 
 __author__ = "Timothy Heys"
 __email__ = "theys@kayak.com"
+
+
+class FunctionTests(unittest.TestCase):
+    def test_dialect_propagation(self):
+        func = fn.Function('func', ['a'], ['b'])
+        self.assertEqual("func(ARRAY['a'],ARRAY['b'])", func.get_sql(dialect=Dialects.POSTGRESQL))
 
 
 class SchemaTests(unittest.TestCase):

--- a/pypika/tests/test_tuples.py
+++ b/pypika/tests/test_tuples.py
@@ -1,7 +1,10 @@
 import unittest
 
 from pypika import (
+    Array,
     Bracket,
+    Dialects,
+    PostgreSQLQuery,
     Query,
     Tables,
     Tuple,
@@ -69,6 +72,24 @@ class TupleTests(unittest.TestCase):
 
         self.assertEqual('SELECT * FROM "abc" JOIN "efg" ON "abc"."foo"="efg"."bar" '
                          'WHERE ("abc"."foo","efg"."bar") IN ((1,1),(2,2),(3,3))', str(query))
+
+
+class ArrayTests(unittest.TestCase):
+    table_abc, table_efg = Tables('abc', 'efg')
+
+    def test_array_general(self):
+        query = Query.from_(self.table_abc) \
+            .select(Array(1, 'a', ['b', 2, 3]))
+
+        self.assertEqual('SELECT [1,\'a\',[\'b\',2,3]] FROM "abc"', str(query))
+        self.assertEqual('SELECT [1,\'a\',[\'b\',2,3]] FROM "abc"', str(query.get_sql()))
+
+    def test_array_postgresql(self):
+        query = PostgreSQLQuery.from_(self.table_abc) \
+            .select(Array(1, 'a', ['b', 2, 3]))
+
+        self.assertEqual('SELECT ARRAY[1,\'a\',ARRAY[\'b\',2,3]] FROM "abc"', str(query))
+        self.assertEqual('SELECT ARRAY[1,\'a\',ARRAY[\'b\',2,3]] FROM "abc"', query.get_sql())
 
 
 class BracketTests(unittest.TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
 envlist = py33,py34,py35,py36,py37,pypy3
 [testenv]
-deps = -r requirements.txt
+deps = -r requirements-dev.txt
 commands = python setup.py build test


### PR DESCRIPTION
Fixes for each of the following issues:
- #270: Dialect is now passed to function arguments
- #271: All imports are now absolute
- #272: `get_sql` now matches `__str__` behaviour by passing dialect in kwargs

Also, tox.ini referred to an outdated name for requirements.txt, so there's an independent commit in there to fix that.

You can cherry-pick if you just want one or two.