### PR TITLE
Fix columns with empty args

### DIFF
--- a/pypika/queries.py
+++ b/pypika/queries.py
@@ -772,7 +772,7 @@ class QueryBuilder(Selectable, Term):
         if self._insert_table is None:
             raise AttributeError("'Query' object has no attribute '%s'" % "insert")
 
-        if isinstance(terms[0], (list, tuple)):
+        if terms and isinstance(terms[0], (list, tuple)):
             terms = terms[0]
 
         for term in terms:

--- a/pypika/tests/test_inserts.py
+++ b/pypika/tests/test_inserts.py
@@ -113,6 +113,17 @@ class InsertIntoTests(unittest.TestCase):
             'INSERT INTO "abc" ("foo","bar","buz") VALUES (1,\'a\',true)', str(query)
         )
 
+    def test_insert_empty_columns(self):
+        query = (
+            Query.into(self.table_abc)
+            .columns()
+            .insert(1, "a", True)
+        )
+
+        self.assertEqual(
+            'INSERT INTO "abc" VALUES (1,\'a\',true)', str(query)
+        )
+
     def test_insert_selected_columns_type_list(self):
         query = (
             Query.into(self.table_abc)
@@ -124,6 +135,17 @@ class InsertIntoTests(unittest.TestCase):
             'INSERT INTO "abc" ("foo","bar","buz") VALUES (1,\'a\',true)', str(query)
         )
 
+    def test_insert_empty_columns_type_list(self):
+        query = (
+            Query.into(self.table_abc)
+            .columns([])
+            .insert(1, "a", True)
+        )
+
+        self.assertEqual(
+            'INSERT INTO "abc" VALUES (1,\'a\',true)', str(query)
+        )
+
     def test_insert_selected_columns_type_tuple(self):
         query = (
             Query.into(self.table_abc)
@@ -133,6 +155,17 @@ class InsertIntoTests(unittest.TestCase):
 
         self.assertEqual(
             'INSERT INTO "abc" ("foo","bar","buz") VALUES (1,\'a\',true)', str(query)
+        )
+
+    def test_insert_empty_columns_type_tuple(self):
+        query = (
+            Query.into(self.table_abc)
+            .columns(())
+            .insert(1, "a", True)
+        )
+
+        self.assertEqual(
+            'INSERT INTO "abc" VALUES (1,\'a\',true)', str(query)
         )
 
     def test_insert_none_skipped(self):


### PR DESCRIPTION
Fix columns with empty arguments. I occurs by #373 that support iterable params to `columns`
Really sorry for the hasty PR :disappointed_relieved: ...

Fixed: #430 