### PR TITLE
Fixed clickhouse query to always use the AS keyword for aliases

### DIFF
--- a/pypika/clickhouse/search_string.py
+++ b/pypika/clickhouse/search_string.py
@@ -1,12 +1,13 @@
 import abc
 
 from pypika.terms import Function
+from pypika.utils import format_alias_sql
 
 
 class _AbstractSearchString(Function, metaclass=abc.ABCMeta):
     def __init__(self, name, pattern: str, alias: str = None):
         super(_AbstractSearchString, self).__init__(
-            self.clickhouse_function(), name, alias=alias
+              self.clickhouse_function(), name, alias=alias
         )
 
         self._pattern = pattern
@@ -17,30 +18,30 @@ class _AbstractSearchString(Function, metaclass=abc.ABCMeta):
         pass
 
     def get_sql(
-        self,
-        with_alias=False,
-        with_namespace=False,
-        quote_char=None,
-        dialect=None,
-        **kwargs
+          self,
+          with_alias=False,
+          with_namespace=False,
+          quote_char=None,
+          dialect=None,
+          **kwargs
     ):
         args = []
         for p in self.args:
             if hasattr(p, "get_sql"):
                 args.append(
-                    'toString("{arg}")'.format(
-                        arg=p.get_sql(with_alias=False, **kwargs)
-                    )
+                      'toString("{arg}")'.format(
+                            arg=p.get_sql(with_alias=False, **kwargs)
+                      )
                 )
             else:
                 args.append(str(p))
 
-        return "{name}({args},'{pattern}'){alias}".format(
-            name=self.name,
-            args=",".join(args),
-            pattern=self._pattern,
-            alias=" " + self.alias if self.alias else "",
+        sql = "{name}({args},'{pattern}')".format(
+              name=self.name,
+              args=",".join(args),
+              pattern=self._pattern,
         )
+        return format_alias_sql(sql, self.alias, **kwargs)
 
 
 class Match(_AbstractSearchString):
@@ -64,7 +65,7 @@ class NotLike(_AbstractSearchString):
 class _AbstractMultiSearchString(Function, metaclass=abc.ABCMeta):
     def __init__(self, name, patterns: list, alias: str = None):
         super(_AbstractMultiSearchString, self).__init__(
-            self.clickhouse_function(), name, alias=alias
+              self.clickhouse_function(), name, alias=alias
         )
 
         self._patterns = patterns
@@ -75,30 +76,30 @@ class _AbstractMultiSearchString(Function, metaclass=abc.ABCMeta):
         pass
 
     def get_sql(
-        self,
-        with_alias=False,
-        with_namespace=False,
-        quote_char=None,
-        dialect=None,
-        **kwargs
+          self,
+          with_alias=False,
+          with_namespace=False,
+          quote_char=None,
+          dialect=None,
+          **kwargs
     ):
         args = []
         for p in self.args:
             if hasattr(p, "get_sql"):
                 args.append(
-                    'toString("{arg}")'.format(
-                        arg=p.get_sql(with_alias=False, **kwargs)
-                    )
+                      'toString("{arg}")'.format(
+                            arg=p.get_sql(with_alias=False, **kwargs)
+                      )
                 )
             else:
                 args.append(str(p))
 
-        return "{name}({args},[{patterns}]){alias}".format(
-            name=self.name,
-            args=",".join(args),
-            patterns=",".join(["'%s'" % i for i in self._patterns]),
-            alias=" " + self.alias if self.alias else "",
+        sql = "{name}({args},[{patterns}])".format(
+              name=self.name,
+              args=",".join(args),
+              patterns=",".join(["'%s'" % i for i in self._patterns]),
         )
+        return format_alias_sql(sql, self.alias, **kwargs)
 
 
 class MultiSearchAny(_AbstractMultiSearchString):

--- a/pypika/clickhouse/type_conversion.py
+++ b/pypika/clickhouse/type_conversion.py
@@ -1,4 +1,8 @@
-from pypika.terms import Function, Field
+from pypika.terms import (
+    Field,
+    Function,
+)
+from pypika.utils import format_alias_sql
 
 
 class ToString(Function):
@@ -16,21 +20,21 @@ class ToFixedString(Function):
         self.args = ()
 
     def get_sql(
-        self,
-        with_alias=False,
-        with_namespace=False,
-        quote_char=None,
-        dialect=None,
-        **kwargs
+          self,
+          with_alias=False,
+          with_namespace=False,
+          quote_char=None,
+          dialect=None,
+          **kwargs
     ):
-        return "{name}({field},{length}){alias}".format(
-            name=self.name,
-            field=self._field
-            if isinstance(self._field, Field)
-            else "'%s'" % str(self._field),
-            length=self._length,
-            alias=" " + self.alias if self.alias else "",
+        sql = "{name}({field},{length})".format(
+              name=self.name,
+              field=self._field
+              if isinstance(self._field, Field)
+              else "'%s'" % str(self._field),
+              length=self._length,
         )
+        return format_alias_sql(sql, self.alias, **kwargs)
 
 
 class ToInt8(Function):

--- a/pypika/dialects.py
+++ b/pypika/dialects.py
@@ -9,12 +9,12 @@ from pypika.queries import (
 )
 from pypika.terms import (
     ArithmeticExpression,
+    EmptyCriterion,
     Field,
-    Term,
     Function,
     Star,
+    Term,
     ValueWrapper,
-    EmptyCriterion
 )
 from pypika.utils import (
     QueryException,
@@ -28,7 +28,7 @@ class SnowFlakeQueryBuilder(QueryBuilder):
 
     def __init__(self, **kwargs):
         super(SnowFlakeQueryBuilder, self).__init__(
-            dialect=Dialects.SNOWFLAKE, **kwargs
+              dialect=Dialects.SNOWFLAKE, **kwargs
         )
 
 
@@ -47,7 +47,7 @@ class MySQLQueryBuilder(QueryBuilder):
 
     def __init__(self, **kwargs):
         super(MySQLQueryBuilder, self).__init__(
-            dialect=Dialects.MYSQL, wrap_union_queries=False, **kwargs
+              dialect=Dialects.MYSQL, wrap_union_queries=False, **kwargs
         )
         self._duplicate_updates = []
         self._modifiers = []
@@ -71,12 +71,12 @@ class MySQLQueryBuilder(QueryBuilder):
 
     def _on_duplicate_key_update_sql(self, **kwargs):
         return " ON DUPLICATE KEY UPDATE {updates}".format(
-            updates=",".join(
-                "{field}={value}".format(
-                    field=field.get_sql(**kwargs), value=value.get_sql(**kwargs)
-                )
-                for field, value in self._duplicate_updates
-            )
+              updates=",".join(
+                    "{field}={value}".format(
+                          field=field.get_sql(**kwargs), value=value.get_sql(**kwargs)
+                    )
+                    for field, value in self._duplicate_updates
+              )
         )
 
     @builder
@@ -95,12 +95,12 @@ class MySQLQueryBuilder(QueryBuilder):
         with the addition of the a modifier if present.
         """
         return "SELECT {distinct}{modifier}{select}".format(
-            distinct="DISTINCT " if self._distinct else "",
-            modifier="{} ".format(" ".join(self._modifiers)) if self._modifiers else "",
-            select=",".join(
-                term.get_sql(with_alias=True, subquery=True, **kwargs)
-                for term in self._selects
-            ),
+              distinct="DISTINCT " if self._distinct else "",
+              modifier="{} ".format(" ".join(self._modifiers)) if self._modifiers else "",
+              select=",".join(
+                    term.get_sql(with_alias=True, subquery=True, **kwargs)
+                    for term in self._selects
+              ),
         )
 
 
@@ -167,7 +167,7 @@ class VerticaQueryBuilder(QueryBuilder):
 
         if self._hint is not None:
             sql = "".join(
-                [sql[:7], "/*+label({hint})*/".format(hint=self._hint), sql[6:]]
+                  [sql[:7], "/*+label({hint})*/".format(hint=self._hint), sql[6:]]
             )
 
         return sql
@@ -195,21 +195,21 @@ class VerticaCreateQueryBuilder(CreateQueryBuilder):
 
     def _create_table_sql(self, **kwargs):
         return "CREATE {local}{temporary}TABLE {table}".format(
-            local="LOCAL " if self._local else "",
-            temporary="TEMPORARY " if self._temporary else "",
-            table=self._create_table.get_sql(**kwargs),
+              local="LOCAL " if self._local else "",
+              temporary="TEMPORARY " if self._temporary else "",
+              table=self._create_table.get_sql(**kwargs),
         )
 
     def _columns_sql(self, **kwargs):
         return " ({columns}){preserve_rows}".format(
-            columns=",".join(column.get_sql(**kwargs) for column in self._columns),
-            preserve_rows=self._preserve_rows_sql(),
+              columns=",".join(column.get_sql(**kwargs) for column in self._columns),
+              preserve_rows=self._preserve_rows_sql(),
         )
 
     def _as_select_sql(self, **kwargs):
         return "{preserve_rows} AS ({query})".format(
-            preserve_rows=self._preserve_rows_sql(),
-            query=self._as_select.get_sql(**kwargs),
+              preserve_rows=self._preserve_rows_sql(),
+              query=self._as_select.get_sql(**kwargs),
         )
 
     def _preserve_rows_sql(self):
@@ -275,7 +275,7 @@ class OracleQueryBuilder(QueryBuilder):
 
     def get_sql(self, *args, **kwargs):
         return super(OracleQueryBuilder, self).get_sql(
-            *args, groupby_alias=False, **kwargs
+              *args, groupby_alias=False, **kwargs
         )
 
 
@@ -378,9 +378,9 @@ class PostgreQueryBuilder(QueryBuilder):
     def _distinct_sql(self, **kwargs):
         if self._distinct_on:
             return "DISTINCT ON({distinct_on}) ".format(
-                distinct_on=",".join(
-                    term.get_sql(with_alias=True, **kwargs) for term in self._distinct_on
-                )
+                  distinct_on=",".join(
+                        term.get_sql(with_alias=True, **kwargs) for term in self._distinct_on
+                  )
             )
         return super()._distinct_sql(**kwargs)
 
@@ -405,7 +405,7 @@ class PostgreQueryBuilder(QueryBuilder):
 
         if self._on_conflict_wheres:
             conflict_query += " WHERE {where}".format(
-                where=self._on_conflict_wheres.get_sql(subquery=True, **kwargs)
+                  where=self._on_conflict_wheres.get_sql(subquery=True, **kwargs)
             )
 
         return conflict_query
@@ -415,18 +415,18 @@ class PostgreQueryBuilder(QueryBuilder):
             return " DO NOTHING"
         elif len(self._on_conflict_do_updates) > 0:
             action_sql = " DO UPDATE SET {updates}".format(
-                updates=",".join(
-                    "{field}={value}".format(
-                        field=field.get_sql(**kwargs),
-                        value=value.get_sql(with_namespace=True, **kwargs),
-                    )
-                    for field, value in self._on_conflict_do_updates
-                )
+                  updates=",".join(
+                        "{field}={value}".format(
+                              field=field.get_sql(**kwargs),
+                              value=value.get_sql(with_namespace=True, **kwargs),
+                        )
+                        for field, value in self._on_conflict_do_updates
+                  )
             )
 
             if self._on_conflict_do_update_wheres:
                 action_sql += " WHERE {where}".format(
-                    where=self._on_conflict_do_update_wheres.get_sql(subquery=True, with_namespace=True, **kwargs)
+                      where=self._on_conflict_do_update_wheres.get_sql(subquery=True, with_namespace=True, **kwargs)
                 )
             return action_sql
 
@@ -451,8 +451,8 @@ class PostgreQueryBuilder(QueryBuilder):
             if not any([self._insert_table, self._update_table, self._delete_from]):
                 raise QueryException("Returning can't be used in this query")
             if (
-                field.table not in {self._insert_table, self._update_table}
-                and term not in self._from
+                  field.table not in {self._insert_table, self._update_table}
+                  and term not in self._from
             ):
                 raise QueryException("You can't return from other tables")
 
@@ -495,16 +495,16 @@ class PostgreQueryBuilder(QueryBuilder):
 
     def _returning_sql(self, **kwargs):
         return " RETURNING {returning}".format(
-            returning=",".join(
-                term.get_sql(with_alias=True, **kwargs) for term in self._returns
-            ),
+              returning=",".join(
+                    term.get_sql(with_alias=True, **kwargs) for term in self._returns
+              ),
         )
 
     def get_sql(self, with_alias=False, subquery=False, **kwargs):
         self._set_kwargs_defaults(kwargs)
 
         querystring = super(PostgreQueryBuilder, self).get_sql(
-            with_alias, subquery, **kwargs
+              with_alias, subquery, **kwargs
         )
         with_namespace = False
         if self._update_table and self.from_:
@@ -559,7 +559,7 @@ class MSSQLQueryBuilder(QueryBuilder):
 
     def get_sql(self, *args, **kwargs):
         return super(MSSQLQueryBuilder, self).get_sql(
-            *args, groupby_alias=False, **kwargs
+              *args, groupby_alias=False, **kwargs
         )
 
     def _top_sql(self):
@@ -570,12 +570,12 @@ class MSSQLQueryBuilder(QueryBuilder):
 
     def _select_sql(self, **kwargs):
         return "SELECT {distinct}{top}{select}".format(
-            top=self._top_sql(),
-            distinct="DISTINCT " if self._distinct else "",
-            select=",".join(
-                term.get_sql(with_alias=True, subquery=True, **kwargs)
-                for term in self._selects
-            ),
+              top=self._top_sql(),
+              distinct="DISTINCT " if self._distinct else "",
+              select=",".join(
+                    term.get_sql(with_alias=True, subquery=True, **kwargs)
+                    for term in self._selects
+              ),
         )
 
 
@@ -593,12 +593,9 @@ class ClickHouseQuery(Query):
     """
     Defines a query class for use with Yandex ClickHouse.
     """
-
     @classmethod
     def _builder(cls, **kwargs):
-        return QueryBuilder(
-            dialect=Dialects.CLICKHOUSE, wrap_union_queries=False, **kwargs
-        )
+        return QueryBuilder(dialect=Dialects.CLICKHOUSE, wrap_union_queries=False, as_keyword=True, **kwargs)
 
 
 class SQLLiteValueWrapper(ValueWrapper):
@@ -616,5 +613,5 @@ class SQLLiteQuery(Query):
     @classmethod
     def _builder(cls, **kwargs):
         return QueryBuilder(
-            dialect=Dialects.SQLLITE, wrapper_cls=SQLLiteValueWrapper, **kwargs
+              dialect=Dialects.SQLLITE, wrapper_cls=SQLLiteValueWrapper, **kwargs
         )

--- a/pypika/queries.py
+++ b/pypika/queries.py
@@ -85,9 +85,9 @@ class Schema:
 
     def __eq__(self, other):
         return (
-            isinstance(other, Schema)
-            and self._name == other._name
-            and self._parent == other._parent
+              isinstance(other, Schema)
+              and self._name == other._name
+              and self._parent == other._parent
         )
 
     def __ne__(self, other):
@@ -103,8 +103,8 @@ class Schema:
 
         if self._parent is not None:
             return "{parent}.{schema}".format(
-                parent=self._parent.get_sql(quote_char=quote_char, **kwargs),
-                schema=schema_sql,
+                  parent=self._parent.get_sql(quote_char=quote_char, **kwargs),
+                  schema=schema_sql,
             )
 
         return schema_sql
@@ -125,7 +125,7 @@ class Table(Selectable):
             return schema
         if isinstance(schema, (list, tuple)):
             return reduce(
-                lambda obj, s: Schema(s, parent=obj), schema[1:], Schema(schema[0])
+                  lambda obj, s: Schema(s, parent=obj), schema[1:], Schema(schema[0])
             )
         if schema is not None:
             return Schema(schema)
@@ -149,7 +149,7 @@ class Table(Selectable):
 
         if self._schema is not None:
             table_sql = "{schema}.{table}".format(
-                schema=self._schema.get_sql(**kwargs), table=table_sql
+                  schema=self._schema.get_sql(**kwargs), table=table_sql
             )
 
         return format_alias_sql(table_sql, self.alias, **kwargs)
@@ -228,13 +228,13 @@ def make_tables(*names, **kwargs):
     for name in names:
         if isinstance(name, tuple) and len(name) == 2:
             t = Table(
-                name=name[0], alias=name[1], schema=kwargs.get("schema"),
-                query_cls=kwargs.get("query_cls"),
+                  name=name[0], alias=name[1], schema=kwargs.get("schema"),
+                  query_cls=kwargs.get("query_cls"),
             )
         else:
             t = Table(
-                name=name, schema=kwargs.get("schema"),
-                query_cls=kwargs.get("query_cls"),
+                  name=name, schema=kwargs.get("schema"),
+                  query_cls=kwargs.get("query_cls"),
             )
         tables.append(t)
     return tables
@@ -249,8 +249,8 @@ class Column:
         quote_char = kwargs.get("quote_char")
 
         column_sql = "{name}{type}".format(
-            name=format_quotes(self.name, quote_char),
-            type=" {}".format(self.type) if self.type else "",
+              name=format_quotes(self.name, quote_char),
+              type=" {}".format(self.type) if self.type else "",
         )
 
         return column_sql
@@ -406,7 +406,7 @@ class _UnionQuery(Selectable, Term):
     """
 
     def __init__(
-        self, base_query, union_query, union_type, alias=None, wrapper_cls=ValueWrapper
+          self, base_query, union_query, union_type, alias=None, wrapper_cls=ValueWrapper
     ):
         super(_UnionQuery, self).__init__(alias)
         self.base_query = base_query
@@ -463,25 +463,25 @@ class _UnionQuery(Selectable, Term):
         kwargs.setdefault("quote_char", self.base_query.QUOTE_CHAR)
 
         base_querystring = self.base_query.get_sql(
-            subquery=self.base_query.wrap_union_queries, **kwargs
+              subquery=self.base_query.wrap_union_queries, **kwargs
         )
 
         querystring = base_querystring
         for union_type, union_query in self._unions:
             union_querystring = union_query.get_sql(
-                subquery=self.base_query.wrap_union_queries, **kwargs
+                  subquery=self.base_query.wrap_union_queries, **kwargs
             )
 
             if len(self.base_query._selects) != len(union_query._selects):
                 raise UnionException(
-                    "Queries must have an equal number of select statements in a union."
-                    "\n\nMain Query:\n{query1}\n\nUnion Query:\n{query2}".format(
-                        query1=base_querystring, query2=union_querystring
-                    )
+                      "Queries must have an equal number of select statements in a union."
+                      "\n\nMain Query:\n{query1}\n\nUnion Query:\n{query2}".format(
+                            query1=base_querystring, query2=union_querystring
+                      )
                 )
 
             querystring += union_template.format(
-                type=union_type.value, union=union_querystring
+                  type=union_type.value, union=union_querystring
             )
 
         if self._orderbys:
@@ -498,7 +498,7 @@ class _UnionQuery(Selectable, Term):
 
         if with_alias:
             return format_alias_sql(
-                querystring, self.alias or self._table_name, **kwargs
+                  querystring, self.alias or self._table_name, **kwargs
             )
 
         return querystring
@@ -522,9 +522,9 @@ class _UnionQuery(Selectable, Term):
             )
 
             clauses.append(
-                "{term} {orient}".format(term=term, orient=directionality.value)
-                if directionality is not None
-                else term
+                  "{term} {orient}".format(term=term, orient=directionality.value)
+                  if directionality is not None
+                  else term
             )
 
         return " ORDER BY {orderby}".format(orderby=",".join(clauses))
@@ -547,11 +547,12 @@ class QueryBuilder(Selectable, Term):
     ALIAS_QUOTE_CHAR = None
 
     def __init__(
-        self,
-        dialect=None,
-        wrap_union_queries=True,
-        wrapper_cls=ValueWrapper,
-        immutable=True,
+          self,
+          dialect=None,
+          wrap_union_queries=True,
+          wrapper_cls=ValueWrapper,
+          immutable=True,
+          as_keyword=False,
     ):
         super(QueryBuilder, self).__init__(None)
 
@@ -592,6 +593,7 @@ class QueryBuilder(Selectable, Term):
         self._foreign_table = False
 
         self.dialect = dialect
+        self.as_keyword = as_keyword
         self.wrap_union_queries = wrap_union_queries
 
         self._wrapper_cls = wrapper_cls
@@ -630,12 +632,12 @@ class QueryBuilder(Selectable, Term):
         """
 
         self._from.append(
-            Table(selectable) if isinstance(selectable, str) else selectable
+              Table(selectable) if isinstance(selectable, str) else selectable
         )
 
         if (
-            isinstance(selectable, (QueryBuilder, _UnionQuery))
-            and selectable.alias is None
+              isinstance(selectable, (QueryBuilder, _UnionQuery))
+              and selectable.alias is None
         ):
             if isinstance(selectable, QueryBuilder):
                 sub_query_count = selectable._subquery_count
@@ -737,7 +739,7 @@ class QueryBuilder(Selectable, Term):
                 self._select_other(term)
             else:
                 self._select_other(
-                    self.wrap_constant(term, wrapper_cls=self._wrapper_cls)
+                      self.wrap_constant(term, wrapper_cls=self._wrapper_cls)
                 )
 
     @builder
@@ -865,8 +867,8 @@ class QueryBuilder(Selectable, Term):
             # MySQL rolls up all of the dimensions always
             if not terms and not self._groupbys:
                 raise RollupException(
-                    "At least one group is required. Call Query.groupby(term) or pass"
-                    "as parameter to rollup."
+                      "At least one group is required. Call Query.groupby(term) or pass"
+                      "as parameter to rollup."
                 )
 
             self._mysql_rollup = True
@@ -931,7 +933,7 @@ class QueryBuilder(Selectable, Term):
     @builder
     def union(self, other):
         return _UnionQuery(
-            self, other, UnionType.distinct, wrapper_cls=self._wrapper_cls
+              self, other, UnionType.distinct, wrapper_cls=self._wrapper_cls
         )
 
     @builder
@@ -968,7 +970,7 @@ class QueryBuilder(Selectable, Term):
     def _select_field_str(self, term):
         if 0 == len(self._from):
             raise QueryException(
-                "Cannot select {term}, no FROM table specified.".format(term=term)
+                  "Cannot select {term}, no FROM table specified.".format(term=term)
             )
 
         if term == "*":
@@ -1009,8 +1011,8 @@ class QueryBuilder(Selectable, Term):
         join.validate(base_tables, self._joins)
 
         table_in_query = any(
-            isinstance(clause, Table) and join.item in base_tables
-            for clause in base_tables
+              isinstance(clause, Table) and join.item in base_tables
+              for clause in base_tables
         )
         if isinstance(join.item, Table) and join.item.alias is None and table_in_query:
             # On the odd chance that we join the same table as the FROM table and don't set an alias
@@ -1033,12 +1035,12 @@ class QueryBuilder(Selectable, Term):
             table_in_base_tables = field.table in base_tables
             table_in_joins = field.table in [join.item for join in self._joins]
             if all(
-                [
-                    field.table is not None,
-                    not table_in_base_tables,
-                    not table_in_joins,
-                    field.table != self._update_table,
-                ]
+                  [
+                      field.table is not None,
+                      not table_in_base_tables,
+                      not table_in_joins,
+                      field.table != self._update_table,
+                  ]
             ):
                 return False
         return True
@@ -1057,10 +1059,10 @@ class QueryBuilder(Selectable, Term):
 
         for values in terms:
             self._values.append(
-                [
-                    value if isinstance(value, Term) else self.wrap_constant(value)
-                    for value in values
-                ]
+                  [
+                      value if isinstance(value, Term) else self.wrap_constant(value)
+                      for value in values
+                  ]
             )
 
     def __str__(self):
@@ -1088,16 +1090,17 @@ class QueryBuilder(Selectable, Term):
         kwargs.setdefault("quote_char", self.QUOTE_CHAR)
         kwargs.setdefault("secondary_quote_char", self.SECONDARY_QUOTE_CHAR)
         kwargs.setdefault("alias_quote_char", self.ALIAS_QUOTE_CHAR)
+        kwargs.setdefault("as_keyword", self.as_keyword)
         kwargs.setdefault("dialect", self.dialect)
 
     def get_sql(self, with_alias=False, subquery=False, **kwargs):
         self._set_kwargs_defaults(kwargs)
 
         if not (
-            self._selects
-            or self._insert_table
-            or self._delete_from
-            or self._update_table
+              self._selects
+              or self._insert_table
+              or self._delete_from
+              or self._update_table
         ):
             return ""
         if self._insert_table and not (self._selects or self._values):
@@ -1108,19 +1111,19 @@ class QueryBuilder(Selectable, Term):
         has_joins = bool(self._joins)
         has_multiple_from_clauses = 1 < len(self._from)
         has_subquery_from_clause = 0 < len(self._from) and isinstance(
-            self._from[0], QueryBuilder
+              self._from[0], QueryBuilder
         )
         has_reference_to_foreign_table = self._foreign_table
         has_update_from = self._update_table and self._from
 
         kwargs["with_namespace"] = any(
-            [
-                has_joins,
-                has_multiple_from_clauses,
-                has_subquery_from_clause,
-                has_reference_to_foreign_table,
-                has_update_from
-            ]
+              [
+                  has_joins,
+                  has_multiple_from_clauses,
+                  has_subquery_from_clause,
+                  has_reference_to_foreign_table,
+                  has_update_from
+              ]
         )
 
         if self._update_table:
@@ -1133,7 +1136,7 @@ class QueryBuilder(Selectable, Term):
 
             if self._joins:
                 querystring += " " + " ".join(
-                    join.get_sql(**kwargs) for join in self._joins
+                      join.get_sql(**kwargs) for join in self._joins
                 )
 
             querystring += self._set_sql(**kwargs)
@@ -1191,7 +1194,7 @@ class QueryBuilder(Selectable, Term):
 
         if self._joins:
             querystring += " " + " ".join(
-                join.get_sql(**kwargs) for join in self._joins
+                  join.get_sql(**kwargs) for join in self._joins
             )
 
         if self._prewheres:
@@ -1227,11 +1230,11 @@ class QueryBuilder(Selectable, Term):
 
     def _with_sql(self, **kwargs):
         return "WITH " + ",".join(
-            clause.name
-            + " AS ("
-            + clause.get_sql(subquery=False, with_alias=False, **kwargs)
-            + ") "
-            for clause in self._with
+              clause.name
+              + " AS ("
+              + clause.get_sql(subquery=False, with_alias=False, **kwargs)
+              + ") "
+              for clause in self._with
         )
 
     def _distinct_sql(self, **kwargs):
@@ -1244,22 +1247,22 @@ class QueryBuilder(Selectable, Term):
 
     def _select_sql(self, **kwargs):
         return "SELECT {distinct}{select}".format(
-            distinct=self._distinct_sql(**kwargs),
-            select=",".join(
-                term.get_sql(with_alias=True, subquery=True, **kwargs)
-                for term in self._selects
-            ),
+              distinct=self._distinct_sql(**kwargs),
+              select=",".join(
+                    term.get_sql(with_alias=True, subquery=True, **kwargs)
+                    for term in self._selects
+              ),
         )
 
     def _insert_sql(self, **kwargs):
         return "INSERT {ignore}INTO {table}".format(
-            table=self._insert_table.get_sql(**kwargs),
-            ignore="IGNORE " if self._ignore else "",
+              table=self._insert_table.get_sql(**kwargs),
+              ignore="IGNORE " if self._ignore else "",
         )
 
     def _replace_sql(self, **kwargs):
         return "REPLACE INTO {table}".format(
-            table=self._insert_table.get_sql(**kwargs),
+              table=self._insert_table.get_sql(**kwargs),
         )
 
     @staticmethod
@@ -1276,54 +1279,54 @@ class QueryBuilder(Selectable, Term):
             Remove from kwargs, never format the column terms with namespaces since only one table can be inserted into
         """
         return " ({columns})".format(
-            columns=",".join(
-                term.get_sql(with_namespace=False, **kwargs) for term in self._columns
-            )
+              columns=",".join(
+                    term.get_sql(with_namespace=False, **kwargs) for term in self._columns
+              )
         )
 
     def _values_sql(self, **kwargs):
         return " VALUES ({values})".format(
-            values="),(".join(
-                ",".join(
-                    term.get_sql(with_alias=True, subquery=True, **kwargs)
-                    for term in row
-                )
-                for row in self._values
-            )
+              values="),(".join(
+                    ",".join(
+                          term.get_sql(with_alias=True, subquery=True, **kwargs)
+                          for term in row
+                    )
+                    for row in self._values
+              )
         )
 
     def _into_sql(self, **kwargs):
         return " INTO {table}".format(
-            table=self._insert_table.get_sql(with_alias=False, **kwargs),
+              table=self._insert_table.get_sql(with_alias=False, **kwargs),
         )
 
     def _from_sql(self, with_namespace=False, **kwargs):
         return " FROM {selectable}".format(
-            selectable=",".join(
-                clause.get_sql(subquery=True, with_alias=True, **kwargs)
-                for clause in self._from
-            )
+              selectable=",".join(
+                    clause.get_sql(subquery=True, with_alias=True, **kwargs)
+                    for clause in self._from
+              )
         )
 
     def _force_index_sql(self, **kwargs):
         return " FORCE INDEX ({indexes})".format(
-            indexes=",".join(index.get_sql(**kwargs) for index in self._force_indexes),
+              indexes=",".join(index.get_sql(**kwargs) for index in self._force_indexes),
         )
 
     def _prewhere_sql(self, quote_char=None, **kwargs):
         return " PREWHERE {prewhere}".format(
-            prewhere=self._prewheres.get_sql(
-                quote_char=quote_char, subquery=True, **kwargs
-            )
+              prewhere=self._prewheres.get_sql(
+                    quote_char=quote_char, subquery=True, **kwargs
+              )
         )
 
     def _where_sql(self, quote_char=None, **kwargs):
         return " WHERE {where}".format(
-            where=self._wheres.get_sql(quote_char=quote_char, subquery=True, **kwargs)
+              where=self._wheres.get_sql(quote_char=quote_char, subquery=True, **kwargs)
         )
 
     def _group_sql(
-        self, quote_char=None, alias_quote_char=None, groupby_alias=True, **kwargs
+          self, quote_char=None, alias_quote_char=None, groupby_alias=True, **kwargs
     ):
         """
         Produces the GROUP BY part of the query.  This is a list of fields. The clauses are stored in the query under
@@ -1339,15 +1342,15 @@ class QueryBuilder(Selectable, Term):
         for field in self._groupbys:
             if groupby_alias and field.alias and field.alias in selected_aliases:
                 clauses.append(
-                    format_quotes(field.alias, alias_quote_char or quote_char)
+                      format_quotes(field.alias, alias_quote_char or quote_char)
                 )
             else:
                 clauses.append(
-                    field.get_sql(
-                        quote_char=quote_char,
-                        alias_quote_char=alias_quote_char,
-                        **kwargs
-                    )
+                      field.get_sql(
+                            quote_char=quote_char,
+                            alias_quote_char=alias_quote_char,
+                            **kwargs
+                      )
                 )
 
         sql = " GROUP BY {groupby}".format(groupby=",".join(clauses))
@@ -1358,7 +1361,7 @@ class QueryBuilder(Selectable, Term):
         return sql
 
     def _orderby_sql(
-        self, quote_char=None, alias_quote_char=None, orderby_alias=True, **kwargs
+          self, quote_char=None, alias_quote_char=None, orderby_alias=True, **kwargs
     ):
         """
         Produces the ORDER BY part of the query.  This is a list of fields and possibly their directionality, ASC or
@@ -1377,14 +1380,14 @@ class QueryBuilder(Selectable, Term):
                 format_quotes(field.alias, alias_quote_char or quote_char)
                 if orderby_alias and field.alias and field.alias in selected_aliases
                 else field.get_sql(
-                    quote_char=quote_char, alias_quote_char=alias_quote_char, **kwargs
+                      quote_char=quote_char, alias_quote_char=alias_quote_char, **kwargs
                 )
             )
 
             clauses.append(
-                "{term} {orient}".format(term=term, orient=directionality.value)
-                if directionality is not None
-                else term
+                  "{term} {orient}".format(term=term, orient=directionality.value)
+                  if directionality is not None
+                  else term
             )
 
         return " ORDER BY {orderby}".format(orderby=",".join(clauses))
@@ -1394,7 +1397,7 @@ class QueryBuilder(Selectable, Term):
 
     def _having_sql(self, quote_char=None, **kwargs):
         return " HAVING {having}".format(
-            having=self._havings.get_sql(quote_char=quote_char, **kwargs)
+              having=self._havings.get_sql(quote_char=quote_char, **kwargs)
         )
 
     def _offset_sql(self):
@@ -1405,12 +1408,12 @@ class QueryBuilder(Selectable, Term):
 
     def _set_sql(self, **kwargs):
         return " SET {set}".format(
-            set=",".join(
-                "{field}={value}".format(
-                    field=field.get_sql(**dict(kwargs, with_namespace=False)), value=value.get_sql(**kwargs)
-                )
-                for field, value in self._updates
-            )
+              set=",".join(
+                    "{field}={value}".format(
+                          field=field.get_sql(**dict(kwargs, with_namespace=False)), value=value.get_sql(**kwargs)
+                    )
+                    for field, value in self._updates
+              )
         )
 
 
@@ -1424,8 +1427,8 @@ class Joiner:
     def on(self, criterion, collate=None):
         if criterion is None:
             raise JoinException(
-                "Parameter 'criterion' is required for a "
-                "{type} JOIN but was not supplied.".format(type=self.type_label)
+                  "Parameter 'criterion' is required for a "
+                  "{type} JOIN but was not supplied.".format(type=self.type_label)
             )
 
         self.query.do_join(JoinOn(self.item, self.how, criterion, collate))
@@ -1434,14 +1437,14 @@ class Joiner:
     def on_field(self, *fields):
         if not fields:
             raise JoinException(
-                "Parameter 'fields' is required for a "
-                "{type} JOIN but was not supplied.".format(type=self.type_label)
+                  "Parameter 'fields' is required for a "
+                  "{type} JOIN but was not supplied.".format(type=self.type_label)
             )
 
         criterion = None
         for field in fields:
             consituent = Field(field, table=self.query._from[0]) == Field(
-                field, table=self.item
+                  field, table=self.item
             )
             criterion = consituent if criterion is None else criterion & consituent
 
@@ -1451,12 +1454,12 @@ class Joiner:
     def using(self, *fields):
         if not fields:
             raise JoinException(
-                "Parameter 'fields' is required when joining with "
-                "a using clause but was not supplied.".format(type=self.type_label)
+                  "Parameter 'fields' is required when joining with "
+                  "a using clause but was not supplied.".format(type=self.type_label)
             )
 
         self.query.do_join(
-            JoinUsing(self.item, self.how, [Field(field) for field in fields])
+              JoinUsing(self.item, self.how, [Field(field) for field in fields])
         )
         return self.query
 
@@ -1474,7 +1477,7 @@ class Join:
 
     def get_sql(self, **kwargs):
         sql = "JOIN {table}".format(
-            table=self.item.get_sql(subquery=True, with_alias=True, **kwargs),
+              table=self.item.get_sql(subquery=True, with_alias=True, **kwargs),
         )
 
         if self.how.value:
@@ -1509,9 +1512,9 @@ class JoinOn(Join):
     def get_sql(self, **kwargs):
         join_sql = super(JoinOn, self).get_sql(**kwargs)
         return "{join} ON {criterion}{collate}".format(
-            join=join_sql,
-            criterion=self.criterion.get_sql(subquery=True, **kwargs),
-            collate=" COLLATE {}".format(self.collate) if self.collate else "",
+              join=join_sql,
+              criterion=self.criterion.get_sql(subquery=True, **kwargs),
+              collate=" COLLATE {}".format(self.collate) if self.collate else "",
         )
 
     def validate(self, _from, _joins):
@@ -1520,10 +1523,10 @@ class JoinOn(Join):
         missing_tables = criterion_tables - available_tables
         if missing_tables:
             raise JoinException(
-                "Invalid join criterion. One field is required from the joined item and "
-                "another from the selected table or an existing join.  Found [{tables}]".format(
-                    tables=", ".join(map(str, missing_tables))
-                )
+                  "Invalid join criterion. One field is required from the joined item and "
+                  "another from the selected table or an existing join.  Found [{tables}]".format(
+                        tables=", ".join(map(str, missing_tables))
+                  )
             )
 
     @builder
@@ -1551,8 +1554,8 @@ class JoinUsing(Join):
     def get_sql(self, **kwargs):
         join_sql = super(JoinUsing, self).get_sql(**kwargs)
         return "{join} USING ({fields})".format(
-            join=join_sql,
-            fields=",".join(field.get_sql(**kwargs) for field in self.fields),
+              join=join_sql,
+              fields=",".join(field.get_sql(**kwargs) for field in self.fields),
         )
 
     def validate(self, _from, _joins):
@@ -1651,17 +1654,17 @@ class CreateQueryBuilder:
 
     def _create_table_sql(self, **kwargs):
         return "CREATE {temporary}TABLE {table}".format(
-            temporary="TEMPORARY " if self._temporary else "",
-            table=self._create_table.get_sql(**kwargs),
+              temporary="TEMPORARY " if self._temporary else "",
+              table=self._create_table.get_sql(**kwargs),
         )
 
     def _columns_sql(self, **kwargs):
         return " ({columns})".format(
-            columns=",".join(column.get_sql(**kwargs) for column in self._columns)
+              columns=",".join(column.get_sql(**kwargs) for column in self._columns)
         )
 
     def _as_select_sql(self, **kwargs):
-        return " AS ({query})".format(query=self._as_select.get_sql(**kwargs),)
+        return " AS ({query})".format(query=self._as_select.get_sql(**kwargs), )
 
     def __str__(self):
         return self.get_sql()

--- a/pypika/terms.py
+++ b/pypika/terms.py
@@ -163,13 +163,13 @@ class Term(Node):
 
     def between(self, lower, upper):
         return BetweenCriterion(
-            self, self.wrap_constant(lower), self.wrap_constant(upper)
+              self, self.wrap_constant(lower), self.wrap_constant(upper)
         )
 
     def isin(self, arg):
         if isinstance(arg, (list, tuple, set)):
             return ContainsCriterion(
-                self, Tuple(*[self.wrap_constant(value) for value in arg])
+                  self, Tuple(*[self.wrap_constant(value) for value in arg])
             )
         return ContainsCriterion(self, arg)
 
@@ -307,7 +307,7 @@ class ValueWrapper(Term):
 
     def get_sql(self, quote_char=None, secondary_quote_char="'", **kwargs):
         sql = self.get_value_sql(
-            quote_char=quote_char, secondary_quote_char=secondary_quote_char, **kwargs
+              quote_char=quote_char, secondary_quote_char=secondary_quote_char, **kwargs
         )
         return format_alias_sql(sql, self.alias, quote_char=quote_char, **kwargs)
 
@@ -331,8 +331,8 @@ class JSON(Term):
     def _get_dict_sql(self, value, **kwargs):
         pairs = [
             "{key}:{value}".format(
-                key=self._recursive_get_sql(k, **kwargs),
-                value=self._recursive_get_sql(v, **kwargs),
+                  key=self._recursive_get_sql(k, **kwargs),
+                  value=self._recursive_get_sql(v, **kwargs),
             )
             for k, v in value.items()
         ]
@@ -351,22 +351,22 @@ class JSON(Term):
 
     def get_json_value(self, key_or_index: Union[str, int]):
         return BasicCriterion(
-            JSONOperators.GET_JSON_VALUE, self, self.wrap_constant(key_or_index)
+              JSONOperators.GET_JSON_VALUE, self, self.wrap_constant(key_or_index)
         )
 
     def get_text_value(self, key_or_index: Union[str, int]):
         return BasicCriterion(
-            JSONOperators.GET_TEXT_VALUE, self, self.wrap_constant(key_or_index)
+              JSONOperators.GET_TEXT_VALUE, self, self.wrap_constant(key_or_index)
         )
 
     def get_path_json_value(self, path_json: str):
         return BasicCriterion(
-            JSONOperators.GET_PATH_JSON_VALUE, self, self.wrap_json(path_json)
+              JSONOperators.GET_PATH_JSON_VALUE, self, self.wrap_json(path_json)
         )
 
     def get_path_text_value(self, path_json: str):
         return BasicCriterion(
-            JSONOperators.GET_PATH_TEXT_VALUE, self, self.wrap_json(path_json)
+              JSONOperators.GET_PATH_TEXT_VALUE, self, self.wrap_json(path_json)
         )
 
     def has_key(self, other):
@@ -387,14 +387,14 @@ class JSON(Term):
 
 class Values(Term):
     def __init__(
-        self, field,
+          self, field,
     ):
         super().__init__(None)
         self.field = Field(field) if not isinstance(field, Field) else field
 
     def get_sql(self, quote_char=None, **kwargs):
         return "VALUES({value})".format(
-            value=self.field.get_sql(quote_char=quote_char, **kwargs)
+              value=self.field.get_sql(quote_char=quote_char, **kwargs)
         )
 
 
@@ -486,13 +486,13 @@ class Field(Criterion, JSON):
         if self.table and (with_namespace or self.table.alias):
             table_name = self.table.get_table_name()
             field_sql = "{namespace}.{name}".format(
-                namespace=format_quotes(table_name, quote_char), name=field_sql,
+                  namespace=format_quotes(table_name, quote_char), name=field_sql,
             )
 
         field_alias = getattr(self, "alias", None)
         if with_alias:
             return format_alias_sql(
-                field_sql, field_alias, quote_char=quote_char, **kwargs
+                  field_sql, field_alias, quote_char=quote_char, **kwargs
             )
 
         return field_sql
@@ -517,7 +517,7 @@ class Star(Field):
             yield from self.table.nodes_()
 
     def get_sql(
-        self, with_alias=False, with_namespace=False, quote_char=None, **kwargs
+          self, with_alias=False, with_namespace=False, quote_char=None, **kwargs
     ):
         if self.table and (with_namespace or self.table.alias):
             namespace = self.table.alias or getattr(self.table, "_table_name")
@@ -597,7 +597,7 @@ class NestedCriterion(Criterion):
     @property
     def is_aggregate(self):
         return resolve_is_aggregate(
-            [term.is_aggregate for term in [self.left, self.right, self.nested]]
+              [term.is_aggregate for term in [self.left, self.right, self.nested]]
         )
 
     @builder
@@ -618,11 +618,11 @@ class NestedCriterion(Criterion):
 
     def get_sql(self, with_alias=False, **kwargs):
         sql = "{left}{comparator}{right}{nested_comparator}{nested}".format(
-            left=self.left.get_sql(**kwargs),
-            comparator=self.comparator.value,
-            right=self.right.get_sql(**kwargs),
-            nested_comparator=self.nested_comparator.value,
-            nested=self.nested.get_sql(**kwargs),
+              left=self.left.get_sql(**kwargs),
+              comparator=self.comparator.value,
+              right=self.right.get_sql(**kwargs),
+              nested_comparator=self.nested_comparator.value,
+              nested=self.nested.get_sql(**kwargs),
         )
 
         if with_alias:
@@ -659,7 +659,7 @@ class BasicCriterion(Criterion):
     @property
     def is_aggregate(self):
         return resolve_is_aggregate(
-            [term.is_aggregate for term in [self.left, self.right]]
+              [term.is_aggregate for term in [self.left, self.right]]
         )
 
     @builder
@@ -679,13 +679,12 @@ class BasicCriterion(Criterion):
 
     def get_sql(self, quote_char='"', with_alias=False, **kwargs):
         sql = "{left}{comparator}{right}".format(
-            comparator=self.comparator.value,
-            left=self.left.get_sql(quote_char=quote_char, **kwargs),
-            right=self.right.get_sql(quote_char=quote_char, **kwargs),
+              comparator=self.comparator.value,
+              left=self.left.get_sql(quote_char=quote_char, **kwargs),
+              right=self.right.get_sql(quote_char=quote_char, **kwargs),
         )
-        if with_alias and self.alias:
-            return '{sql} "{alias}"'.format(sql=sql, alias=self.alias)
-
+        if with_alias:
+            return format_alias_sql(sql, self.alias, **kwargs)
         return sql
 
 
@@ -731,9 +730,9 @@ class ContainsCriterion(Criterion):
 
     def get_sql(self, subquery=None, **kwargs):
         sql = "{term} {not_}IN {container}".format(
-            term=self.term.get_sql(**kwargs),
-            container=self.container.get_sql(subquery=True, **kwargs),
-            not_="NOT " if self._is_negated else "",
+              term=self.term.get_sql(**kwargs),
+              container=self.container.get_sql(subquery=True, **kwargs),
+              not_="NOT " if self._is_negated else "",
         )
         return format_alias_sql(sql, self.alias, **kwargs)
 
@@ -776,9 +775,9 @@ class BetweenCriterion(Criterion):
     def get_sql(self, **kwargs):
         # FIXME escape
         sql = "{term} BETWEEN {start} AND {end}".format(
-            term=self.term.get_sql(**kwargs),
-            start=self.start.get_sql(**kwargs),
-            end=self.end.get_sql(**kwargs),
+              term=self.term.get_sql(**kwargs),
+              start=self.start.get_sql(**kwargs),
+              end=self.end.get_sql(**kwargs),
         )
         return format_alias_sql(sql, self.alias, **kwargs)
 
@@ -810,7 +809,7 @@ class BitwiseAndCriterion(Criterion):
 
     def get_sql(self, **kwargs):
         sql = "({term} & {value})".format(
-            term=self.term.get_sql(**kwargs), value=self.value,
+              term=self.term.get_sql(**kwargs), value=self.value,
         )
         return format_alias_sql(sql, self.alias, **kwargs)
 
@@ -839,20 +838,20 @@ class NullCriterion(Criterion):
         self.term = self.term.replace_table(current_table, new_table)
 
     def get_sql(self, with_alias=False, **kwargs):
-        sql = "{term} IS NULL".format(term=self.term.get_sql(**kwargs),)
+        sql = "{term} IS NULL".format(term=self.term.get_sql(**kwargs), )
         return format_alias_sql(sql, self.alias, **kwargs)
 
 
 class ComplexCriterion(BasicCriterion):
     def get_sql(self, subcriterion=False, **kwargs):
         sql = "{left} {comparator} {right}".format(
-            comparator=self.comparator.value,
-            left=self.left.get_sql(
-                subcriterion=self.needs_brackets(self.left), **kwargs
-            ),
-            right=self.right.get_sql(
-                subcriterion=self.needs_brackets(self.right), **kwargs
-            ),
+              comparator=self.comparator.value,
+              left=self.left.get_sql(
+                    subcriterion=self.needs_brackets(self.left), **kwargs
+              ),
+              right=self.right.get_sql(
+                    subcriterion=self.needs_brackets(self.right), **kwargs
+              ),
         )
 
         if subcriterion:
@@ -862,8 +861,8 @@ class ComplexCriterion(BasicCriterion):
 
     def needs_brackets(self, term):
         return (
-            isinstance(term, ComplexCriterion)
-            and not term.comparator == self.comparator
+              isinstance(term, ComplexCriterion)
+              and not term.comparator == self.comparator
         )
 
 
@@ -930,13 +929,13 @@ class ArithmeticExpression(Term):
         ]
 
         arithmetic_sql = "{left}{operator}{right}".format(
-            operator=self.operator.value,
-            left=("({})" if is_mul and is_left_add else "{}").format(
-                self.left.get_sql(**kwargs)
-            ),
-            right=("({})" if is_mul and is_right_add else "{}").format(
-                self.right.get_sql(**kwargs)
-            ),
+              operator=self.operator.value,
+              left=("({})" if is_mul and is_left_add else "{}").format(
+                    self.left.get_sql(**kwargs)
+              ),
+              right=("({})" if is_mul and is_right_add else "{}").format(
+                    self.right.get_sql(**kwargs)
+              ),
         )
 
         if with_alias:
@@ -965,8 +964,8 @@ class Case(Term):
     def is_aggregate(self):
         # True if all cases are True or None. None all cases are None. Otherwise, False
         return resolve_is_aggregate(
-            [term.is_aggregate for _, term in self._cases]
-            + [self._else.is_aggregate if self._else else None]
+              [term.is_aggregate for _, term in self._cases]
+              + [self._else.is_aggregate if self._else else None]
         )
 
     @builder
@@ -1004,14 +1003,14 @@ class Case(Term):
     def get_sql(self, with_alias=False, **kwargs):
         if not self._cases:
             raise CaseException(
-                "At least one 'when' case is required for a CASE statement."
+                  "At least one 'when' case is required for a CASE statement."
             )
 
         cases = " ".join(
-            "WHEN {when} THEN {then}".format(
-                when=criterion.get_sql(**kwargs), then=term.get_sql(**kwargs)
-            )
-            for criterion, term in self._cases
+              "WHEN {when} THEN {then}".format(
+                    when=criterion.get_sql(**kwargs), then=term.get_sql(**kwargs)
+              )
+              for criterion, term in self._cases
         )
         else_ = " ELSE {}".format(self._else.get_sql(**kwargs)) if self._else else ""
 
@@ -1082,11 +1081,11 @@ class CustomFunction:
 
         if not self._is_valid_function_call(*args):
             raise FunctionException(
-                "Function {name} require these arguments ({params}), ({args}) passed".format(
-                    name=self.name,
-                    params=", ".join(str(p) for p in self.params),
-                    args=", ".join(str(p) for p in args),
-                )
+                  "Function {name} require these arguments ({params}), ({args}) passed".format(
+                        name=self.name,
+                        params=", ".join(str(p) for p in self.params),
+                        args=", ".join(str(p) for p in args),
+                  )
             )
 
         return Function(self.name, *args, alias=kwargs.get("alias"))
@@ -1143,14 +1142,14 @@ class Function(Criterion):
         special_params_sql = self.get_special_params_sql(**kwargs)
 
         return "{name}({args}{special})".format(
-            name=self.name,
-            args=",".join(
-                p.get_sql(with_alias=True, **kwargs)
-                if hasattr(p, "get_sql")
-                else str(p)
-                for p in self.args
-            ),
-            special=(" " + special_params_sql) if special_params_sql else "",
+              name=self.name,
+              args=",".join(
+                    p.get_sql(with_alias=True, **kwargs)
+                    if hasattr(p, "get_sql")
+                    else str(p)
+                    for p in self.args
+              ),
+              special=(" " + special_params_sql) if special_params_sql else "",
         )
 
     def get_sql(self, **kwargs):
@@ -1161,20 +1160,20 @@ class Function(Criterion):
 
         # FIXME escape
         function_sql = self.get_function_sql(
-            with_namespace=with_namespace, quote_char=quote_char, dialect=dialect
+              with_namespace=with_namespace, quote_char=quote_char, dialect=dialect
         )
 
         if self.schema is not None:
             function_sql = "{schema}.{function}".format(
-                schema=self.schema.get_sql(
-                    quote_char=quote_char, dialect=dialect, **kwargs
-                ),
-                function=function_sql,
+                  schema=self.schema.get_sql(
+                        quote_char=quote_char, dialect=dialect, **kwargs
+                  ),
+                  function=function_sql,
             )
 
         if with_alias:
             return format_alias_sql(
-                function_sql, self.alias, quote_char=quote_char, **kwargs
+                  function_sql, self.alias, quote_char=quote_char, **kwargs
             )
 
         return function_sql
@@ -1215,35 +1214,35 @@ class AnalyticFunction(Function):
             return field.get_sql(**kwargs)
 
         return "{field} {orient}".format(
-            field=field.get_sql(**kwargs), orient=orient.value,
+              field=field.get_sql(**kwargs), orient=orient.value,
         )
 
     def get_filter_sql(self):
         if self._include_filter:
             return "WHERE {criterions}".format(
-                criterions=Criterion.all(self._filters).get_sql()
+                  criterions=Criterion.all(self._filters).get_sql()
             )
 
     def get_partition_sql(self, **kwargs):
         terms = []
         if self._partition:
             terms.append(
-                "PARTITION BY {args}".format(
-                    args=",".join(
-                        p.get_sql(**kwargs) if hasattr(p, "get_sql") else str(p)
-                        for p in self._partition
-                    )
-                )
+                  "PARTITION BY {args}".format(
+                        args=",".join(
+                              p.get_sql(**kwargs) if hasattr(p, "get_sql") else str(p)
+                              for p in self._partition
+                        )
+                  )
             )
 
         if self._orderbys:
             terms.append(
-                "ORDER BY {orderby}".format(
-                    orderby=",".join(
-                        self._orderby_field(field, orient, **kwargs)
-                        for field, orient in self._orderbys
-                    )
-                )
+                  "ORDER BY {orderby}".format(
+                        orderby=",".join(
+                              self._orderby_field(field, orient, **kwargs)
+                              for field, orient in self._orderbys
+                        )
+                  )
             )
 
         return " ".join(terms)
@@ -1269,7 +1268,7 @@ class WindowFrameAnalyticFunction(AnalyticFunction):
 
         def __str__(self):
             return "{value} {modifier}".format(
-                value=self.value or "UNBOUNDED", modifier=self.modifier,
+                  value=self.value or "UNBOUNDED", modifier=self.modifier,
             )
 
     def __init__(self, name, *args, **kwargs):
@@ -1298,12 +1297,12 @@ class WindowFrameAnalyticFunction(AnalyticFunction):
 
         lower, upper = self.bound
         return "{frame} BETWEEN {lower} AND {upper}".format(
-            frame=self.frame, lower=lower, upper=upper,
+              frame=self.frame, lower=lower, upper=upper,
         )
 
     def get_partition_sql(self, **kwargs):
         partition_sql = super(WindowFrameAnalyticFunction, self).get_partition_sql(
-            **kwargs
+              **kwargs
         )
 
         if not self.frame and not self.bound:
@@ -1347,17 +1346,17 @@ class Interval(Node):
     trim_pattern = re.compile(r"(^0+\.)|(\.0+$)|(^[0\-.: ]+[\-: ])|([\-:. ][0\-.: ]+$)")
 
     def __init__(
-        self,
-        years=0,
-        months=0,
-        days=0,
-        hours=0,
-        minutes=0,
-        seconds=0,
-        microseconds=0,
-        quarters=0,
-        weeks=0,
-        dialect=None,
+          self,
+          years=0,
+          months=0,
+          days=0,
+          hours=0,
+          minutes=0,
+          seconds=0,
+          microseconds=0,
+          quarters=0,
+          weeks=0,
+          dialect=None,
     ):
         self.dialect = dialect
         self.largest = None
@@ -1372,9 +1371,9 @@ class Interval(Node):
             return
 
         for unit, label, value in zip(
-            self.units,
-            self.labels,
-            [years, months, days, hours, minutes, seconds, microseconds],
+              self.units,
+              self.labels,
+              [years, months, days, hours, minutes, seconds, microseconds],
         ):
             if value:
                 setattr(self, unit, int(value))
@@ -1402,19 +1401,19 @@ class Interval(Node):
         else:
             # Create the whole expression but trim out the unnecessary fields
             expr = "{years}-{months}-{days} {hours}:{minutes}:{seconds}.{microseconds}".format(
-                years=getattr(self, "years", 0),
-                months=getattr(self, "months", 0),
-                days=getattr(self, "days", 0),
-                hours=getattr(self, "hours", 0),
-                minutes=getattr(self, "minutes", 0),
-                seconds=getattr(self, "seconds", 0),
-                microseconds=getattr(self, "microseconds", 0),
+                  years=getattr(self, "years", 0),
+                  months=getattr(self, "months", 0),
+                  days=getattr(self, "days", 0),
+                  hours=getattr(self, "hours", 0),
+                  minutes=getattr(self, "minutes", 0),
+                  seconds=getattr(self, "seconds", 0),
+                  microseconds=getattr(self, "microseconds", 0),
             )
             expr = self.trim_pattern.sub("", expr)
 
             unit = (
                 "{largest}_{smallest}".format(
-                    largest=self.largest, smallest=self.smallest,
+                      largest=self.largest, smallest=self.smallest,
                 )
                 if self.largest != self.smallest
                 else self.largest
@@ -1425,7 +1424,7 @@ class Interval(Node):
                 unit = "DAY"
 
         return self.templates.get(dialect, "INTERVAL '{expr} {unit}'").format(
-            expr=expr, unit=unit
+              expr=expr, unit=unit
         )
 
 

--- a/pypika/tests/clickhouse/test_array.py
+++ b/pypika/tests/clickhouse/test_array.py
@@ -3,27 +3,36 @@ import unittest
 from parameterized import parameterized
 
 from pypika import Field
-from pypika.clickhouse.array import HasAny, Array, Length, Empty, NotEmpty
-from pypika.clickhouse.type_conversion import ToInt64, ToFixedString
+from pypika.clickhouse.array import (
+    Array,
+    Empty,
+    HasAny,
+    Length,
+    NotEmpty,
+)
+from pypika.clickhouse.type_conversion import (
+    ToFixedString,
+    ToInt64,
+)
 
 
 class TestArray(unittest.TestCase):
     @parameterized.expand(
-        [
-            (
-                "['ridley', 'scott', 'jimi', 'hendrix']",
-                Array(["ridley", "scott", "jimi", "hendrix"]),
-            ),
-            ("[1, 2, 3, 4]", Array([1, 2, 3, 4]),),
-            (
-                "[toInt64('1'),toInt64('2'),toInt64('3'),toInt64('4')]",
-                Array(["1", "2", "3", "4"], ToInt64),
-            ),
-            (
-                "[toFixedString('mogwai',10),toFixedString('mono',10),toFixedString('bonobo',10)]",
-                Array(["mogwai", "mono", "bonobo"], ToFixedString, {"length": 10}),
-            ),
-        ]
+          [
+              (
+                    "['ridley', 'scott', 'jimi', 'hendrix']",
+                    Array(["ridley", "scott", "jimi", "hendrix"]),
+              ),
+              ("[1, 2, 3, 4]", Array([1, 2, 3, 4]),),
+              (
+                    "[toInt64('1'),toInt64('2'),toInt64('3'),toInt64('4')]",
+                    Array(["1", "2", "3", "4"], ToInt64),
+              ),
+              (
+                    "[toFixedString('mogwai',10),toFixedString('mono',10),toFixedString('bonobo',10)] arr",
+                    Array(["mogwai", "mono", "bonobo"], ToFixedString, {"length": 10}).as_('arr'),
+              ),
+          ]
     )
     def test_get_sql(self, expected: str, array: Array):
         self.assertEqual(expected, array.get_sql())
@@ -31,20 +40,20 @@ class TestArray(unittest.TestCase):
 
 class TestHasAny(unittest.TestCase):
     @parameterized.expand(
-        [
-            (
-                'hasAny("mental_abilities","physical_abilities")',
-                HasAny(Field("mental_abilities"), Field("physical_abilities")),
-            ),
-            ("hasAny([1, 2, 3, 4],[3])", HasAny(Array([1, 2, 3, 4]), Array([3]))),
-            (
-                "hasAny(\"bands\",[toFixedString('port-royal',20),toFixedString('hammock',20)])",
-                HasAny(
-                    Field("bands"),
-                    Array(["port-royal", "hammock"], ToFixedString, {"length": 20}),
-                ),
-            ),
-        ]
+          [
+              (
+                    'hasAny("mental_abilities","physical_abilities")',
+                    HasAny(Field("mental_abilities"), Field("physical_abilities")),
+              ),
+              ("hasAny([1, 2, 3, 4],[3])", HasAny(Array([1, 2, 3, 4]), Array([3]))),
+              (
+                    "hasAny(\"bands\",[toFixedString('port-royal',20),toFixedString('hammock',20)])",
+                    HasAny(
+                          Field("bands"),
+                          Array(["port-royal", "hammock"], ToFixedString, {"length": 20}),
+                    ),
+              ),
+          ]
     )
     def test_get_sql(self, expected: str, func: HasAny):
         self.assertEqual(expected, func.get_sql())
@@ -52,10 +61,10 @@ class TestHasAny(unittest.TestCase):
 
 class TestLength(unittest.TestCase):
     @parameterized.expand(
-        [
-            ('length("tags")', Length(Field("tags")),),
-            ("length([1, 2, 3])", Length(Array([1, 2, 3]))),
-        ]
+          [
+              ('length("tags")', Length(Field("tags")),),
+              ("length([1, 2, 3])", Length(Array([1, 2, 3]))),
+          ]
     )
     def test_get_sql(self, expected: str, func: Length):
         self.assertEqual(expected, func.get_sql())
@@ -63,10 +72,10 @@ class TestLength(unittest.TestCase):
 
 class TestEmpty(unittest.TestCase):
     @parameterized.expand(
-        [
-            ('empty("tags")', Empty(Field("tags")),),
-            ("empty([1, 2, 3])", Empty(Array([1, 2, 3]))),
-        ]
+          [
+              ('empty("tags")', Empty(Field("tags")),),
+              ("empty([1, 2, 3])", Empty(Array([1, 2, 3]))),
+          ]
     )
     def test_get_sql(self, expected: str, func: Empty):
         self.assertEqual(expected, func.get_sql())
@@ -74,10 +83,10 @@ class TestEmpty(unittest.TestCase):
 
 class TestNotEmpty(unittest.TestCase):
     @parameterized.expand(
-        [
-            ('notEmpty("tags")', NotEmpty(Field("tags")),),
-            ("notEmpty([1, 2, 3])", NotEmpty(Array([1, 2, 3]))),
-        ]
+          [
+              ('notEmpty("tags")', NotEmpty(Field("tags")),),
+              ("notEmpty([1, 2, 3])", NotEmpty(Array([1, 2, 3]))),
+          ]
     )
     def test_get_sql(self, expected: str, func: NotEmpty):
         self.assertEqual(expected, func.get_sql())

--- a/pypika/tests/dialects/test_clickhouse.py
+++ b/pypika/tests/dialects/test_clickhouse.py
@@ -1,0 +1,13 @@
+from unittest import TestCase
+
+from pypika import (
+    ClickHouseQuery,
+    Table,
+)
+
+
+class ClickHouseQueryTests(TestCase):
+    def test_use_AS_keyword_for_alias(self):
+        t = Table('abc')
+        query = ClickHouseQuery.from_(t).select(t.foo.as_('f1'), t.bar.as_('f2'))
+        self.assertEqual(str(query), 'SELECT "foo" AS "f1","bar" AS "f2" FROM "abc"')

--- a/pypika/tests/dialects/test_mssql.py
+++ b/pypika/tests/dialects/test_mssql.py
@@ -1,6 +1,5 @@
 import unittest
 
-from pypika import Table
 from pypika.dialects import MSSQLQuery
 from pypika.utils import QueryException
 

--- a/pypika/tests/test_criterions.py
+++ b/pypika/tests/test_criterions.py
@@ -25,7 +25,7 @@ class CriterionTests(unittest.TestCase):
 
         self.assertEqual('"foo"="bar"', str(c1))
         self.assertEqual(
-            '"foo"="bar" "criterion"', c1.get_sql(with_alias=True, quote_char='"')
+            '"foo"="bar" "criterion"', c1.get_sql(with_alias=True, quote_char='"', alias_quote_char='"')
         )
 
     def test__criterion_eq_number(self):

--- a/pypika/tests/test_selects.py
+++ b/pypika/tests/test_selects.py
@@ -97,7 +97,7 @@ class SelectTests(unittest.TestCase):
 
     def test_select__column__single__table_alias__str(self):
         q = Query.from_(self.table_abc.as_("fizzbuzz")).select(
-            self.table_abc.foo.as_("bar")
+              self.table_abc.foo.as_("bar")
         )
 
         self.assertEqual('SELECT "foo" "bar" FROM "abc" "fizzbuzz"', str(q))
@@ -119,8 +119,8 @@ class SelectTests(unittest.TestCase):
         q1 = Query.from_(self.table_abc).select(self.table_abc.foo, self.table_abc.bar)
         q2 = (
             Query.from_(self.table_abc)
-            .select(self.table_abc.foo)
-            .select(self.table_abc.bar)
+                .select(self.table_abc.foo)
+                .select(self.table_abc.bar)
         )
 
         self.assertEqual('SELECT "foo","bar" FROM "abc"', str(q1))
@@ -129,9 +129,9 @@ class SelectTests(unittest.TestCase):
     def test_select__multiple_tables(self):
         q = (
             Query.from_(self.table_abc)
-            .select(self.table_abc.foo)
-            .from_(self.table_efg)
-            .select(self.table_efg.bar)
+                .select(self.table_abc.foo)
+                .from_(self.table_efg)
+                .select(self.table_efg.bar)
         )
 
         self.assertEqual('SELECT "abc"."foo","efg"."bar" FROM "abc","efg"', str(q))
@@ -141,7 +141,7 @@ class SelectTests(unittest.TestCase):
         q = Query.from_(subquery).select(subquery.foo, subquery.bar)
 
         self.assertEqual(
-            'SELECT "sq0"."foo","sq0"."bar" ' 'FROM (SELECT * FROM "abc") "sq0"', str(q)
+              'SELECT "sq0"."foo","sq0"."bar" ' 'FROM (SELECT * FROM "abc") "sq0"', str(q)
         )
 
     def test_select__multiple_subqueries(self):
@@ -150,10 +150,10 @@ class SelectTests(unittest.TestCase):
         q = Query.from_(subquery0).from_(subquery1).select(subquery0.foo, subquery1.bar)
 
         self.assertEqual(
-            'SELECT "sq0"."foo","sq1"."bar" '
-            'FROM (SELECT "foo" FROM "abc") "sq0",'
-            '(SELECT "bar" FROM "efg") "sq1"',
-            str(q),
+              'SELECT "sq0"."foo","sq1"."bar" '
+              'FROM (SELECT "foo" FROM "abc") "sq0",'
+              '(SELECT "bar" FROM "efg") "sq1"',
+              str(q),
         )
 
     def test_select__nested_subquery(self):
@@ -164,11 +164,11 @@ class SelectTests(unittest.TestCase):
         q = Query.from_(subquery2).select(subquery2.foo)
 
         self.assertEqual(
-            'SELECT "sq2"."foo" '
-            'FROM (SELECT "sq1"."foo" '
-            'FROM (SELECT "sq0"."foo","sq0"."bar" '
-            'FROM (SELECT * FROM "abc") "sq0") "sq1") "sq2"',
-            str(q),
+              'SELECT "sq2"."foo" '
+              'FROM (SELECT "sq1"."foo" '
+              'FROM (SELECT "sq0"."foo","sq0"."bar" '
+              'FROM (SELECT * FROM "abc") "sq0") "sq1") "sq2"',
+              str(q),
         )
 
     def test_select__no_table(self):
@@ -223,7 +223,7 @@ class SelectTests(unittest.TestCase):
         self.assertEqual('SELECT "foo" FROM "abc" FORCE INDEX ("egg","bacon")', str(q))
 
     def test_select_with_force_index_multiple_calls(self):
-        q = Query.from_("abc").select("foo").force_index("egg",).force_index("spam")
+        q = Query.from_("abc").select("foo").force_index("egg", ).force_index("spam")
 
         self.assertEqual('SELECT "foo" FROM "abc" FORCE INDEX ("egg","spam")', str(q))
 
@@ -265,11 +265,11 @@ class SelectTests(unittest.TestCase):
 
     def test_table_select_alias_with_offset_and_limit(self):
         self.assertEqual(
-            self.table_abc.select("foo")[10:10], Query.from_("abc").select("foo")[10:10]
+              self.table_abc.select("foo")[10:10], Query.from_("abc").select("foo")[10:10]
         )
         self.assertEqual(
-            self.table_abc.select(self.table_abc.foo)[10:10],
-            Query.from_("abc").select("foo")[10:10],
+              self.table_abc.select(self.table_abc.foo)[10:10],
+              Query.from_("abc").select("foo")[10:10],
         )
 
 
@@ -288,9 +288,9 @@ class WhereTests(unittest.TestCase):
     def test_where_field_equals_where(self):
         q = (
             Query.from_(self.t)
-            .select("*")
-            .where(self.t.foo == 1)
-            .where(self.t.bar == self.t.baz)
+                .select("*")
+                .where(self.t.foo == 1)
+                .where(self.t.bar == self.t.baz)
         )
 
         self.assertEqual('SELECT * FROM "abc" WHERE "foo"=1 AND "bar"="baz"', str(q))
@@ -298,25 +298,25 @@ class WhereTests(unittest.TestCase):
     def test_where_field_equals_where_not(self):
         q = (
             Query.from_(self.t)
-            .select("*")
-            .where((self.t.foo == 1).negate())
-            .where(self.t.bar == self.t.baz)
+                .select("*")
+                .where((self.t.foo == 1).negate())
+                .where(self.t.bar == self.t.baz)
         )
 
         self.assertEqual(
-            'SELECT * FROM "abc" WHERE NOT "foo"=1 AND "bar"="baz"', str(q)
+              'SELECT * FROM "abc" WHERE NOT "foo"=1 AND "bar"="baz"', str(q)
         )
 
     def test_where_field_equals_where_two_not(self):
         q = (
             Query.from_(self.t)
-            .select("*")
-            .where((self.t.foo == 1).negate())
-            .where((self.t.bar == self.t.baz).negate())
+                .select("*")
+                .where((self.t.foo == 1).negate())
+                .where((self.t.bar == self.t.baz).negate())
         )
 
         self.assertEqual(
-            'SELECT * FROM "abc" WHERE NOT "foo"=1 AND NOT "bar"="baz"', str(q)
+              'SELECT * FROM "abc" WHERE NOT "foo"=1 AND NOT "bar"="baz"', str(q)
         )
 
     def test_where_single_quote(self):
@@ -327,8 +327,8 @@ class WhereTests(unittest.TestCase):
     def test_where_field_equals_and(self):
         q = (
             Query.from_(self.t)
-            .select("*")
-            .where((self.t.foo == 1) & (self.t.bar == self.t.baz))
+                .select("*")
+                .where((self.t.foo == 1) & (self.t.bar == self.t.baz))
         )
 
         self.assertEqual('SELECT * FROM "abc" WHERE "foo"=1 AND "bar"="baz"', str(q))
@@ -336,8 +336,8 @@ class WhereTests(unittest.TestCase):
     def test_where_field_equals_or(self):
         q = (
             Query.from_(self.t)
-            .select("*")
-            .where((self.t.foo == 1) | (self.t.bar == self.t.baz))
+                .select("*")
+                .where((self.t.foo == 1) | (self.t.bar == self.t.baz))
         )
 
         self.assertEqual('SELECT * FROM "abc" WHERE "foo"=1 OR "bar"="baz"', str(q))
@@ -345,13 +345,13 @@ class WhereTests(unittest.TestCase):
     def test_where_nested_conditions(self):
         q = (
             Query.from_(self.t)
-            .select("*")
-            .where((self.t.foo == 1) | (self.t.bar == self.t.baz))
-            .where(self.t.baz == 0)
+                .select("*")
+                .where((self.t.foo == 1) | (self.t.bar == self.t.baz))
+                .where(self.t.baz == 0)
         )
 
         self.assertEqual(
-            'SELECT * FROM "abc" WHERE ("foo"=1 OR "bar"="baz") AND "baz"=0', str(q)
+              'SELECT * FROM "abc" WHERE ("foo"=1 OR "bar"="baz") AND "baz"=0', str(q)
         )
 
     def test_where_field_starts_with(self):
@@ -407,13 +407,13 @@ class WhereTests(unittest.TestCase):
     def test_select_with_force_index_and_where(self):
         q = (
             Query.from_("abc")
-            .select("foo")
-            .where(self.t.foo == self.t.bar)
-            .force_index("egg")
+                .select("foo")
+                .where(self.t.foo == self.t.bar)
+                .force_index("egg")
         )
 
         self.assertEqual(
-            'SELECT "foo" FROM "abc" FORCE INDEX ("egg") WHERE "foo"="bar"', str(q)
+              'SELECT "foo" FROM "abc" FORCE INDEX ("egg") WHERE "foo"="bar"', str(q)
         )
 
 
@@ -430,13 +430,13 @@ class PreWhereTests(WhereTests):
     def test_where_and_prewhere(self):
         q = (
             Query.from_(self.t)
-            .select("*")
-            .prewhere(self.t.foo == self.t.bar)
-            .where(self.t.foo == self.t.bar)
+                .select("*")
+                .prewhere(self.t.foo == self.t.bar)
+                .where(self.t.foo == self.t.bar)
         )
 
         self.assertEqual(
-            'SELECT * FROM "abc" PREWHERE "foo"="bar" WHERE "foo"="bar"', str(q)
+              'SELECT * FROM "abc" PREWHERE "foo"="bar" WHERE "foo"="bar"', str(q)
         )
 
 
@@ -452,8 +452,8 @@ class GroupByTests(unittest.TestCase):
     def test_groupby__multi(self):
         q = (
             Query.from_(self.t)
-            .groupby(self.t.foo, self.t.bar)
-            .select(self.t.foo, self.t.bar)
+                .groupby(self.t.foo, self.t.bar)
+                .select(self.t.foo, self.t.bar)
         )
 
         self.assertEqual('SELECT "foo","bar" FROM "abc" GROUP BY "foo","bar"', str(q))
@@ -466,8 +466,8 @@ class GroupByTests(unittest.TestCase):
     def test_groupby__count_field(self):
         q = (
             Query.from_(self.t)
-            .groupby(self.t.foo)
-            .select(self.t.foo, fn.Count(self.t.bar))
+                .groupby(self.t.foo)
+                .select(self.t.foo, fn.Count(self.t.bar))
         )
 
         self.assertEqual('SELECT "foo",COUNT("bar") FROM "abc" GROUP BY "foo"', str(q))
@@ -475,30 +475,30 @@ class GroupByTests(unittest.TestCase):
     def test_groupby__count_distinct(self):
         q = (
             Query.from_(self.t)
-            .groupby(self.t.foo)
-            .select(self.t.foo, fn.Count("*").distinct())
+                .groupby(self.t.foo)
+                .select(self.t.foo, fn.Count("*").distinct())
         )
 
         self.assertEqual(
-            'SELECT "foo",COUNT(DISTINCT *) FROM "abc" GROUP BY "foo"', str(q)
+              'SELECT "foo",COUNT(DISTINCT *) FROM "abc" GROUP BY "foo"', str(q)
         )
 
     def test_groupby__sum_distinct(self):
         q = (
             Query.from_(self.t)
-            .groupby(self.t.foo)
-            .select(self.t.foo, fn.Sum(self.t.bar).distinct())
+                .groupby(self.t.foo)
+                .select(self.t.foo, fn.Sum(self.t.bar).distinct())
         )
 
         self.assertEqual(
-            'SELECT "foo",SUM(DISTINCT "bar") FROM "abc" GROUP BY "foo"', str(q)
+              'SELECT "foo",SUM(DISTINCT "bar") FROM "abc" GROUP BY "foo"', str(q)
         )
 
     def test_groupby__str(self):
         q = Query.from_("abc").groupby("foo").select("foo", fn.Count("*").distinct())
 
         self.assertEqual(
-            'SELECT "foo",COUNT(DISTINCT *) FROM "abc" GROUP BY "foo"', str(q)
+              'SELECT "foo",COUNT(DISTINCT *) FROM "abc" GROUP BY "foo"', str(q)
         )
 
     def test_groupby__int(self):
@@ -511,7 +511,7 @@ class GroupByTests(unittest.TestCase):
         q = Query.from_(self.t).select(fn.Sum(self.t.foo), bar).groupby(bar)
 
         self.assertEqual(
-            'SELECT SUM("foo"),"bar" "bar01" FROM "abc" GROUP BY "bar01"', str(q)
+              'SELECT SUM("foo"),"bar" "bar01" FROM "abc" GROUP BY "bar01"', str(q)
         )
 
     def test_groupby__no_alias(self):
@@ -519,8 +519,8 @@ class GroupByTests(unittest.TestCase):
         q = Query.from_(self.t).select(fn.Sum(self.t.foo), bar).groupby(bar)
 
         self.assertEqual(
-            'SELECT SUM("foo"),"bar" "bar01" FROM "abc" GROUP BY "bar"',
-            q.get_sql(groupby_alias=False),
+              'SELECT SUM("foo"),"bar" "bar01" FROM "abc" GROUP BY "bar"',
+              q.get_sql(groupby_alias=False),
         )
 
     def test_groupby__no_alias_platforms(self):
@@ -529,7 +529,7 @@ class GroupByTests(unittest.TestCase):
             q = query_cls.from_(self.t).select(fn.Sum(self.t.foo), bar).groupby(bar)
 
             self.assertEqual(
-                'SELECT SUM("foo"),"bar" "bar01" FROM "abc" GROUP BY "bar"', str(q)
+                  'SELECT SUM("foo"),"bar" "bar01" FROM "abc" GROUP BY "bar"', str(q)
             )
 
     def test_groupby__alias_platforms(self):
@@ -552,11 +552,16 @@ class GroupByTests(unittest.TestCase):
             )
 
             self.assertEqual(
-                "SELECT SUM({quote_char}foo{quote_char}),{quote_char}bar{quote_char} "
-                "{quote_char}bar01{quote_char} "
-                "FROM {quote_char}abc{quote_char} "
-                "GROUP BY {quote_char}bar01{quote_char}".format(quote_char=quote_char),
-                str(q),
+                  "SELECT "
+                  "SUM({quote_char}foo{quote_char}),"
+                  "{quote_char}bar{quote_char}{as_keyword}{quote_char}bar01{quote_char} "
+                  "FROM {quote_char}abc{quote_char} "
+                  "GROUP BY {quote_char}bar01{quote_char}"
+                      .format(
+                        as_keyword=' AS ' if query_cls is ClickHouseQuery else ' ',
+                        quote_char=quote_char
+                  ),
+                  str(q),
             )
 
     def test_groupby__alias_with_join(self):
@@ -564,44 +569,44 @@ class GroupByTests(unittest.TestCase):
         bar = table1.bar.as_("bar01")
         q = (
             Query.from_(self.t)
-            .join(table1)
-            .on(self.t.id == table1.t_ref)
-            .select(fn.Sum(self.t.foo), bar)
-            .groupby(bar)
+                .join(table1)
+                .on(self.t.id == table1.t_ref)
+                .select(fn.Sum(self.t.foo), bar)
+                .groupby(bar)
         )
 
         self.assertEqual(
-            'SELECT SUM("abc"."foo"),"t1"."bar" "bar01" FROM "abc" '
-            'JOIN "table1" "t1" ON "abc"."id"="t1"."t_ref" '
-            'GROUP BY "bar01"',
-            str(q),
+              'SELECT SUM("abc"."foo"),"t1"."bar" "bar01" FROM "abc" '
+              'JOIN "table1" "t1" ON "abc"."id"="t1"."t_ref" '
+              'GROUP BY "bar01"',
+              str(q),
         )
 
     def test_groupby_with_case_uses_the_alias(self):
         q = (
             Query.from_(self.t)
-            .select(
-                fn.Sum(self.t.foo).as_("bar"),
-                Case()
-                .when(self.t.fname == "Tom", "It was Tom")
-                .else_("It was someone else.")
-                .as_("who_was_it"),
+                .select(
+                  fn.Sum(self.t.foo).as_("bar"),
+                  Case()
+                      .when(self.t.fname == "Tom", "It was Tom")
+                      .else_("It was someone else.")
+                      .as_("who_was_it"),
             )
-            .groupby(
-                Case()
-                .when(self.t.fname == "Tom", "It was Tom")
-                .else_("It was someone else.")
-                .as_("who_was_it")
+                .groupby(
+                  Case()
+                      .when(self.t.fname == "Tom", "It was Tom")
+                      .else_("It was someone else.")
+                      .as_("who_was_it")
             )
         )
 
         self.assertEqual(
-            'SELECT SUM("foo") "bar",'
-            "CASE WHEN \"fname\"='Tom' THEN 'It was Tom' "
-            "ELSE 'It was someone else.' END \"who_was_it\" "
-            'FROM "abc" '
-            'GROUP BY "who_was_it"',
-            str(q),
+              'SELECT SUM("foo") "bar",'
+              "CASE WHEN \"fname\"='Tom' THEN 'It was Tom' "
+              "ELSE 'It was someone else.' END \"who_was_it\" "
+              'FROM "abc" '
+              'GROUP BY "who_was_it"',
+              str(q),
         )
 
     def test_mysql_query_uses_backtick_quote_chars(self):
@@ -642,13 +647,13 @@ class GroupByTests(unittest.TestCase):
     def test_groupby__multi_with_totals(self):
         q = (
             Query.from_(self.t)
-            .groupby(self.t.foo, self.t.bar)
-            .select(self.t.foo, self.t.bar)
-            .with_totals()
+                .groupby(self.t.foo, self.t.bar)
+                .select(self.t.foo, self.t.bar)
+                .with_totals()
         )
 
         self.assertEqual(
-            'SELECT "foo","bar" FROM "abc" GROUP BY "foo","bar" WITH TOTALS', str(q)
+              'SELECT "foo","bar" FROM "abc" GROUP BY "foo","bar" WITH TOTALS', str(q)
         )
 
 
@@ -658,114 +663,114 @@ class HavingTests(unittest.TestCase):
     def test_having_greater_than(self):
         q = (
             Query.from_(self.table_abc)
-            .select(self.table_abc.foo, fn.Sum(self.table_abc.bar))
-            .groupby(self.table_abc.foo)
-            .having(fn.Sum(self.table_abc.bar) > 1)
+                .select(self.table_abc.foo, fn.Sum(self.table_abc.bar))
+                .groupby(self.table_abc.foo)
+                .having(fn.Sum(self.table_abc.bar) > 1)
         )
 
         self.assertEqual(
-            'SELECT "foo",SUM("bar") FROM "abc" GROUP BY "foo" HAVING SUM("bar")>1',
-            str(q),
+              'SELECT "foo",SUM("bar") FROM "abc" GROUP BY "foo" HAVING SUM("bar")>1',
+              str(q),
         )
 
     def test_having_and(self):
         q = (
             Query.from_(self.table_abc)
-            .select(self.table_abc.foo, fn.Sum(self.table_abc.bar))
-            .groupby(self.table_abc.foo)
-            .having(
-                (fn.Sum(self.table_abc.bar) > 1) & (fn.Sum(self.table_abc.bar) < 100)
+                .select(self.table_abc.foo, fn.Sum(self.table_abc.bar))
+                .groupby(self.table_abc.foo)
+                .having(
+                  (fn.Sum(self.table_abc.bar) > 1) & (fn.Sum(self.table_abc.bar) < 100)
             )
         )
 
         self.assertEqual(
-            'SELECT "foo",SUM("bar") FROM "abc" GROUP BY "foo" HAVING SUM("bar")>1 AND SUM("bar")<100',
-            str(q),
+              'SELECT "foo",SUM("bar") FROM "abc" GROUP BY "foo" HAVING SUM("bar")>1 AND SUM("bar")<100',
+              str(q),
         )
 
     def test_having_join_and_equality(self):
         q = (
             Query.from_(self.table_abc)
-            .join(self.table_efg)
-            .on(self.table_abc.foo == self.table_efg.foo)
-            .select(self.table_abc.foo, fn.Sum(self.table_efg.bar), self.table_abc.buz)
-            .groupby(self.table_abc.foo)
-            .having(self.table_abc.buz == "fiz")
-            .having(fn.Sum(self.table_efg.bar) > 100)
+                .join(self.table_efg)
+                .on(self.table_abc.foo == self.table_efg.foo)
+                .select(self.table_abc.foo, fn.Sum(self.table_efg.bar), self.table_abc.buz)
+                .groupby(self.table_abc.foo)
+                .having(self.table_abc.buz == "fiz")
+                .having(fn.Sum(self.table_efg.bar) > 100)
         )
 
         self.assertEqual(
-            'SELECT "abc"."foo",SUM("efg"."bar"),"abc"."buz" FROM "abc" '
-            'JOIN "efg" ON "abc"."foo"="efg"."foo" '
-            'GROUP BY "abc"."foo" '
-            'HAVING "abc"."buz"=\'fiz\' AND SUM("efg"."bar")>100',
-            str(q),
+              'SELECT "abc"."foo",SUM("efg"."bar"),"abc"."buz" FROM "abc" '
+              'JOIN "efg" ON "abc"."foo"="efg"."foo" '
+              'GROUP BY "abc"."foo" '
+              'HAVING "abc"."buz"=\'fiz\' AND SUM("efg"."bar")>100',
+              str(q),
         )
 
     def test_mysql_query_uses_backtick_quote_chars(self):
         q = (
             MySQLQuery.from_(self.table_abc)
-            .select(self.table_abc.foo)
-            .groupby(self.table_abc.foo)
-            .having(self.table_abc.buz == "fiz")
+                .select(self.table_abc.foo)
+                .groupby(self.table_abc.foo)
+                .having(self.table_abc.buz == "fiz")
         )
         self.assertEqual(
-            "SELECT `foo` FROM `abc` GROUP BY `foo` HAVING `buz`='fiz'", str(q)
+              "SELECT `foo` FROM `abc` GROUP BY `foo` HAVING `buz`='fiz'", str(q)
         )
 
     def test_vertica_query_uses_double_quote_chars(self):
         q = (
             VerticaQuery.from_(self.table_abc)
-            .select(self.table_abc.foo)
-            .groupby(self.table_abc.foo)
-            .having(self.table_abc.buz == "fiz")
+                .select(self.table_abc.foo)
+                .groupby(self.table_abc.foo)
+                .having(self.table_abc.buz == "fiz")
         )
         self.assertEqual(
-            'SELECT "foo" FROM "abc" GROUP BY "foo" HAVING "buz"=\'fiz\'', str(q)
+              'SELECT "foo" FROM "abc" GROUP BY "foo" HAVING "buz"=\'fiz\'', str(q)
         )
 
     def test_mssql_query_uses_double_quote_chars(self):
         q = (
             MSSQLQuery.from_(self.table_abc)
-            .select(self.table_abc.foo)
-            .groupby(self.table_abc.foo)
-            .having(self.table_abc.buz == "fiz")
+                .select(self.table_abc.foo)
+                .groupby(self.table_abc.foo)
+                .having(self.table_abc.buz == "fiz")
         )
         self.assertEqual(
-            'SELECT "foo" FROM "abc" GROUP BY "foo" HAVING "buz"=\'fiz\'', str(q)
+              'SELECT "foo" FROM "abc" GROUP BY "foo" HAVING "buz"=\'fiz\'', str(q)
         )
 
     def test_oracle_query_uses_double_quote_chars(self):
         q = (
             OracleQuery.from_(self.table_abc)
-            .select(self.table_abc.foo)
-            .groupby(self.table_abc.foo)
-            .having(self.table_abc.buz == "fiz")
+                .select(self.table_abc.foo)
+                .groupby(self.table_abc.foo)
+                .having(self.table_abc.buz == "fiz")
         )
         self.assertEqual(
-            'SELECT "foo" FROM "abc" GROUP BY "foo" HAVING "buz"=\'fiz\'', str(q)
+              'SELECT "foo" FROM "abc" GROUP BY "foo" HAVING "buz"=\'fiz\'', str(q)
         )
 
     def test_postgres_query_uses_double_quote_chars(self):
         q = (
             PostgreSQLQuery.from_(self.table_abc)
-            .select(self.table_abc.foo)
-            .groupby(self.table_abc.foo)
-            .having(self.table_abc.buz == "fiz")
+                .select(self.table_abc.foo)
+                .groupby(self.table_abc.foo)
+                .having(self.table_abc.buz == "fiz")
         )
         self.assertEqual(
-            'SELECT "foo" FROM "abc" GROUP BY "foo" HAVING "buz"=\'fiz\'', str(q)
+              'SELECT "foo" FROM "abc" GROUP BY "foo" HAVING "buz"=\'fiz\'', str(q)
         )
 
     def test_redshift_query_uses_double_quote_chars(self):
         q = (
             RedshiftQuery.from_(self.table_abc)
-            .select(self.table_abc.foo)
-            .groupby(self.table_abc.foo)
-            .having(self.table_abc.buz == "fiz")
+                .select(self.table_abc.foo)
+                .groupby(self.table_abc.foo)
+                .having(self.table_abc.buz == "fiz")
         )
         self.assertEqual(
-            'SELECT "foo" FROM "abc" GROUP BY "foo" HAVING "buz"=\'fiz\'', str(q)
+              'SELECT "foo" FROM "abc" GROUP BY "foo" HAVING "buz"=\'fiz\'', str(q)
         )
 
 
@@ -780,8 +785,8 @@ class OrderByTests(unittest.TestCase):
     def test_orderby_multi_fields(self):
         q = (
             Query.from_(self.t)
-            .orderby(self.t.foo, self.t.bar)
-            .select(self.t.foo, self.t.bar)
+                .orderby(self.t.foo, self.t.bar)
+                .select(self.t.foo, self.t.bar)
         )
 
         self.assertEqual('SELECT "foo","bar" FROM "abc" ORDER BY "foo","bar"', str(q))
@@ -806,8 +811,8 @@ class OrderByTests(unittest.TestCase):
         q = Query.from_(self.t).select(fn.Sum(self.t.foo), bar).orderby(bar)
 
         self.assertEqual(
-            'SELECT SUM("foo"),"bar" "bar01" FROM "abc" ORDER BY "bar"',
-            q.get_sql(orderby_alias=False),
+              'SELECT SUM("foo"),"bar" "bar01" FROM "abc" ORDER BY "bar"',
+              q.get_sql(orderby_alias=False),
         )
 
     def test_orderby_alias(self):
@@ -815,7 +820,7 @@ class OrderByTests(unittest.TestCase):
         q = Query.from_(self.t).select(fn.Sum(self.t.foo), bar).orderby(bar)
 
         self.assertEqual(
-            'SELECT SUM("foo"),"bar" "bar01" FROM "abc" ORDER BY "bar01"', q.get_sql()
+              'SELECT SUM("foo"),"bar" "bar01" FROM "abc" ORDER BY "bar01"', q.get_sql()
         )
 
 
@@ -884,31 +889,31 @@ class AliasTests(unittest.TestCase):
 
     def test_ignored_in_field_inside_case(self):
         q = Query.from_(self.t).select(
-            Case().when(self.t.foo == 1, "a").else_(self.t.bar.as_('"buz"'))
+              Case().when(self.t.foo == 1, "a").else_(self.t.bar.as_('"buz"'))
         )
 
         self.assertEqual(
-            'SELECT CASE WHEN "foo"=1 THEN \'a\' ELSE "bar" END FROM "abc"', str(q)
+              'SELECT CASE WHEN "foo"=1 THEN \'a\' ELSE "bar" END FROM "abc"', str(q)
         )
 
     def test_case_using_as(self):
         q = Query.from_(self.t).select(
-            Case().when(self.t.foo == 1, "a").else_("b").as_("bar")
+              Case().when(self.t.foo == 1, "a").else_("b").as_("bar")
         )
 
         self.assertEqual(
-            'SELECT CASE WHEN "foo"=1 THEN \'a\' ELSE \'b\' END "bar" FROM "abc"',
-            str(q),
+              'SELECT CASE WHEN "foo"=1 THEN \'a\' ELSE \'b\' END "bar" FROM "abc"',
+              str(q),
         )
 
     def test_case_using_constructor_param(self):
         q = Query.from_(self.t).select(
-            Case(alias="bar").when(self.t.foo == 1, "a").else_("b")
+              Case(alias="bar").when(self.t.foo == 1, "a").else_("b")
         )
 
         self.assertEqual(
-            'SELECT CASE WHEN "foo"=1 THEN \'a\' ELSE \'b\' END "bar" FROM "abc"',
-            str(q),
+              'SELECT CASE WHEN "foo"=1 THEN \'a\' ELSE \'b\' END "bar" FROM "abc"',
+              str(q),
         )
 
     def test_select__multiple_tables(self):
@@ -916,13 +921,13 @@ class AliasTests(unittest.TestCase):
 
         q = (
             Query.from_(table_abc)
-            .select(table_abc.foo)
-            .from_(table_efg)
-            .select(table_efg.bar)
+                .select(table_abc.foo)
+                .from_(table_efg)
+                .select(table_efg.bar)
         )
 
         self.assertEqual(
-            'SELECT "q0"."foo","q1"."bar" FROM "abc" "q0","efg" "q1"', str(q)
+              'SELECT "q0"."foo","q1"."bar" FROM "abc" "q0","efg" "q1"', str(q)
         )
 
     def test_use_aliases_in_groupby_and_orderby(self):
@@ -931,17 +936,17 @@ class AliasTests(unittest.TestCase):
         my_foo = table_abc.foo.as_("my_foo")
         q = (
             Query.from_(table_abc)
-            .select(my_foo, table_abc.bar)
-            .groupby(my_foo)
-            .orderby(my_foo)
+                .select(my_foo, table_abc.bar)
+                .groupby(my_foo)
+                .orderby(my_foo)
         )
 
         self.assertEqual(
-            'SELECT "q0"."foo" "my_foo","q0"."bar" '
-            'FROM "abc" "q0" '
-            'GROUP BY "my_foo" '
-            'ORDER BY "my_foo"',
-            str(q),
+              'SELECT "q0"."foo" "my_foo","q0"."bar" '
+              'FROM "abc" "q0" '
+              'GROUP BY "my_foo" '
+              'ORDER BY "my_foo"',
+              str(q),
         )
 
     def test_table_with_schema_and_alias(self):
@@ -962,31 +967,31 @@ class SubqueryTests(unittest.TestCase):
     def test_where__in(self):
         q = (
             Query.from_(self.table_abc)
-            .select("*")
-            .where(
-                self.table_abc.foo.isin(
-                    Query.from_(self.table_efg)
-                    .select(self.table_efg.foo)
-                    .where(self.table_efg.bar == 0)
-                )
+                .select("*")
+                .where(
+                  self.table_abc.foo.isin(
+                        Query.from_(self.table_efg)
+                            .select(self.table_efg.foo)
+                            .where(self.table_efg.bar == 0)
+                  )
             )
         )
 
         self.assertEqual(
-            'SELECT * FROM "abc" WHERE "foo" IN (SELECT "foo" FROM "efg" WHERE "bar"=0)',
-            str(q),
+              'SELECT * FROM "abc" WHERE "foo" IN (SELECT "foo" FROM "efg" WHERE "bar"=0)',
+              str(q),
         )
 
     def test_where__in_nested(self):
         q = (
             Query.from_(self.table_abc)
-            .select("*")
-            .where(self.table_abc.foo)
-            .isin(self.table_efg.select("*"))
+                .select("*")
+                .where(self.table_abc.foo)
+                .isin(self.table_efg.select("*"))
         )
 
         self.assertEqual(
-            'SELECT * FROM "abc" WHERE "foo" IN (SELECT * FROM "efg")', str(q)
+              'SELECT * FROM "abc" WHERE "foo" IN (SELECT * FROM "efg")', str(q)
         )
 
     def test_join(self):
@@ -994,16 +999,16 @@ class SubqueryTests(unittest.TestCase):
 
         q = (
             Query.from_(self.table_abc)
-            .join(subquery)
-            .on(self.table_abc.bar == subquery.buz)
-            .select(self.table_abc.foo, subquery.fiz)
+                .join(subquery)
+                .on(self.table_abc.bar == subquery.buz)
+                .select(self.table_abc.foo, subquery.fiz)
         )
 
         self.assertEqual(
-            'SELECT "abc"."foo","sq0"."fiz" FROM "abc" '
-            'JOIN (SELECT "fiz","buz" FROM "efg" WHERE "buz"=0) "sq0" '
-            'ON "abc"."bar"="sq0"."buz"',
-            str(q),
+              'SELECT "abc"."foo","sq0"."fiz" FROM "abc" '
+              'JOIN (SELECT "fiz","buz" FROM "efg" WHERE "buz"=0) "sq0" '
+              'ON "abc"."bar"="sq0"."buz"',
+              str(q),
         )
 
     def test_select_subquery(self):
@@ -1014,9 +1019,9 @@ class SubqueryTests(unittest.TestCase):
         q = Query.from_(self.table_abc).select("foo", "bar").select(subq)
 
         self.assertEqual(
-            'SELECT "foo","bar",(SELECT "fizzbuzz" FROM "efg" WHERE "id"=1) '
-            'FROM "abc"',
-            str(q),
+              'SELECT "foo","bar",(SELECT "fizzbuzz" FROM "efg" WHERE "id"=1) '
+              'FROM "abc"',
+              str(q),
         )
 
     def test_select_subquery_with_alias(self):
@@ -1027,150 +1032,150 @@ class SubqueryTests(unittest.TestCase):
         q = Query.from_(self.table_abc).select("foo", "bar").select(subq.as_("sq"))
 
         self.assertEqual(
-            'SELECT "foo","bar",(SELECT "fizzbuzz" FROM "efg" WHERE "id"=1) "sq" '
-            'FROM "abc"',
-            str(q),
+              'SELECT "foo","bar",(SELECT "fizzbuzz" FROM "efg" WHERE "id"=1) "sq" '
+              'FROM "abc"',
+              str(q),
         )
 
     def test_where__equality(self):
         subquery = Query.from_("efg").select("fiz").where(F("buz") == 0)
         query = (
             Query.from_(self.table_abc)
-            .select(self.table_abc.foo, self.table_abc.bar)
-            .where(self.table_abc.bar == subquery)
+                .select(self.table_abc.foo, self.table_abc.bar)
+                .where(self.table_abc.bar == subquery)
         )
 
         self.assertEqual(
-            'SELECT "foo","bar" FROM "abc" '
-            'WHERE "bar"=(SELECT "fiz" FROM "efg" WHERE "buz"=0)',
-            str(query),
+              'SELECT "foo","bar" FROM "abc" '
+              'WHERE "bar"=(SELECT "fiz" FROM "efg" WHERE "buz"=0)',
+              str(query),
         )
 
     def test_select_from_nested_query(self):
         subquery = Query.from_(self.table_abc).select(
-            self.table_abc.foo,
-            self.table_abc.bar,
-            (self.table_abc.fizz + self.table_abc.buzz).as_("fizzbuzz"),
+              self.table_abc.foo,
+              self.table_abc.bar,
+              (self.table_abc.fizz + self.table_abc.buzz).as_("fizzbuzz"),
         )
 
         query = Query.from_(subquery).select(
-            subquery.foo, subquery.bar, subquery.fizzbuzz
+              subquery.foo, subquery.bar, subquery.fizzbuzz
         )
 
         self.assertEqual(
-            'SELECT "sq0"."foo","sq0"."bar","sq0"."fizzbuzz" '
-            "FROM ("
-            'SELECT "foo","bar","fizz"+"buzz" "fizzbuzz" '
-            'FROM "abc"'
-            ') "sq0"',
-            str(query),
+              'SELECT "sq0"."foo","sq0"."bar","sq0"."fizzbuzz" '
+              "FROM ("
+              'SELECT "foo","bar","fizz"+"buzz" "fizzbuzz" '
+              'FROM "abc"'
+              ') "sq0"',
+              str(query),
         )
 
     def test_select_from_nested_query_with_join(self):
         subquery1 = (
             Query.from_(self.table_abc)
-            .select(
-                self.table_abc.foo,
-                fn.Sum(self.table_abc.fizz + self.table_abc.buzz).as_("fizzbuzz"),
+                .select(
+                  self.table_abc.foo,
+                  fn.Sum(self.table_abc.fizz + self.table_abc.buzz).as_("fizzbuzz"),
             )
-            .groupby(self.table_abc.foo)
+                .groupby(self.table_abc.foo)
         )
 
         subquery2 = Query.from_(self.table_efg).select(
-            self.table_efg.foo.as_("foo_two"), self.table_efg.bar,
+              self.table_efg.foo.as_("foo_two"), self.table_efg.bar,
         )
 
         query = (
             Query.from_(subquery1)
-            .select(subquery1.foo, subquery1.fizzbuzz)
-            .join(subquery2)
-            .on(subquery1.foo == subquery2.foo_two)
-            .select(subquery2.foo_two, subquery2.bar)
+                .select(subquery1.foo, subquery1.fizzbuzz)
+                .join(subquery2)
+                .on(subquery1.foo == subquery2.foo_two)
+                .select(subquery2.foo_two, subquery2.bar)
         )
 
         self.assertEqual(
-            "SELECT "
-            '"sq0"."foo","sq0"."fizzbuzz",'
-            '"sq1"."foo_two","sq1"."bar" '
-            "FROM ("
-            "SELECT "
-            '"foo",SUM("fizz"+"buzz") "fizzbuzz" '
-            'FROM "abc" '
-            'GROUP BY "foo"'
-            ') "sq0" JOIN ('
-            "SELECT "
-            '"foo" "foo_two","bar" '
-            'FROM "efg"'
-            ') "sq1" ON "sq0"."foo"="sq1"."foo_two"',
-            str(query),
+              "SELECT "
+              '"sq0"."foo","sq0"."fizzbuzz",'
+              '"sq1"."foo_two","sq1"."bar" '
+              "FROM ("
+              "SELECT "
+              '"foo",SUM("fizz"+"buzz") "fizzbuzz" '
+              'FROM "abc" '
+              'GROUP BY "foo"'
+              ') "sq0" JOIN ('
+              "SELECT "
+              '"foo" "foo_two","bar" '
+              'FROM "efg"'
+              ') "sq1" ON "sq0"."foo"="sq1"."foo_two"',
+              str(query),
         )
 
     def test_from_subquery_without_alias(self):
         subquery = Query.from_(self.table_efg).select(
-            self.table_efg.base_id.as_("x"), self.table_efg.fizz, self.table_efg.buzz
+              self.table_efg.base_id.as_("x"), self.table_efg.fizz, self.table_efg.buzz
         )
 
         test_query = Query.from_(subquery).select(
-            subquery.x, subquery.fizz, subquery.buzz
+              subquery.x, subquery.fizz, subquery.buzz
         )
 
         self.assertEqual(
-            'SELECT "sq0"."x","sq0"."fizz","sq0"."buzz" '
-            "FROM ("
-            'SELECT "base_id" "x","fizz","buzz" FROM "efg"'
-            ') "sq0"',
-            str(test_query),
+              'SELECT "sq0"."x","sq0"."fizz","sq0"."buzz" '
+              "FROM ("
+              'SELECT "base_id" "x","fizz","buzz" FROM "efg"'
+              ') "sq0"',
+              str(test_query),
         )
 
     def test_join_query_with_alias(self):
         subquery = (
             Query.from_(self.table_efg)
-            .select(
-                self.table_efg.base_id.as_("x"),
-                self.table_efg.fizz,
-                self.table_efg.buzz,
+                .select(
+                  self.table_efg.base_id.as_("x"),
+                  self.table_efg.fizz,
+                  self.table_efg.buzz,
             )
-            .as_("subq")
+                .as_("subq")
         )
 
         test_query = Query.from_(subquery).select(
-            subquery.x, subquery.fizz, subquery.buzz
+              subquery.x, subquery.fizz, subquery.buzz
         )
 
         self.assertEqual(
-            'SELECT "subq"."x","subq"."fizz","subq"."buzz" '
-            "FROM ("
-            'SELECT "base_id" "x","fizz","buzz" FROM "efg"'
-            ') "subq"',
-            str(test_query),
+              'SELECT "subq"."x","subq"."fizz","subq"."buzz" '
+              "FROM ("
+              'SELECT "base_id" "x","fizz","buzz" FROM "efg"'
+              ') "subq"',
+              str(test_query),
         )
 
     def test_with(self):
         sub_query = Query.from_(self.table_efg).select("fizz")
         test_query = (
             Query.with_(sub_query, "an_alias")
-            .from_(AliasedQuery("an_alias"))
-            .select("*")
+                .from_(AliasedQuery("an_alias"))
+                .select("*")
         )
 
         self.assertEqual(
-            'WITH an_alias AS (SELECT "fizz" FROM "efg") SELECT * FROM an_alias',
-            str(test_query),
+              'WITH an_alias AS (SELECT "fizz" FROM "efg") SELECT * FROM an_alias',
+              str(test_query),
         )
 
     def test_join_with_with(self):
         sub_query = Query.from_(self.table_efg).select("fizz")
         test_query = (
             Query.with_(sub_query, "an_alias")
-            .from_(self.table_abc)
-            .join(AliasedQuery("an_alias"))
-            .on(AliasedQuery("an_alias").fizz == self.table_abc.buzz)
-            .select("*")
+                .from_(self.table_abc)
+                .join(AliasedQuery("an_alias"))
+                .on(AliasedQuery("an_alias").fizz == self.table_abc.buzz)
+                .select("*")
         )
         self.assertEqual(
-            'WITH an_alias AS (SELECT "fizz" FROM "efg") '
-            'SELECT * FROM "abc" JOIN an_alias ON "an_alias"."fizz"="abc"."buzz"',
-            str(test_query),
+              'WITH an_alias AS (SELECT "fizz" FROM "efg") '
+              'SELECT * FROM "abc" JOIN an_alias ON "an_alias"."fizz"="abc"."buzz"',
+              str(test_query),
         )
 
 
@@ -1181,14 +1186,14 @@ class QuoteTests(unittest.TestCase):
 
         query = (
             Query.from_(t1)
-            .join(t2)
-            .on(t1.Value.between(t2.start, t2.end))
-            .select(t1.value)
+                .join(t2)
+                .on(t1.Value.between(t2.start, t2.end))
+                .select(t1.value)
         )
 
         self.assertEqual(
-            "SELECT t1.value FROM table1 t1 "
-            "JOIN table2 t2 ON t1.Value "
-            "BETWEEN t2.start AND t2.end",
-            query.get_sql(quote_char=None),
+              "SELECT t1.value FROM table1 t1 "
+              "JOIN table2 t2 ON t1.Value "
+              "BETWEEN t2.start AND t2.end",
+              query.get_sql(quote_char=None),
         )

--- a/pypika/utils.py
+++ b/pypika/utils.py
@@ -76,7 +76,7 @@ def ignore_copy(func):
             "__getnewargs__",
         ]:
             raise AttributeError(
-                "'%s' object has no attribute '%s'" % (self.__class__.__name__, name)
+                  "'%s' object has no attribute '%s'" % (self.__class__.__name__, name)
             )
 
         return func(self, name)
@@ -103,11 +103,13 @@ def format_quotes(value, quote_char):
     return "{quote}{value}{quote}".format(value=value, quote=quote_char or "")
 
 
-def format_alias_sql(sql, alias, quote_char=None, alias_quote_char=None, **kwargs):
+def format_alias_sql(sql, alias, quote_char=None, alias_quote_char=None, as_keyword=False, **kwargs):
     if alias is None:
         return sql
-    return "{sql} {alias}".format(
-        sql=sql, alias=format_quotes(alias, alias_quote_char or quote_char)
+    return "{sql}{_as}{alias}".format(
+          sql=sql,
+          _as=' AS ' if as_keyword else ' ',
+          alias=format_quotes(alias, alias_quote_char or quote_char)
     )
 
 


### PR DESCRIPTION
Fixes #390

Added a dialect option for requiring the "AS" keyword when declaring aliases and set it as True for Clickhouse queries.