### PR TITLE
SnowflakeQuery: You really don't need quote in Snowflake should fix #483 

### DIFF
--- a/pypika/dialects.py
+++ b/pypika/dialects.py
@@ -26,7 +26,7 @@ from pypika.utils import (
 
 class SnowFlakeQueryBuilder(QueryBuilder):
     QUOTE_CHAR = None
-    ALIAS_QUOTE_CHAR = '"'
+    ALIAS_QUOTE_CHAR = ''
     QUERY_ALIAS_QUOTE_CHAR = ''
 
     def __init__(self, **kwargs: Any) -> None:

--- a/pypika/tests/dialects/test_snowflake.py
+++ b/pypika/tests/dialects/test_snowflake.py
@@ -13,7 +13,7 @@ class QuoteTests(unittest.TestCase):
     def test_use_double_quotes_on_alias_but_not_on_terms(self):
         q = SnowflakeQuery.from_(self.table_abc).select(self.table_abc.a.as_("bar"))
 
-        self.assertEqual('SELECT a "bar" FROM abc', q.get_sql(with_namespace=True))
+        self.assertEqual('SELECT a bar FROM abc', q.get_sql(with_namespace=True))
 
     def test_use_double_quotes_on_alias_but_not_on_terms_with_joins(self):
         foo = self.table_abc.as_("foo")
@@ -28,8 +28,8 @@ class QuoteTests(unittest.TestCase):
 
         self.assertEqual(
             "SELECT foo.a,bar.b "
-            'FROM abc "foo" '
-            'JOIN efg "bar" '
+            'FROM abc foo '
+            'JOIN efg bar '
             "ON foo.fk=bar.id",
             q.get_sql(with_namespace=True),
         )
@@ -45,10 +45,10 @@ class QuoteTests(unittest.TestCase):
         )
 
         self.assertEqual(
-            'SELECT index "idx",SUM(value) "val" '
+            'SELECT index idx,SUM(value) val '
             "FROM abc "
-            'GROUP BY "idx" '
-            'ORDER BY "idx"',
+            'GROUP BY idx '
+            'ORDER BY idx',
             q.get_sql(with_namespace=True),
         )
 


### PR DESCRIPTION
I removed the quote from Snowflake.
The query run and it just make everything easier :) 
It should close #483 