### PR TITLE
Add force index

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,3 @@ ENV/
 
 # OS X
 .DS_Store
-
-# misc
-/playground.py

--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,6 @@ ENV/
 
 # OS X
 .DS_Store
+
+# misc
+/playground.py

--- a/pypika/__init__.py
+++ b/pypika/__init__.py
@@ -65,6 +65,7 @@ from pypika.terms import (
     Criterion,
     EmptyCriterion,
     Field,
+    Index,
     Interval,
     JSON,
     Not,

--- a/pypika/__init__.py
+++ b/pypika/__init__.py
@@ -86,4 +86,4 @@ from pypika.utils import (
 
 __author__ = 'Timothy Heys'
 __email__ = 'theys@kayak.com'
-__version__ = '0.35.10'
+__version__ = '0.35.8'

--- a/pypika/queries.py
+++ b/pypika/queries.py
@@ -627,14 +627,12 @@ class QueryBuilder(Selectable, Term):
         self._replace = True
 
     @builder
-    def force_index(self, *terms):
-        for term in terms:
-            if isinstance(term, Index):
-                self._force_indexes.append(term)
-            elif isinstance(term, str):
-                self._force_indexes.append(Index(term))
-        if len(self._force_indexes) == 0:
-            raise TypeError("No proper index provided for FORCE INDEX.")
+    def force_index(self, term, *terms):
+        for t in (term, *terms):
+            if isinstance(t, Index):
+                self._force_indexes.append(t)
+            elif isinstance(t, str):
+                self._force_indexes.append(Index(t))
 
     @builder
     def distinct(self):
@@ -1071,8 +1069,8 @@ class QueryBuilder(Selectable, Term):
         ))
 
     def _force_index_sql(self, **kwargs):
-        return ' FORCE INDEX({indexes})'.format(indexes=','.join(
-            index.get_sql(with_alias=False, subquery=True, **kwargs)
+        return ' FORCE INDEX ({indexes})'.format(indexes=','.join(
+            index.get_sql(**kwargs)
             for index in self._force_indexes),
         )
 

--- a/pypika/queries.py
+++ b/pypika/queries.py
@@ -10,6 +10,7 @@ from pypika.terms import (
     EmptyCriterion,
     Field,
     Function,
+    Index,
     Rollup,
     Star,
     Term,
@@ -628,10 +629,10 @@ class QueryBuilder(Selectable, Term):
     @builder
     def force_index(self, *terms):
         for term in terms:
-            if isinstance(term, Field):
+            if isinstance(term, Index):
                 self._force_indexes.append(term)
             elif isinstance(term, str):
-                self._force_indexes.append(Field(term, table=self._from[0]))
+                self._force_indexes.append(Index(term))
         if len(self._force_indexes) == 0:
             raise TypeError("No proper index provided for FORCE INDEX.")
 
@@ -1071,7 +1072,7 @@ class QueryBuilder(Selectable, Term):
 
     def _force_index_sql(self, **kwargs):
         return ' FORCE INDEX({indexes})'.format(indexes=','.join(
-            index.get_sql(with_alias=True, subquery=True, **kwargs)
+            index.get_sql(with_alias=False, subquery=True, **kwargs)
             for index in self._force_indexes),
         )
 

--- a/pypika/terms.py
+++ b/pypika/terms.py
@@ -483,9 +483,6 @@ class Index(Term):
         super(Index, self).__init__(alias)
         self.name = name
 
-    def fields(self):
-        return None
-
     def get_sql(self, quote_char=None, secondary_quote_char="'", **kwargs):
         return format_quotes(self.name, quote_char)
 

--- a/pypika/terms.py
+++ b/pypika/terms.py
@@ -478,6 +478,18 @@ class Field(Criterion, JSON):
         return field_sql
 
 
+class Index(Term):
+    def __init__(self, name, alias=None):
+        super(Index, self).__init__(alias)
+        self.name = name
+
+    def fields(self):
+        return None
+
+    def get_sql(self, quote_char=None, secondary_quote_char="'", **kwargs):
+        return format_quotes(self.name, quote_char)
+
+
 class Star(Field):
     def __init__(self, table=None):
         super(Star, self).__init__('*', table=table)

--- a/pypika/terms.py
+++ b/pypika/terms.py
@@ -483,7 +483,7 @@ class Index(Term):
         super(Index, self).__init__(alias)
         self.name = name
 
-    def get_sql(self, quote_char=None, secondary_quote_char="'", **kwargs):
+    def get_sql(self, quote_char=None, **kwargs):
         return format_quotes(self.name, quote_char)
 
 

--- a/pypika/tests/test_selects.py
+++ b/pypika/tests/test_selects.py
@@ -6,6 +6,7 @@ from pypika import (
     ClickHouseQuery,
     EmptyCriterion,
     Field as F,
+    Index,
     MSSQLQuery,
     MySQLQuery,
     NullValue,
@@ -199,6 +200,12 @@ class SelectTests(unittest.TestCase):
 
     def test_select_with_force_index(self):
         q = Query.from_('abc').select('foo').force_index('egg')
+
+        self.assertEqual('SELECT "foo" FROM "abc" FORCE INDEX ("egg")', str(q))
+
+    def test_select_with_force_index_with_index_object(self):
+        index = Index('egg')
+        q = Query.from_('abc').select('foo').force_index(index)
 
         self.assertEqual('SELECT "foo" FROM "abc" FORCE INDEX ("egg")', str(q))
 

--- a/pypika/tests/test_selects.py
+++ b/pypika/tests/test_selects.py
@@ -197,6 +197,21 @@ class SelectTests(unittest.TestCase):
 
         self.assertEqual('SELECT "foo" FROM "abc" LIMIT 10 OFFSET 10', str(q1))
 
+    def test_select_with_force_index(self):
+        q = Query.from_('abc').select('foo').force_index('egg')
+
+        self.assertEqual('SELECT "foo" FROM "abc" FORCE INDEX ("egg")', str(q))
+
+    def test_select_with_force_index_multiple_indexes(self):
+        q = Query.from_('abc').select('foo').force_index('egg', 'bacon')
+
+        self.assertEqual('SELECT "foo" FROM "abc" FORCE INDEX ("egg","bacon")', str(q))
+
+    def test_select_with_force_index_multiple_calls(self):
+        q = Query.from_('abc').select('foo').force_index('egg',).force_index('spam')
+
+        self.assertEqual('SELECT "foo" FROM "abc" FORCE INDEX ("egg","spam")', str(q))
+
     def test_mysql_query_uses_backtick_quote_chars(self):
         q = MySQLQuery.from_('abc').select('foo', 'bar')
 
@@ -343,6 +358,10 @@ class WhereTests(unittest.TestCase):
 
         self.assertEqual('SELECT * FROM "abc"', str(q1))
 
+    def test_select_with_force_index_and_where(self):
+        q = Query.from_('abc').select('foo').where(self.t.foo == self.t.bar).force_index('egg')
+
+        self.assertEqual('SELECT "foo" FROM "abc" FORCE INDEX ("egg") WHERE "foo"="bar"', str(q))
 
 class PreWhereTests(WhereTests):
     t = Table('abc')

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.35.10
+current_version = 0.35.8
 commit = True
 tag = True
 


### PR DESCRIPTION
Add FORCE INDEX hint to enhance performance with query optimizer

This replaces PR 'add force index hint #330' (I made the changes on branch in my fork - whereas #330 PR was done on patch, thus this new PR)

I added class for Index (previously, I used Field) and tests. Requests and comments from #330 were taken in account.