### PR TITLE
Allow raw sql string usage

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -660,6 +660,27 @@ using the ``when`` method and to set the default value using ``else_``.
     SELECT "id",CASE WHEN "fname"='Tom' THEN 'It was Tom' WHEN "fname"='John' THEN 'It was John' ELSE 'It was someone else.' END "who_was_it" FROM "customers"
 
 
+Raw SQL
+"""""""""""""""
+
+Raw SQL allows us to use any string on queries, as some functions that are not covered by PyPika in some
+different dialects.
+
+
+.. code-block:: python
+
+    from pypika import functions as fn
+
+    customers = Tables('customers')
+    q = Query.from_(customers).select(
+        customers.id,
+        fn.Raw('current_date'),
+    )
+
+.. code-block:: sql
+
+    SELECT id,current_date FROM customers
+
 Inserting Data
 ^^^^^^^^^^^^^^
 

--- a/pypika/functions.py
+++ b/pypika/functions.py
@@ -41,9 +41,9 @@ class Count(DistinctOptionFunction):
         super(Count, self).__init__('COUNT', Star() if is_star else param, alias=alias)
 
 class Raw(Function):
-    def __init__(self, term):
+    def __init__(self, term, alias=None):
         self.term = term
-        super(Raw, self).__init__(term)
+        super(Raw, self).__init__(term, alias=alias)
 
     def get_function_sql(self, **kwargs):
         return self.term

--- a/pypika/functions.py
+++ b/pypika/functions.py
@@ -40,6 +40,14 @@ class Count(DistinctOptionFunction):
         is_star = isinstance(param, str) and '*' == param
         super(Count, self).__init__('COUNT', Star() if is_star else param, alias=alias)
 
+class Raw(Function):
+    def __init__(self, term):
+        self.term = term
+        super(Raw, self).__init__(term)
+
+    def get_function_sql(self, **kwargs):
+        return self.term
+
 
 # Arithmetic Functions
 class Sum(DistinctOptionFunction):
@@ -302,3 +310,4 @@ class IfNull(Function):
 class NVL(Function):
     def __init__(self, condition, term, alias=None):
         super(NVL, self).__init__('NVL', condition, term, alias=alias)
+

--- a/pypika/tests/test_functions.py
+++ b/pypika/tests/test_functions.py
@@ -405,6 +405,11 @@ class StringTests(unittest.TestCase):
 
         self.assertEqual("SELECT current_date FROM \"abc\"", str(q))
 
+    def test__raw__sql_on_select_with_alias(self):
+        q = Q.from_(self.t).select(fn.Raw('current_date', 'now'))
+
+        self.assertEqual("SELECT current_date \"now\" FROM \"abc\"", str(q))
+
     def test__raw__sql_on_where(self):
         q = Q.from_(self.t).select('foo').where(fn.Raw('foo != bar'))
 

--- a/pypika/tests/test_functions.py
+++ b/pypika/tests/test_functions.py
@@ -400,6 +400,16 @@ class StringTests(unittest.TestCase):
 
         self.assertEqual("SELECT SUBSTRING(\"foo\",2,6) FROM \"abc\"", str(q))
 
+    def test__raw__sql_on_select(self):
+        q = Q.from_(self.t).select(fn.Raw('current_date'))
+
+        self.assertEqual("SELECT current_date FROM \"abc\"", str(q))
+
+    def test__raw__sql_on_where(self):
+        q = Q.from_(self.t).select('foo').where(fn.Raw('foo != bar'))
+
+        self.assertEqual("SELECT \"foo\" FROM \"abc\" WHERE foo != bar", str(q))
+
 
 class SplitPartFunctionTests(unittest.TestCase):
     t = T('abc')


### PR DESCRIPTION
As some dialects don't understand the current functions, it's a way to
use some reserved functions in all dialects without the need to change
the core for each.

I understand that with it we can open a margin for errors, but also we
can give to the user more flexibility.

Closes #337 