### PR TITLE
fixing gh actions 

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,4 @@
+[run]
+source = pypika
+relative_files = True
+command_line = -m unittest discover

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -1,4 +1,4 @@
-name: Python package
+name: Unit Tests
 
 on:
   push:
@@ -7,7 +7,7 @@ on:
     branches: ["master"]
 
 jobs:
-  build:
+  test:
 
     runs-on: ubuntu-latest
     strategy:
@@ -16,21 +16,38 @@ jobs:
         python-version: [3.5, 3.6, 3.7, 3.8]
 
     steps:
-    - uses: actions/checkout@v1
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements-dev.txt
-    - name: Run test suite
-      run: tox
-#    - name: Run Coveralls
-#      run: coveralls
-#      env:
-#        COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-#    Uncomment when Black is setup for PyPika
-#    - name: Run Black code formatter check
-#      run: black --check .
+      - uses: actions/checkout@v1
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+
+      - name: Run test suite
+        run: tox
+
+      # Uncomment when Black is setup for PyPika
+      #    - name: Run Black code formatter check
+      #      run: black --check .
+
+      - name: Coveralls
+        # Official Coveralls GitHub action does not work with Python coverage files!
+        # https://github.com/coverallsapp/github-action/issues/30
+        uses: AndreMiras/coveralls-python-action@develop
+        with:
+          parallel: true
+          debug: true
+
+  coveralls_finish:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Coveralls Finished
+        uses: AndreMiras/coveralls-python-action@develop
+        with:
+          parallel-finished: true
+          debug: true

--- a/README.rst
+++ b/README.rst
@@ -991,9 +991,9 @@ Crafted with ♥ in Berlin.
 
 .. _available_badges_start:
 
-.. |BuildStatus| image:: https://github.com/kayak/pypika/workflows/Python%20package/badge.svg
+.. |BuildStatus| image:: https://github.com/kayak/pypika/workflows/Unit%Tests/badge.svg
    :target: https://github.com/kayak/pypika/actions
-.. |CoverageStatus| image:: https://coveralls.io/repos/kayak/pypika/badge.svg?branch=master&service=github
+.. |CoverageStatus| image:: https://coveralls.io/repos/kayak/pypika/badge.svg?branch=master
    :target: https://coveralls.io/github/kayak/pypika?branch=master
 .. |Codacy| image:: https://api.codacy.com/project/badge/Grade/6d7e44e5628b4839a23da0bd82eaafcf
    :target: https://www.codacy.com/app/twheys/pypika

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,8 +2,10 @@
 Sphinx==1.6.5
 sphinx-rtd-theme==0.2.4
 bumpversion==0.5.3
+
+# Testing
 parameterized==0.7.0
 tox==3.14.3
 tox-venv==0.4.0
 tox-gh-actions==0.3.0
-coveralls==1.10.0
+coverage==5.1

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist = py35,py36,py37,py38,py39,pypy3
 [testenv]
 deps = -r requirements-dev.txt
 commands =
-    coverage run --source=pypika -m unittest discover
+    coverage run
     coverage report
 [gh-actions]
 python =


### PR DESCRIPTION
There is another unofficial GH Coveralls action which works with Python. This should fix the issues with the manual Coveralls run which does not work inside PRs.

No need to merge - this PR will be used for testing so may be open for some time.