### PR TITLE
Support FETCH NEXT N ROWS ONLY statement in MSSQLQueryBuilder

### DIFF
--- a/pypika/queries.py
+++ b/pypika/queries.py
@@ -1259,11 +1259,7 @@ class QueryBuilder(Selectable, Term):
         if self._orderbys:
             querystring += self._orderby_sql(**kwargs)
 
-        if self._limit is not None:
-            querystring += self._limit_sql()
-
-        if self._offset:
-            querystring += self._offset_sql()
+        querystring = self._apply_pagination(querystring)
 
         if subquery:
             querystring = "({query})".format(query=querystring)
@@ -1276,13 +1272,22 @@ class QueryBuilder(Selectable, Term):
 
         return querystring
 
+    def _apply_pagination(self, querystring: str) -> str:
+        if self._limit is not None:
+            querystring += self._limit_sql()
+
+        if self._offset:
+            querystring += self._offset_sql()
+
+        return querystring
+
     def _with_sql(self, **kwargs: Any) -> str:
         return "WITH " + ",".join(
-              clause.name
-              + " AS ("
-              + clause.get_sql(subquery=False, with_alias=False, **kwargs)
-              + ") "
-              for clause in self._with
+            clause.name
+            + " AS ("
+            + clause.get_sql(subquery=False, with_alias=False, **kwargs)
+            + ") "
+            for clause in self._with
         )
 
     def _distinct_sql(self, **kwargs: Any) -> str:

--- a/pypika/tests/dialects/test_mssql.py
+++ b/pypika/tests/dialects/test_mssql.py
@@ -28,3 +28,23 @@ class SelectTests(unittest.TestCase):
     def test_top_select_non_int(self):
         with self.assertRaisesRegex(QueryException, "TOP value must be an integer"):
             MSSQLQuery.from_("abc").select("def").top("a")
+
+    def test_limit(self):
+        q = MSSQLQuery.from_("abc").select("def").orderby("def").limit(10)
+
+        self.assertEqual('SELECT "def" FROM "abc" ORDER BY "def" OFFSET 0 ROWS FETCH NEXT 10 ROWS ONLY', str(q))
+
+    def test_fetch_next(self):
+        q = MSSQLQuery.from_("abc").select("def").orderby("def").fetch_next(10)
+
+        self.assertEqual('SELECT "def" FROM "abc" ORDER BY "def" OFFSET 0 ROWS FETCH NEXT 10 ROWS ONLY', str(q))
+
+    def test_offset(self):
+        q = MSSQLQuery.from_("abc").select("def").orderby("def").offset(10)
+
+        self.assertEqual('SELECT "def" FROM "abc" ORDER BY "def" OFFSET 10 ROWS', str(q))
+
+    def test_fetch_next_with_offset(self):
+        q = MSSQLQuery.from_("abc").select("def").orderby("def").fetch_next(10).offset(10)
+
+        self.assertEqual('SELECT "def" FROM "abc" ORDER BY "def" OFFSET 10 ROWS FETCH NEXT 10 ROWS ONLY', str(q))


### PR DESCRIPTION
* I re-used some limit/offset code for MSSQL offset/fetch, as this is the de facto way now of limiting/offsetting rows in modern versions of SQL Server. There are more configuration options, but we can look at supporting them if/when needed. What is provided here is for common use cases.
* I also provided a `fetch_next` method which is has the same behaviour as using the `limit` method to make it more friendly to T-SQL users.