### PR TITLE
Custom Function implementation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -628,6 +628,30 @@ There are several string operations and function wrappers included in |Brand|.  
     SELECT id,CONCAT(fname, ' ', lname) full_name FROM customers
 
 
+Custom Functions
+"""""""""""""""""
+
+Custom Functions allows us to use any function on queries, as some functions are not covered by PyPika as default, we can appeal
+to Custom functions.
+
+.. code-block:: python
+
+    from pypika import CustomFunction
+
+    customers = Tables('customers')
+    DateDiff = CustomFunction('DATE_DIFF', ['interval', 'start_date', 'end_date'])
+
+    q = Query.from_(customers).select(
+        customers.id,
+        customers.fname,
+        customers.lname,
+        DateDiff('day', customers.created_date, customers.updated_date)
+    )
+
+.. code-block:: sql
+
+    SELECT id,fname,lname,DATE_DIFF('day',created_date,updated_date) FROM customers
+    
 Case Statements
 """""""""""""""
 

--- a/pypika/__init__.py
+++ b/pypika/__init__.py
@@ -73,6 +73,7 @@ from pypika.terms import (
     Parameter,
     Rollup,
     Tuple,
+    CustomFunction,
 )
 # noinspection PyUnresolvedReferences
 from pypika.utils import (
@@ -82,6 +83,7 @@ from pypika.utils import (
     QueryException,
     RollupException,
     UnionException,
+    FunctionException,
 )
 
 __author__ = 'Timothy Heys'

--- a/pypika/tests/test_custom_functions.py
+++ b/pypika/tests/test_custom_functions.py
@@ -1,0 +1,49 @@
+import unittest
+
+from pypika import (
+    FunctionException,
+    Query,
+    Table,
+    functions as fn,
+    CustomFunction
+)
+
+__author__ = "Airton Zanon"
+__email__ = "me@airton.dev"
+
+class TestUnitCustomFunction(unittest.TestCase):
+
+    def test_should_fail_with_wrong_arguments(self):
+        DateDiff = CustomFunction('DATE_DIFF', ['interval', 'start_date', 'end_date']);
+
+        with self.assertRaises(FunctionException):
+            DateDiff('foo')
+    
+    def test_should_return_function_with_arguments(self):
+        DateDiff = CustomFunction('DATE_DIFF', ['interval', 'start_date', 'end_date']);
+
+        self.assertEqual("DATE_DIFF('day','start_date','end_date')", str(DateDiff('day', 'start_date', 'end_date')))
+
+    def test_should_return_function_with_no_arguments(self):
+        CurrentDate = CustomFunction('CURRENT_DATE');
+
+        self.assertEqual("CURRENT_DATE()", str(CurrentDate()))
+
+class TestFunctionalCustomFunction(unittest.TestCase):
+
+    def test_should_use_custom_function_on_select(self):
+        service = Table('service')
+
+        DateDiff = CustomFunction('DATE_DIFF', ['interval', 'start_date', 'end_date'])
+
+        q = Query.from_(service).select(DateDiff("day", service.created_date, service.updated_date))
+
+        self.assertEqual("SELECT DATE_DIFF('day',\"created_date\",\"updated_date\") FROM \"service\"", str(q))
+
+    def test_should_fail_use_custom_function_on_select_with_wrong_arguments(self):
+        service = Table('service')
+
+        DateDiff = CustomFunction('DATE_DIFF', ['interval', 'start_date', 'end_date'])
+
+        with self.assertRaises(FunctionException):
+            Query.from_(service).select(DateDiff("day", service.created_date))

--- a/pypika/utils.py
+++ b/pypika/utils.py
@@ -31,6 +31,9 @@ class RollupException(Exception):
 class DialectNotSupported(Exception):
     pass
 
+class FunctionException(Exception):
+    pass
+
 
 def builder(func):
     """


### PR DESCRIPTION
As some dialects don't understand the current functions, it's a way to
use some reserved functions in all dialects without the need to change
the core for each.

This works as a Factory, it gets the function name and arguments and
return a callable that can be used in the query builder.

It also works for functions that don't need arguments.

It was discussed on PR #338 
It closes #337