### PR TITLE
Add implementation of fields_() for EmptyCriterion

### DIFF
--- a/pypika/terms.py
+++ b/pypika/terms.py
@@ -454,6 +454,9 @@ class EmptyCriterion:
     is_aggregate = None
     tables_ = set()
 
+    def fields_(self) -> Set["Field"]:
+        return set()
+
     def __and__(self, other: Any) -> Any:
         return other
 

--- a/pypika/tests/test_criterions.py
+++ b/pypika/tests/test_criterions.py
@@ -763,6 +763,13 @@ class AnyTests(unittest.TestCase):
         self.assertEqual(str(crit), '"a" OR "b" OR "c" OR "d"')
 
 
+class EmptyCriterionTests(unittest.TestCase):
+    def test_fields_(self):
+        empty_criterion = EmptyCriterion()
+
+        self.assertEqual(len(empty_criterion.fields_()), 0)
+
+
 class AllTests(unittest.TestCase):
     def test_zero_args_returns_empty_criterion(self):
         crit = Criterion.all()


### PR DESCRIPTION
This issue would have also been solved if `EmptyCriterion` was a subclass of `Criterion`, which would make sense but adds a lot of unnecessary overhead.