### PR TITLE
Added JSON data type class an refactored JSON operators

### DIFF
--- a/pypika/__init__.py
+++ b/pypika/__init__.py
@@ -66,6 +66,7 @@ from pypika.terms import (
     EmptyCriterion,
     Field,
     Interval,
+    JSON,
     Not,
     NullValue,
     Parameter,

--- a/pypika/enums.py
+++ b/pypika/enums.py
@@ -127,7 +127,7 @@ class Dialects(Enum):
     SQLLITE = 'sqllite'
 
 
-class PostgresOperators(Enum):
+class JSONOperators(Enum):
     HAS_KEY = '?'
     CONTAINS = '@>'
     CONTAINED_BY = '<@'
@@ -135,4 +135,6 @@ class PostgresOperators(Enum):
     HAS_ANY_KEYS = '?|'
     GET_JSON_VALUE = '->'
     GET_TEXT_VALUE = '->>'
+    GET_PATH_JSON_VALUE = '#>'
+    GET_PATH_TEXT_VALUE = '#>>'
 

--- a/pypika/queries.py
+++ b/pypika/queries.py
@@ -50,6 +50,10 @@ class Selectable:
     def __getattr__(self, name):
         return self.field(name)
 
+    @ignore_copy
+    def __getitem__(self, name):
+        return self.field(name)
+
 
 class AliasedQuery(Selectable):
     def __init__(self, name, query=None):
@@ -393,7 +397,7 @@ class _UnionQuery(Selectable, Term):
         clauses = []
         selected_aliases = {s.alias for s in self.base_query._selects}
         for field, directionality in self._orderbys:
-            term = "{quote}{alias}{quote}".format(alias=field.alias, quote=quote_char or '') \
+            term = format_quotes(field.alias, quote_char) \
                 if field.alias and field.alias in selected_aliases \
                 else field.get_sql(quote_char=quote_char, **kwargs)
 
@@ -415,7 +419,12 @@ class QueryBuilder(Selectable, Term):
     state to be branched immutably.
     """
 
-    def __init__(self, quote_char='"', dialect=None, wrap_union_queries=True, wrapper_cls=ValueWrapper):
+    def __init__(self,
+                 quote_char='"',
+                 secondary_quote_char="'",
+                 dialect=None,
+                 wrap_union_queries=True,
+                 wrapper_cls=ValueWrapper):
         super(QueryBuilder, self).__init__(None)
 
         self._from = []
@@ -454,6 +463,7 @@ class QueryBuilder(Selectable, Term):
         self._foreign_table = False
 
         self.quote_char = quote_char
+        self.secondary_quote_char = secondary_quote_char
         self.dialect = dialect
         self.wrap_union_queries = wrap_union_queries
 
@@ -866,6 +876,7 @@ class QueryBuilder(Selectable, Term):
 
     def get_sql(self, with_alias=False, subquery=False, **kwargs):
         kwargs.setdefault('quote_char', self.quote_char)
+        kwargs.setdefault('secondary_quote_char', self.secondary_quote_char)
         kwargs.setdefault('dialect', self.dialect)
 
         if not (self._selects or self._insert_table or self._delete_from or self._update_table):
@@ -1058,10 +1069,7 @@ class QueryBuilder(Selectable, Term):
         selected_aliases = {s.alias for s in self._selects}
         for field in self._groupbys:
             if groupby_alias and field.alias and field.alias in selected_aliases:
-                clauses.append("{quote}{alias}{quote}".format(
-                      alias=field.alias,
-                      quote=quote_char or '',
-                ))
+                clauses.append(format_quotes(field.alias, quote_char))
             else:
                 clauses.append(field.get_sql(quote_char=quote_char, **kwargs))
 
@@ -1084,7 +1092,7 @@ class QueryBuilder(Selectable, Term):
         clauses = []
         selected_aliases = {s.alias for s in self._selects}
         for field, directionality in self._orderbys:
-            term = "{quote}{alias}{quote}".format(alias=field.alias, quote=quote_char or '') \
+            term = format_quotes(field.alias, quote_char) \
                 if orderby_alias and field.alias and field.alias in selected_aliases \
                 else field.get_sql(quote_char=quote_char, **kwargs)
 

--- a/pypika/tests/dialects/test_postgresql.py
+++ b/pypika/tests/dialects/test_postgresql.py
@@ -1,133 +1,168 @@
 import unittest
 
-from pypika import Table, Query, QueryException
+from pypika import (
+    JSON,
+    Table,
+)
 from pypika.dialects import PostgreSQLQuery
-from pypika.terms import JSONField
 
 
 class InsertTests(unittest.TestCase):
     table_abc = Table('abc')
-    json_field = JSONField('json')
 
     def test_array_keyword(self):
         q = PostgreSQLQuery.into(self.table_abc).insert(1, [1, "a", True])
 
         self.assertEqual('INSERT INTO "abc" VALUES (1,ARRAY[1,\'a\',true])', str(q))
 
-    def test_json_contains(self):
-        q = PostgreSQLQuery.from_(
-            self.table_abc,
-        ).select("*").where(
-            self.json_field.contains(
-                {"dates": "2018-07-10 - 2018-07-17"},
-            ),
-        )
+
+class JSONObjectTests(unittest.TestCase):
+    def test_json_value_from_dict(self):
+        q = PostgreSQLQuery \
+            .select(JSON({"a":"foo"}))
+
+        self.assertEqual('SELECT \'{"a":"foo"}\'', str(q))
+
+    def test_json_value_from_array_num(self):
+        q = PostgreSQLQuery \
+            .select(JSON([1, 2, 3]))
+
+        self.assertEqual('SELECT \'[1,2,3]\'', str(q))
+
+    def test_json_value_from_array_str(self):
+        q = PostgreSQLQuery \
+            .select(JSON(['a', 'b', 'c']))
+
+        self.assertEqual('SELECT \'["a","b","c"]\'', str(q))
+
+    def test_json_value_from_dict_recursive(self):
+        q = PostgreSQLQuery \
+            .select(JSON({"a":[1, 2, 3], "b":{"c":"foo"}, "d":1}))
+
+        self.assertEqual('SELECT \'{"a":[1,2,3],"b":{"c":"foo"},"d":1}\'', str(q))
+
+
+class JSONOperatorsTests(unittest.TestCase):
+    # reference https://www.postgresql.org/docs/9.5/functions-json.html
+    table_abc = Table('abc')
+
+    def test_get_json_value_by_key(self):
+        q = PostgreSQLQuery \
+            .from_(self.table_abc) \
+            .select("*") \
+            .where(self.table_abc.json.get_json_value('dates'))
+
+        self.assertEqual('SELECT * FROM "abc" WHERE "json"->\'dates\'', str(q))
+
+    def test_get_json_value_by_index(self):
+        q = PostgreSQLQuery \
+            .from_(self.table_abc) \
+            .select("*") \
+            .where(self.table_abc.json.get_json_value(1))
+
+        self.assertEqual('SELECT * FROM "abc" WHERE "json"->1', str(q))
+
+    def test_get_text_value_by_key(self):
+        q = PostgreSQLQuery \
+            .from_(self.table_abc) \
+            .select("*") \
+            .where(self.table_abc.json.get_text_value('dates'))
+
+        self.assertEqual('SELECT * FROM "abc" WHERE "json"->>\'dates\'', str(q))
+
+    def test_get_text_value_by_index(self):
+        q = PostgreSQLQuery \
+            .from_(self.table_abc) \
+            .select("*") \
+            .where(self.table_abc.json.get_text_value(1))
+
+        self.assertEqual('SELECT * FROM "abc" WHERE "json"->>1', str(q))
+
+    def test_get_path_json_value(self):
+        q = PostgreSQLQuery \
+            .from_(self.table_abc) \
+            .select("*") \
+            .where(self.table_abc.json.get_path_json_value('{a,b}'))
+
+        self.assertEqual('SELECT * FROM "abc" WHERE "json"#>\'{a,b}\'', str(q))
+
+    def test_get_path_text_value(self):
+        q = PostgreSQLQuery \
+            .from_(self.table_abc) \
+            .select("*") \
+            .where(self.table_abc.json.get_path_text_value('{a,b}'))
+
+        self.assertEqual('SELECT * FROM "abc" WHERE "json"#>>\'{a,b}\'', str(q))
+
+
+class JSONBOperatorsTests(unittest.TestCase):
+    # reference https://www.postgresql.org/docs/9.5/functions-json.html
+    table_abc = Table('abc')
+
+    def test_json_contains_for_json(self):
+        q = PostgreSQLQuery \
+            .select(JSON({"a":1, 'b':2}).contains({"a":1}))
+
+        self.assertEqual('SELECT \'{"a":1,"b":2}\'@>\'{"a":1}\'', str(q))
+
+    def test_json_contains_for_field(self):
+        q = PostgreSQLQuery \
+            .from_(self.table_abc) \
+            .select("*") \
+            .where(self.table_abc.json.contains({"dates":"2018-07-10 - 2018-07-17"}))
+
+        self.assertEqual('SELECT * '
+                         'FROM "abc" '
+                         'WHERE "json"@>\'{"dates":"2018-07-10 - 2018-07-17"}\'', str(q))
+
+    def test_json_contained_by_using_str_arg(self):
+        q = PostgreSQLQuery \
+            .from_(self.table_abc) \
+            .select('*') \
+            .where(self.table_abc.json.contained_by({"dates":"2018-07-10 - 2018-07-17", "imported":"8"}))
 
         self.assertEqual(
-            'SELECT * '
-            'FROM "abc" '
-            'WHERE "json"@>\'{"dates": "2018-07-10 - 2018-07-17"}\'',
-            str(q),
+              'SELECT * FROM "abc" '
+              'WHERE "json"<@\'{"dates":"2018-07-10 - 2018-07-17","imported":"8"}\'',
+              str(q),
         )
 
-        q = PostgreSQLQuery.from_(
-            self.table_abc
-        ).select("*").where(
-            self.json_field.contains(
-                '{"dates": "2018-07-10 - 2018-07-17"}'
-            )
-        )
-        self.assertEqual(
-            'SELECT * '
-            'FROM "abc" '
-            'WHERE "json"@>\'{"dates": "2018-07-10 - 2018-07-17"}\'',
-            str(q),
-        )
+    def test_json_contained_by_using_list_arg(self):
+        q = PostgreSQLQuery \
+            .from_(self.table_abc) \
+            .select('*') \
+            .where(self.table_abc.json.contained_by(["One", 'Two', "Three"]))
+
+        self.assertEqual('SELECT * FROM "abc" WHERE "json"<@\'["One","Two","Three"]\'', str(q))
+
+    def test_json_contained_by_with_complex_criterion(self):
+        q = PostgreSQLQuery \
+            .from_(self.table_abc) \
+            .select('*') \
+            .where(self.table_abc.json.contained_by(["One", "Two", "Three"]) & (self.table_abc.id == 26))
+
+        self.assertEqual('SELECT * FROM "abc" WHERE "json"<@\'["One","Two","Three"]\' AND "id"=26', str(q))
 
     def test_json_has_key(self):
-        q = PostgreSQLQuery.from_(self.table_abc).select("*").where(
-            self.json_field.has_key("dates"),
-        )
+        q = PostgreSQLQuery \
+            .from_(self.table_abc) \
+            .select("*") \
+            .where(self.table_abc.json.has_key("dates"))
 
-        self.assertEqual(
-            'SELECT * FROM "abc" WHERE "json"?\'dates\'', str(q),
-        )
-
-        q = PostgreSQLQuery.from_(self.table_abc).select("*").where(
-            self.json_field.has_key(JSONField("dates")),
-        )
-
-        self.assertEqual(
-            'SELECT * FROM "abc" WHERE "json"?\'dates\'', str(q),
-        )
-
-    def test_json_contained_by(self):
-        q = PostgreSQLQuery.from_(self.table_abc).select('*').where(
-            self.json_field.contained_by(
-                '{"dates": "2018-07-10 - 2018-07-17", "imported": "8"}',
-            ),
-        )
-
-        self.assertEqual(
-            'SELECT * FROM "abc" WHERE "json"<@\'{"dates": "2018-07-10 - 2018-07-17", "imported": "8"}\'',
-            str(q),
-        )
-
-        q = PostgreSQLQuery.from_(self.table_abc).select('*').where(
-            self.json_field.contained_by(
-                ["One", 'Two', "Three"],
-            ),
-        )
-
-        self.assertEqual(
-            'SELECT * FROM "abc" WHERE "json"<@\'["One", "Two", "Three"]\'', str(q),
-        )
-
-        q = PostgreSQLQuery.from_(self.table_abc).select('*').where(
-            self.json_field.contained_by('["One", "Two", "Three"]') & self.table_abc.id == 26
-        )
-
-        self.assertEqual(
-            'SELECT * FROM "abc" WHERE "json"<@\'["One", "Two", "Three"]\' AND "id"=26', str(q),
-        )
+        self.assertEqual('SELECT * FROM "abc" WHERE "json"?\'dates\'', str(q))
 
     def test_json_has_keys(self):
-        q = PostgreSQLQuery.from_(self.table_abc).select("*").where(
-            self.json_field.has_keys(['dates', 'imported']),
-        )
+        q = PostgreSQLQuery \
+            .from_(self.table_abc) \
+            .select("*") \
+            .where(self.table_abc.json.has_keys(['dates', 'imported']))
 
-        self.assertEqual(
-            'SELECT * FROM "abc" WHERE "json"?&ARRAY[\'dates\',\'imported\']', str(q)
-        )
+        self.assertEqual('SELECT * FROM "abc" WHERE "json"?&ARRAY[\'dates\',\'imported\']', str(q))
 
     def test_json_has_any_keys(self):
-        q = PostgreSQLQuery.from_(self.table_abc).select("*").where(
-            self.json_field.has_any_keys(['dates', 'imported']),
-        )
+        q = PostgreSQLQuery \
+            .from_(self.table_abc) \
+            .select("*") \
+            .where(self.table_abc.json.has_any_keys(['dates', 'imported']))
 
-        self.assertEqual(
-            'SELECT * FROM "abc" WHERE "json"?|ARRAY[\'dates\',\'imported\']', str(q)
-        )
-
-    def test_get_value_by_key(self):
-        q = PostgreSQLQuery.from_(self.table_abc).select(self.json_field.get_value_by_key(['dates', 'import']))
-
-        self.assertEqual(
-            'SELECT "json"->\'dates\'->>\'import\' FROM "abc"', str(q)
-        )
-
-        q = PostgreSQLQuery.from_(self.table_abc).select(self.json_field.get_value_by_key('dates'))
-
-        self.assertEqual(
-            'SELECT "json"->\'dates\' FROM "abc"', str(q)
-        )
-
-    def test_not_valid_values(self):
-        q = Query.from_(self.table_abc).select("*").where(self.json_field.has_key("dates"))
-        self.assertRaises(QueryException, str, q)
-
-        self.assertRaises(QueryException, self.json_field.has_keys, 'dates')
-        self.assertRaises(QueryException, self.json_field.has_any_keys, 'dates')
-        self.assertRaises(QueryException, self.json_field.get_value_by_key, {'test':'test'})
-        self.assertRaises(QueryException, self.json_field.has_key, 1)
-
+        self.assertEqual('SELECT * FROM "abc" WHERE "json"?|ARRAY[\'dates\',\'imported\']', str(q))

--- a/pypika/utils.py
+++ b/pypika/utils.py
@@ -66,7 +66,7 @@ def ignore_copy(func):
     """
 
     def _getattr(self, name):
-        if name in ['__copy__','__deepcopy__', '__getstate__', '__setstate__', '__getnewargs__']:
+        if name in ['__copy__', '__deepcopy__', '__getstate__', '__setstate__', '__getnewargs__']:
             raise AttributeError("'%s' object has no attribute '%s'" % (self.__class__.__name__, name))
 
         return func(self, name)
@@ -100,3 +100,10 @@ def alias_sql(sql, alias, quote_char=None):
     if alias is None:
         return sql
     return '{sql} {alias}'.format(sql=sql, alias=format_quotes(alias, quote_char))
+
+
+def validate(*args, exc=None, type=None):
+    if type is not None:
+        for arg in args:
+            if not isinstance(arg, type):
+                raise exc

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,4 @@ Sphinx==1.6.5
 sphinx-rtd-theme==0.2.4
 bumpversion==0.5.3
 parameterized==0.7.0
+typing==3.6.2

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 import ast
+
 from setuptools import setup
 
 
@@ -15,7 +16,7 @@ def version():
             if len(node.targets) == 1:
                 name = node.targets[0]
                 if isinstance(name, ast.Name) and \
-                        name.id in ('__version__', '__version_info__', 'VERSION'):
+                      name.id in ('__version__', '__version_info__', 'VERSION'):
                     v = node.value
                     if isinstance(v, ast.Str):
                         return v.s
@@ -31,48 +32,52 @@ def version():
 
 
 setup(
-    # Application name:
-    name="PyPika",
+      # Application name:
+      name="PyPika",
 
-    # Version number:
-    version=version(),
+      # Version number:
+      version=version(),
 
-    # Application author details:
-    author="Timothy Heys",
-    author_email="theys@kayak.com",
+      # Application author details:
+      author="Timothy Heys",
+      author_email="theys@kayak.com",
 
-    # License
-    license='Apache License Version 2.0',
+      # License
+      license='Apache License Version 2.0',
 
-    # Packages
-    packages=["pypika", "pypika.clickhouse"],
+      # Packages
+      packages=["pypika", "pypika.clickhouse"],
 
-    # Include additional files into the package
-    include_package_data=True,
+      # Include additional files into the package
+      include_package_data=True,
 
-    # Details
-    url="https://github.com/kayak/pypika",
+      install_requires=[
+          'typing==3.6.2'
+      ],
 
-    description="A SQL query builder API for Python",
-    long_description=readme(),
+      # Details
+      url="https://github.com/kayak/pypika",
 
-    classifiers=[
-        'License :: OSI Approved :: Apache Software License',
-        'Development Status :: 5 - Production/Stable',
-        'Intended Audience :: Developers',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: PL/SQL',
-        'Topic :: Software Development :: Libraries :: Python Modules',
-        'Topic :: Scientific/Engineering :: Information Analysis',
-        'Topic :: Scientific/Engineering :: Mathematics',
-        'Operating System :: POSIX',
-        'Operating System :: MacOS :: MacOS X',
-        'Operating System :: Microsoft :: Windows',
-    ],
-    keywords=('pypika python query builder querybuilder sql mysql postgres psql oracle vertica aggregated '
-              'relational database rdbms business analytics bi data science analysis pandas '
-              'orm object mapper'),
+      description="A SQL query builder API for Python",
+      long_description=readme(),
 
-    # Dependent packages (distributions)
-    test_suite="pypika.tests",
+      classifiers=[
+          'License :: OSI Approved :: Apache Software License',
+          'Development Status :: 5 - Production/Stable',
+          'Intended Audience :: Developers',
+          'Programming Language :: Python :: 3',
+          'Programming Language :: PL/SQL',
+          'Topic :: Software Development :: Libraries :: Python Modules',
+          'Topic :: Scientific/Engineering :: Information Analysis',
+          'Topic :: Scientific/Engineering :: Mathematics',
+          'Operating System :: POSIX',
+          'Operating System :: MacOS :: MacOS X',
+          'Operating System :: Microsoft :: Windows',
+      ],
+      keywords=('pypika python query builder querybuilder sql mysql postgres psql oracle vertica aggregated '
+                'relational database rdbms business analytics bi data science analysis pandas '
+                'orm object mapper'),
+
+      # Dependent packages (distributions)
+      test_suite="pypika.tests",
 )


### PR DESCRIPTION
Fixes #277

Did some refactoring to the implementation of the JSON data type for psql and redshift to align it closer to pypika's style

@teror4uks Perhaps you can review this? Sorry for not giving better guidance on your original PR. There were a couple bits of code that needed to get moved around to keep the JSON and JSON comparators aligned with the rest of the pieces.

I introduced a JSON object for carrying JSON data, which can be used directly, but also Fields can be treated as such. See the unit tests for it.

