### PR TITLE
Allow alias with nested function

### DIFF
--- a/pypika/terms.py
+++ b/pypika/terms.py
@@ -1148,7 +1148,7 @@ class Function(Criterion):
         return "{name}({args}{special})".format(
             name=self.name,
             args=",".join(
-                p.get_sql(with_alias=False, **kwargs)
+                p.get_sql(with_alias=True, **kwargs)
                 if hasattr(p, "get_sql")
                 else str(p)
                 for p in self.args

--- a/pypika/tests/test_selects.py
+++ b/pypika/tests/test_selects.py
@@ -847,6 +847,16 @@ class AliasTests(unittest.TestCase):
 
         self.assertEqual('SELECT COUNT(*) "foo" FROM "abc"', str(q))
 
+    def test_function_using_as_nested(self):
+        q = Query.from_(self.t).select(fn.Sqrt(fn.Count("*").as_("foo")).as_("bar"))
+
+        self.assertEqual('SELECT SQRT(COUNT(*) "foo") "bar" FROM "abc"', str(q))
+
+    def test_functions_using_constructor_param_nested(self):
+        q = Query.from_(self.t).select(fn.Sqrt(fn.Count("*", alias="foo"), alias="bar"))
+
+        self.assertEqual('SELECT SQRT(COUNT(*) "foo") "bar" FROM "abc"', str(q))
+
     def test_ignored_in_where(self):
         q = Query.from_(self.t).select(self.t.foo).where(self.t.foo.as_("bar") == 1)
 


### PR DESCRIPTION
With #388, when using function nest. Inner alias is ignored.
I don't know that this behavior is intended.
Allowing alias with nested function (inner) can be useful
(Maybe custom function?.. umm.. i'm not sure 😕, Plz see #388)
And add test to test this feature.

Fixed: #388 