### PR TITLE
Support iterable params to columns

### DIFF
--- a/pypika/queries.py
+++ b/pypika/queries.py
@@ -719,6 +719,9 @@ class QueryBuilder(Selectable, Term):
         if self._insert_table is None:
             raise AttributeError("'Query' object has no attribute '%s'" % "insert")
 
+        if isinstance(terms[0], (list, tuple)):
+            terms = terms[0]
+
         for term in terms:
             if isinstance(term, str):
                 term = Field(term, table=self._insert_table)

--- a/pypika/tests/test_inserts.py
+++ b/pypika/tests/test_inserts.py
@@ -111,6 +111,28 @@ class InsertIntoTests(unittest.TestCase):
             'INSERT INTO "abc" ("foo","bar","buz") VALUES (1,\'a\',true)', str(query)
         )
 
+    def test_insert_selected_columns_type_list(self):
+        query = (
+            Query.into(self.table_abc)
+            .columns([self.table_abc.foo, self.table_abc.bar, self.table_abc.buz])
+            .insert(1, "a", True)
+        )
+
+        self.assertEqual(
+            'INSERT INTO "abc" ("foo","bar","buz") VALUES (1,\'a\',true)', str(query)
+        )
+
+    def test_insert_selected_columns_type_tuple(self):
+        query = (
+            Query.into(self.table_abc)
+            .columns((self.table_abc.foo, self.table_abc.bar, self.table_abc.buz))
+            .insert(1, "a", True)
+        )
+
+        self.assertEqual(
+            'INSERT INTO "abc" ("foo","bar","buz") VALUES (1,\'a\',true)', str(query)
+        )
+
     def test_insert_none_skipped(self):
         query = Query.into(self.table_abc).insert()
 


### PR DESCRIPTION
- Support iterable params(list, tuple) to columns 
- Add type checking in QueryBuilder colum methods

Fixed : #372 