### PR TITLE
Fix is_aggregate property for Case fields

### DIFF
--- a/pypika/terms.py
+++ b/pypika/terms.py
@@ -974,9 +974,9 @@ class Case(Term):
 
     @property
     def is_aggregate(self) -> Optional[bool]:
-        # True if all cases are True or None. None all cases are None. Otherwise, False
+        # True if all criterions/cases are True or None. None all cases are None. Otherwise, False
         return resolve_is_aggregate(
-              [term.is_aggregate for _, term in self._cases]
+              [criterion.is_aggregate or term.is_aggregate for criterion, term in self._cases]
               + [self._else.is_aggregate if self._else else None]
         )
 

--- a/pypika/tests/test_aggregate.py
+++ b/pypika/tests/test_aggregate.py
@@ -53,6 +53,15 @@ class IsAggregateTests(unittest.TestCase):
         v = 1 / fn.Sum(Field("foo"))
         self.assertTrue(v.is_aggregate)
 
+    def test__agg_case_criterion_is_aggregate(self):
+        v = (
+            Case()
+            .when(fn.Sum(Field("foo")) > 666, 'More than 666')
+            .else_('Less than 666')
+        )
+
+        self.assertTrue(v.is_aggregate)
+
     def test__agg_case_is_aggregate(self):
         v = (
             Case()
@@ -97,7 +106,7 @@ class IsAggregateTests(unittest.TestCase):
 
         self.assertFalse(v.is_aggregate)
 
-    def test__case_with_single_aggregate_field_is_not_aggregate(self):
+    def test__case_with_single_aggregate_field_in_one_criterion_is_aggregate(self):
         v = (
             Case()
             .when(Field("foo") == 1, 1)
@@ -105,12 +114,7 @@ class IsAggregateTests(unittest.TestCase):
             .else_(3)
         )
 
-        self.assertFalse(v.is_aggregate)
-
-    def test__case_all_constants_is_aggregate_none(self):
-        v = Case().when(True, 1).when(False, 2).else_(3)
-
-        self.assertIsNone(v.is_aggregate)
+        self.assertTrue(v.is_aggregate)
 
     def test__non_aggregate_function_with_aggregated_arg(self):
         t = Table("abc")


### PR DESCRIPTION
So Case's criterions were not taken into account when evaluation a Case field's is_aggregate property, which imo is incorrect.