### PR TITLE
Use self._wrapper_cls in QueryBuilder.set

### DIFF
--- a/pypika/queries.py
+++ b/pypika/queries.py
@@ -901,7 +901,7 @@ class QueryBuilder(Selectable, Term):
     @builder
     def set(self, field, value):
         field = Field(field) if not isinstance(field, Field) else field
-        self._updates.append((field, ValueWrapper(value)))
+        self._updates.append((field, self._wrapper_cls(value)))
 
     def __add__(self, other):
         return self.union(other)

--- a/pypika/tests/test_updates.py
+++ b/pypika/tests/test_updates.py
@@ -1,6 +1,6 @@
 import unittest
 
-from pypika import Table, Query, PostgreSQLQuery, AliasedQuery
+from pypika import Table, Query, PostgreSQLQuery, AliasedQuery, SQLLiteQuery
 
 __author__ = "Timothy Heys"
 __email__ = "theys@kayak.com"
@@ -132,3 +132,12 @@ class PostgresUpdateTests(unittest.TestCase):
         self.assertEqual(
             'UPDATE "abc" SET "lname"="bcd"."long_name" FROM "bcd" RETURNING "abc"."id","bcd"."fname"', str(q)
         )
+
+
+class SQLLiteUpdateTests(unittest.TestCase):
+    table_abc = Table("abc")
+
+    def test_update_with_bool(self):
+        q = SQLLiteQuery.update(self.table_abc).set(self.table_abc.foo, True)
+
+        self.assertEqual('UPDATE "abc" SET "foo"=1', str(q))


### PR DESCRIPTION
This commit fixes a problem where the QueryBuilder.set method always
used the ValueWrapper class instead of the instance's _wrapper_cls.

Signed-off-by: Petter Nyström <jimorie@gmail.com>