### PR TITLE
Add handler for MySQL ON CONFLICT IGNORE statement

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -832,7 +832,7 @@ PostgreSQL
 
 .. code-block:: sql
 
-    INSERT INTO "abc" VALUES (1,'Jane','Doe','jane@example.com') ON CONFLICT ("email") DO UPDATE SET "email"='bob@example.com'
+    INSERT INTO "customers" VALUES (1,'Jane','Doe','jane@example.com') ON CONFLICT ("email") DO UPDATE SET "email"='bob@example.com'
 
 
 Insert from a SELECT Sub-query
@@ -840,7 +840,7 @@ Insert from a SELECT Sub-query
 
 .. code-block:: sql
 
-    INSERT INTO customers VALUES (1,'Jane','Doe','jane@example.com'),(2,'John','Doe','john@example.com')
+    INSERT INTO "customers" VALUES (1,'Jane','Doe','jane@example.com'),(2,'John','Doe','john@example.com')
 
 
 To specify the columns and the order, use the ``columns`` function.

--- a/README.rst
+++ b/README.rst
@@ -772,8 +772,23 @@ Multiple rows of data can be inserted either by chaining the ``insert`` function
     q = Query.into(customers).insert((1, 'Jane', 'Doe', 'jane@example.com'),
                                      (2, 'John', 'Doe', 'john@example.com'))
 
-Insert with on Duplicate Key Update
-"""""""""""""""""""""""""""""""""""
+Insert with constraint violation handling
+"""""""""""""""""""""""""""""""""""""""""
+
+MySQL
+~~~~~
+
+.. code-block:: python
+
+    customers = Table('customers')
+
+    q = Query.into(customers)\
+        .insert(1, 'Jane', 'Doe', 'jane@example.com')\
+        .on_duplicate_key_ignore())
+
+.. code-block:: sql
+
+    INSERT INTO customers VALUES (1,'Jane','Doe','jane@example.com') ON DUPLICATE KEY IGNORE
 
 .. code-block:: python
 
@@ -789,6 +804,35 @@ Insert with on Duplicate Key Update
 
 ``.on_duplicate_key_update`` works similar to ``.set`` for updating rows, additionally it provides the ``Values``
 wrapper to update to the value specified in the ``INSERT`` clause.
+
+PostgreSQL
+~~~~~~~~~~
+
+.. code-block:: python
+
+    customers = Table('customers')
+
+    q = Query.into(customers)\
+        .insert(1, 'Jane', 'Doe', 'jane@example.com')\
+        .on_conflict(customers.email)
+        .do_nothing()
+
+.. code-block:: sql
+
+    INSERT INTO "abc" VALUES (1,'Jane','Doe','jane@example.com') ON CONFLICT ("email") DO NOTHING
+
+.. code-block:: python
+
+    customers = Table('customers')
+
+    q = Query.into(customers)\
+        .insert(1, 'Jane', 'Doe', 'jane@example.com')\
+        .on_conflict(customers.email)
+        .do_update(customers.email, 'bob@example.com')
+
+.. code-block:: sql
+
+    INSERT INTO "abc" VALUES (1,'Jane','Doe','jane@example.com') ON CONFLICT ("email") DO UPDATE SET "email"='bob@example.com'
 
 
 Insert from a SELECT Sub-query

--- a/pypika/tests/dialects/test_mysql.py
+++ b/pypika/tests/dialects/test_mysql.py
@@ -3,6 +3,7 @@ import unittest
 from pypika import (
     Table,
     MySQLQuery,
+    QueryException,
 )
 
 
@@ -40,6 +41,51 @@ class SelectTests(unittest.TestCase):
         self.assertEqual(
             "SELECT HIGH_PRIORITY SQL_CALC_FOUND_ROWS `def` FROM `abc`", str(q)
         )
+
+
+class UpdateTests(unittest.TestCase):
+    table_abc = Table("abc")
+
+    def test_update(self):
+        q = (
+            MySQLQuery.into("abc")
+            .insert(1, [1, "a", True])
+        )
+
+        self.assertEqual(
+            "INSERT INTO `abc` VALUES (1,[1,'a',true])", str(q)
+        )
+
+    def test_on_duplicate_key_ignore_update(self):
+        q = (
+            MySQLQuery.into("abc")
+            .insert(1, [1, "a", True])
+            .on_duplicate_key_ignore()
+        )
+
+        self.assertEqual(
+            "INSERT INTO `abc` VALUES (1,[1,'a',true]) ON DUPLICATE KEY IGNORE", str(q)
+        )
+
+    def test_on_duplicate_key_update_update(self):
+        q = (
+            MySQLQuery.into("abc")
+            .insert(1, [1, "a", True])
+            .on_duplicate_key_update(self.table_abc.a, 'b')
+        )
+
+        self.assertEqual(
+            "INSERT INTO `abc` VALUES (1,[1,'a',true]) ON DUPLICATE KEY UPDATE `a`='b'", str(q)
+        )
+
+    def test_conflict_handlers_update(self):
+        with self.assertRaises(QueryException):
+            (
+                MySQLQuery.into("abc")
+                .insert(1, [1, "a", True])
+                .on_duplicate_key_ignore()
+                .on_duplicate_key_update(self.table_abc.a, 'b')
+            )
 
 
 class LoadCSVTests(unittest.TestCase):

--- a/pypika/tests/test_inserts.py
+++ b/pypika/tests/test_inserts.py
@@ -192,9 +192,9 @@ class PostgresInsertIntoOnConflictTests(unittest.TestCase):
     def test_insert_on_conflict_do_nothing_multiple_fields(self):
         query = (
             PostgreSQLQuery.into(self.table_abc)
-                .insert(1)
-                .on_conflict(self.table_abc.id, self.table_abc.sub_id)
-                .do_nothing()
+            .insert(1)
+            .on_conflict(self.table_abc.id, self.table_abc.sub_id)
+            .do_nothing()
         )
 
         self.assertEqual(


### PR DESCRIPTION
Also added a couple of PostgreSQL ON CONFLICT statement examples to README. Not sure about where to place tests for this feature as many PostgreSQL specific modifier tests are in `test_inserts` module.