### PR TITLE
Undo the showing of aliases of fields that are arguments of a function

### DIFF
--- a/pypika/terms.py
+++ b/pypika/terms.py
@@ -1156,7 +1156,7 @@ class Function(Criterion):
         return "{name}({args}{special})".format(
               name=self.name,
               args=",".join(
-                    p.get_sql(with_alias=True, **kwargs)
+                    p.get_sql(with_alias=False, **kwargs)
                     if hasattr(p, "get_sql")
                     else str(p)
                     for p in self.args

--- a/pypika/tests/test_selects.py
+++ b/pypika/tests/test_selects.py
@@ -862,14 +862,20 @@ class AliasTests(unittest.TestCase):
         self.assertEqual('SELECT COUNT(*) "foo" FROM "abc"', str(q))
 
     def test_function_using_as_nested(self):
+        """
+        We don't show aliases of fields that are arguments of a function.
+        """
         q = Query.from_(self.t).select(fn.Sqrt(fn.Count("*").as_("foo")).as_("bar"))
 
-        self.assertEqual('SELECT SQRT(COUNT(*) "foo") "bar" FROM "abc"', str(q))
+        self.assertEqual('SELECT SQRT(COUNT(*)) "bar" FROM "abc"', str(q))
 
     def test_functions_using_constructor_param_nested(self):
+        """
+        We don't show aliases of fields that are arguments of a function.
+        """
         q = Query.from_(self.t).select(fn.Sqrt(fn.Count("*", alias="foo"), alias="bar"))
 
-        self.assertEqual('SELECT SQRT(COUNT(*) "foo") "bar" FROM "abc"', str(q))
+        self.assertEqual('SELECT SQRT(COUNT(*)) "bar" FROM "abc"', str(q))
 
     def test_ignored_in_where(self):
         q = Query.from_(self.t).select(self.t.foo).where(self.t.foo.as_("bar") == 1)


### PR DESCRIPTION
This is essentially a rollback of https://github.com/kayak/pypika/pull/392. I commented on that pull request as well.

The linked PR made too drastic changes that had a big impact on existing usages. We should either provide a migration guide or find a different solution for this feature. 