### PR TITLE
Set default unit with Interval query

### DIFF
--- a/pypika/terms.py
+++ b/pypika/terms.py
@@ -1425,6 +1425,10 @@ class Interval(Node):
                 else self.largest
             )
 
+            # Set default unit with DAY
+            if unit is None:
+                unit = "DAY"
+
         return self.templates.get(dialect, "INTERVAL '{expr} {unit}'").format(
             expr=expr, unit=unit
         )

--- a/pypika/tests/test_date_math.py
+++ b/pypika/tests/test_date_math.py
@@ -50,6 +50,11 @@ class AddIntervalTests(unittest.TestCase):
 
         self.assertEqual("\"dt\"+INTERVAL '1 YEAR'", str(c))
 
+    def test_add_default(self):
+        c = dt + Interval(days=0)
+
+        self.assertEqual("\"dt\"+INTERVAL '0 DAY'", str(c))
+
 
 class AddIntervalMultipleUnitsTests(unittest.TestCase):
     def test_add_second_microsecond(self):


### PR DESCRIPTION
Current `Interval` code can generate wrong query When all value is unset.
`(e.g Interval(days=0).get_sql())`

So just check that all value is unset, and set default with `DAY`. 
This is small fixing, you may don't like this solution. 
Maybe we need to consider as `exception` when all value is unset.
Please check it and review plz. Thank u :)

Fixed : #389 