### PR TITLE
Support for Bitwise AND

### DIFF
--- a/pypika/enums.py
+++ b/pypika/enums.py
@@ -23,7 +23,6 @@ class Equality(Comparator):
     gte = '>='
     lt = '<'
     lte = '<='
-    bitwise_and = "&"
 
 
 class Matching(Comparator):

--- a/pypika/enums.py
+++ b/pypika/enums.py
@@ -23,6 +23,7 @@ class Equality(Comparator):
     gte = '>='
     lt = '<'
     lte = '<='
+    bitwise_and = "&"
 
 
 class Matching(Comparator):

--- a/pypika/terms.py
+++ b/pypika/terms.py
@@ -206,6 +206,12 @@ class Term:
     def __le__(self, other):
         return BasicCriterion(Equality.lte, self, self.wrap_constant(other))
 
+    def __matmul__(self, other):
+        return BasicCriterion(Equality.bitwise_and, self, self.wrap_constant(other))
+
+    def __rmatmul__(self, other):
+        return BasicCriterion(Equality.bitwise_and, self.wrap_constant(other), self)
+
     def __getitem__(self, item):
         if not isinstance(item, slice):
             raise TypeError("Field' object is not subscriptable")

--- a/pypika/tests/test_criterions.py
+++ b/pypika/tests/test_criterions.py
@@ -246,11 +246,11 @@ class CriterionTests(unittest.TestCase):
         self.assertEqual('"crit"."foo">=-1', str(c2))
 
     def test__criterion_bitwise_and(self):
-        c1 = Field("foo") @ 2
-        c2 = 2 @ Field("foo", table=self.t)
+        c1 = Field("foo").bitwiseand(2)
+        c2 = Field("foo", table=self.t).bitwiseand(10) == 2
 
-        self.assertEqual('"foo"&2', str(c1))
-        self.assertEqual('2&"crit"."foo"', str(c2))
+        self.assertEqual('("foo" & 2)', str(c1))
+        self.assertEqual('("crit"."foo" & 10)=2', str(c2))
 
 
 class NotTests(unittest.TestCase):

--- a/pypika/tests/test_criterions.py
+++ b/pypika/tests/test_criterions.py
@@ -245,6 +245,13 @@ class CriterionTests(unittest.TestCase):
         self.assertEqual('"foo">=1', str(c1))
         self.assertEqual('"crit"."foo">=-1', str(c2))
 
+    def test__criterion_bitwise_and(self):
+        c1 = Field("foo") @ 2
+        c2 = 2 @ Field("foo", table=self.t)
+
+        self.assertEqual('"foo"&2', str(c1))
+        self.assertEqual('2&"crit"."foo"', str(c2))
+
 
 class NotTests(unittest.TestCase):
     table_abc, table_efg = Table('abc', alias='cx0'), Table('efg', alias='cx1')


### PR DESCRIPTION
Support for Bitwise AND for Field.

Usage:
```
table = pypika.Table("t")
table.foo.bitwiseand(10) # Returns ("foo" & 10)
table.foo.bitwiseand(10) == 10 # Returns ("foo" & 10)=10
```

While using PyPika in our company I needed to use bitwise and in where clause and I found out that pypika does not support this feature yet. So here it is.

I am happy to change name of functions/class/etc. if you have different opinion about it, but I would love to have this feature in PyPika. :)