### PR TITLE
BUG: fix JoinUsing get_sql

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -441,7 +441,7 @@ Example of a join using `USING`
     history, customers = Tables('history', 'customers')
     q = Query.from_(history).join(
         customers
-    ).on(
+    ).using(
         'customer_id'
     ).select(
         history.star

--- a/pypika/queries.py
+++ b/pypika/queries.py
@@ -1325,7 +1325,7 @@ class JoinUsing(Join):
         join_sql = super(JoinUsing, self).get_sql(**kwargs)
         return '{join} USING ({fields})'.format(
               join=join_sql,
-              fields=','.join(str(field) for field in self.fields)
+              fields=','.join(field.get_sql(**kwargs) for field in self.fields)
         )
 
     def validate(self, _from, _joins):

--- a/pypika/tests/test_joins.py
+++ b/pypika/tests/test_joins.py
@@ -92,6 +92,11 @@ class SelectQueryJoinTests(unittest.TestCase):
 
         self.assertEqual('SELECT * FROM "abc" JOIN "efg" USING ("foo","bar")', str(query))
 
+    def test_join_using_with_quote_char(self):
+        query = Query.from_(self.table0).join(self.table1).using('foo', 'bar').select('*')
+
+        self.assertEqual('SELECT * FROM abc JOIN efg USING (foo,bar)', query.get_sql(quote_char=''))
+
     def test_join_using_without_fields_raises_exception(self):
         with self.assertRaises(JoinException):
             query = Query.from_(self.table0).join(self.table1).using()


### PR DESCRIPTION
When creating a query that uses JoinUsing, the get_sql method ignores the quote_char argument for parts of the query.
For example:
```
q = Query.from_('abc').join('efg').using('foo', 'bar').select('*')
q.get_sql(quote_char='')
```
will result in:
```SELECT * FROM abc JOIN efg USING ("foo","bar")```

The PR fixes this issue, and now this command will result with:
```SELECT * FROM abc JOIN efg USING (foo,bar)```


In addition a unit test was added, and README.rst was updated as well
