### PR TITLE
Support JOINs with _SetOperation subqueries (union, itersect, except, minus)

### DIFF
--- a/pypika/queries.py
+++ b/pypika/queries.py
@@ -921,7 +921,9 @@ class QueryBuilder(Selectable, Term):
             self._orderbys.append((field, kwargs.get("order")))
 
     @builder
-    def join(self, item: Union[Table, "QueryBuilder", AliasedQuery], how: JoinType = JoinType.inner) -> "Joiner":
+    def join(
+        self, item: Union[Table, "QueryBuilder", AliasedQuery, Selectable], how: JoinType = JoinType.inner
+    ) -> "Joiner":
         if isinstance(item, Table):
             return Joiner(self, item, how, type_label="table")
 
@@ -932,6 +934,9 @@ class QueryBuilder(Selectable, Term):
 
         elif isinstance(item, AliasedQuery):
             return Joiner(self, item, how, type_label="table")
+
+        elif isinstance(item, Selectable):
+            return Joiner(self, item, how, type_label="subquery")
 
         raise ValueError("Cannot join on type '%s'" % type(item))
 

--- a/pypika/tests/test_joins.py
+++ b/pypika/tests/test_joins.py
@@ -728,6 +728,30 @@ class JoinBehaviorTests(unittest.TestCase):
             str(test_query),
         )
 
+    def test_join_query_with_setoperation(self):
+        subquery = (
+            Query.from_(self.table_abc).select("*")
+            .union(
+                Query.from_(self.table_abc).select("*")
+            ).as_("subq")
+        )
+
+        test_query = (
+            Query.from_(self.table_abc)
+            .join(subquery)
+            .on(subquery.x == self.table_abc.id)
+            .select(self.table_abc.foo)
+        )
+
+        self.assertEqual(
+            'SELECT "abc"."foo" FROM "abc" '
+            'JOIN '
+            '((SELECT * FROM "abc") '
+            'UNION '
+            '(SELECT * FROM "abc")) "subq" '
+            'ON "subq"."x"="abc"."id"',
+            str(test_query)
+        )
 
 class UnionTests(unittest.TestCase):
     table1, table2 = Tables("abc", "efg")


### PR DESCRIPTION
Joining with a union subquery fails with: ValueError: Cannot join on type '<class 'pypika.queries._SetOperation'>' 

Example:
```
        subquery = (
            Query.from_(self.table_abc).select("*")
            .union(
                Query.from_(self.table_abc).select("*")
            ).as_("subq")
        )

        test_query = (
            Query.from_(self.table_abc)
            .join(subquery)
            .on(subquery.x == self.table_abc.id)
            .select(self.table_abc.foo)
        )
```


