### PR TITLE
Added ability to have fieldless ON CONFLICT DO NOTHING

### DIFF
--- a/pypika/tests/test_inserts.py
+++ b/pypika/tests/test_inserts.py
@@ -160,6 +160,14 @@ class PostgresInsertIntoOnConflictTests(unittest.TestCase):
             query = PostgreSQLQuery.update(self.table_abc).set('foo', 'bar').on_conflict(
                   'id').do_update(['name'], ["m"])
 
+    def test_insert_on_fieldless_conflict_do_nothing(self):
+        query = PostgreSQLQuery.into(self.table_abc).insert(1).on_conflict(None).do_nothing()
+
+        self.assertEqual('INSERT INTO "abc" VALUES (1) ON CONFLICT DO NOTHING', str(query))
+
+    def test_insert_on_fieldless_conflict_do_update_field(self):
+        with self.assertRaises(QueryException):
+            query = str(PostgreSQLQuery.into(self.table_abc).insert(1, "m").on_conflict(None).do_update(self.table_abc.name, "m"))
 
 class PostgresInsertIntoReturningTests(unittest.TestCase):
     table_abc = Table('abc')


### PR DESCRIPTION
While using the PostgreSQL query builder in PyPika recently, I discovered there was no way to perform a ON CONFLICT DO NOTHING, with PyPika only allowing for ON CONFLICT (abc.xyz) DO NOTHING queries. 

ON CONFLICT DO NOTHING is useful in PostgreSQL for when you do not know which column is going to conflict, however in the event that any column conflicts, DO NOTHING should be applied. 

There is no need to implement ON CONFLICT DO UPDATE functionality, as PostgreSQL requires that ON CONFLICT is given a field to perform a DO UPDATE