### PR TITLE
Implement ANSI SQL CURRENT_TIMESTAMP function

### DIFF
--- a/pypika/functions.py
+++ b/pypika/functions.py
@@ -243,6 +243,16 @@ class UtcTimestamp(Function):
         super(UtcTimestamp, self).__init__('UTC_TIMESTAMP', alias=alias)
 
 
+class CurTimestamp(Function):
+    def __init__(self, alias=None):
+        super(CurTimestamp, self).__init__('CURRENT_TIMESTAMP', alias=alias)
+
+    def get_function_sql(self, **kwargs):
+        # CURRENT_TIMESTAMP takes no arguments, so the SQL to generate is quite
+        # simple.  Note that empty parentheses have been omitted intentionally.
+        return 'CURRENT_TIMESTAMP'
+
+
 class CurDate(Function):
     def __init__(self, alias=None):
         super(CurDate, self).__init__('CURRENT_DATE', alias=alias)

--- a/pypika/tests/test_functions.py
+++ b/pypika/tests/test_functions.py
@@ -604,6 +604,16 @@ class DateFunctionsTests(unittest.TestCase):
 
         self.assertEqual("SELECT CURRENT_TIME()", str(query))
 
+    def test_current_timestamp(self):
+        query = Query.select(fn.CurTimestamp())
+
+        self.assertEqual("SELECT CURRENT_TIMESTAMP", str(query))
+
+    def test_current_timestamp_with_alias(self):
+        query = Query.select(fn.CurTimestamp('ts'))
+
+        self.assertEqual("SELECT CURRENT_TIMESTAMP \"ts\"", str(query))
+
     def test_to_date(self):
         q1 = fn.ToDate('2019-06-21', 'yyyy-mm-dd')
         q2 = Query.from_(self.t).select(fn.ToDate('2019-06-21', 'yyyy-mm-dd'))


### PR DESCRIPTION
Hopefully this is the right approach.

Initially I thought I'd pattern it on the similar functions `CurDate` (for `CURRENT_DATE`) and `CurTime` (for `CURRENT_TIME`).  However, I found those implementations include empty parentheses in the generated SQL, such as `CURRENT_TIME()`, and that breaks `CURRENT_TIMESTAMP` on the platform I'm using (MSSQL).  

From I can tell, the parentheses aren't required by the standard, so this doesn't appear to be a platform quirk, so my implementation omits them.

The function seems like it probably has some overlap with the existing `Now` function, but since that one isn't supported by MSSQL and `CURRENT_TIMESTAMP` is part of ANSI SQL, I'm guessing it makes sense to include this in pypika.