### PR TITLE
Add support for subqueries in JoinOn criterion

### DIFF
--- a/pypika/queries.py
+++ b/pypika/queries.py
@@ -1191,7 +1191,7 @@ class JoinOn(Join):
         join_sql = super(JoinOn, self).get_sql(**kwargs)
         return '{join} ON {criterion}{collate}'.format(
               join=join_sql,
-              criterion=self.criterion.get_sql(**kwargs),
+              criterion=self.criterion.get_sql(subquery=True, **kwargs),
               collate=" COLLATE {}".format(self.collate) if self.collate else ""
         )
 

--- a/pypika/tests/test_joins.py
+++ b/pypika/tests/test_joins.py
@@ -125,6 +125,17 @@ class SelectQueryJoinTests(unittest.TestCase):
         self.assertEqual('SELECT * FROM "abc" '
                          'RIGHT JOIN "efg" ON "abc"."foo"="efg"."fiz" AND "abc"."bar"="efg"."buz"', str(q))
 
+    def test_join_on_subquery_criteria(self):
+        table_a, table_b, table_c = Tables('a', 'b', 'c')
+        subquery = Query.from_(table_c).select('id').limit(1)
+        query = Query.from_(table_a).select('*') \
+            .join(table_b).on((table_a.b_id == table_b.id) & (table_b.c_id == subquery))
+
+        self.assertEqual('SELECT * '
+                         'FROM "a" '
+                         'JOIN "b" ON "a"."b_id"="b"."id" AND "b"."c_id"='
+                         '(SELECT "id" FROM "c" LIMIT 1)', str(query))
+
     def test_use_different_table_objects_for_same_table(self):
         table = Table("t")
         q = Query.from_(table).select('*').where(Field('id', table=table) == 1)


### PR DESCRIPTION
Subqueries aren't currently wrapped in parentheses when used in a `JOIN ON` criterion, similar to the issue reported in #220. This PR specifies `subquery=True` when calling `criterion.get_sql()` so that subqueries do get wrapped as expected. It also includes a corresponding test case in `test_joins.py`.

Note that the Python 3.4 tests are failing, but this is unrelated to these changes.