### PR TITLE
Feature/temporal query support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1152,6 +1152,33 @@ This produces:
 
     SELECT * FROM "abc" FOR "valid_period" BETWEEN '2020-01-01' AND '2020-02-01'
 
+Joins
+"""""
+
+With joins, when the table object is used when specifying columns, it is
+important to use the table from which the temporal constraint was generated.
+This is because `Table("abc")` is not the same table as `Table("abc").for_(...)`.
+The following example demonstrates this.
+
+.. code-block:: python
+
+    t0 = Table("abc").for_(SYSTEM_TIME.as_of('2020-01-01'))
+    t1 = Table("efg").for_(SYSTEM_TIME.as_of('2020-01-01'))
+    query = (
+        Query.from_(t0)
+        .join(t1)
+        .on(t0.foo == t1.bar)
+        .select("*")
+    )
+
+This produces:
+
+.. code-block:: sql
+
+    SELECT * FROM "abc" FOR SYSTEM_TIME AS OF '2020-01-01'
+    JOIN "efg" FOR SYSTEM_TIME AS OF '2020-01-01'
+    ON "abc"."foo"="efg"."bar"
+
 Update & Deletes
 """"""""""""""""
 

--- a/README.rst
+++ b/README.rst
@@ -1073,6 +1073,123 @@ MSSQL:
 
 You can find out what parameter style is needed for DBAPI compliant drivers here: https://www.python.org/dev/peps/pep-0249/#paramstyle or in the DB driver documentation.
 
+Temporal support
+^^^^^^^^^^^^^^^^
+
+Temporal criteria can be added to the tables.
+
+Select
+""""""
+
+Here is a select using system time.
+
+.. code-block:: python
+
+    t = Table("abc")
+    q = Query.from_(t.for_(SYSTEM_TIME.as_of('2020-01-01'))).select("*")
+
+This produces:
+
+.. code-block:: sql
+
+    SELECT * FROM "abc" FOR SYSTEM_TIME AS OF '2020-01-01'
+
+You can also use between.
+
+.. code-block:: python
+
+    t = Table("abc")
+    q = Query.from_(
+        t.for_(SYSTEM_TIME.between('2020-01-01', '2020-02-01'))
+    ).select("*")
+
+This produces:
+
+.. code-block:: sql
+
+    SELECT * FROM "abc" FOR SYSTEM_TIME BETWEEN '2020-01-01' AND '2020-02-01'
+
+You can also use a period range.
+
+.. code-block:: python
+
+    t = Table("abc")
+    q = Query.from_(
+        t.for_(SYSTEM_TIME.from_to('2020-01-01', '2020-02-01'))
+    ).select("*")
+
+This produces:
+
+.. code-block:: sql
+
+    SELECT * FROM "abc" FOR SYSTEM_TIME FROM '2020-01-01' TO '2020-02-01'
+
+Finally you can select for all times:
+
+.. code-block:: python
+
+    t = Table("abc")
+    q = Query.from_(t.for_(SYSTEM_TIME.all_())).select("*")
+
+This produces:
+
+.. code-block:: sql
+
+    SELECT * FROM "abc" FOR SYSTEM_TIME ALL
+
+A user defined period can also be used in the following manner.
+
+.. code-block:: python
+
+    t = Table("abc")
+    q = Query.from_(
+        t.for_(t.valid_period.between('2020-01-01', '2020-02-01'))
+    ).select("*")
+
+This produces:
+
+.. code-block:: sql
+
+    SELECT * FROM "abc" FOR "valid_period" BETWEEN '2020-01-01' AND '2020-02-01'
+
+Update & Deletes
+""""""""""""""""
+
+An update can be written as follows:
+
+.. code-block:: python
+
+    t = Table("abc")
+    q = Query.update(
+        t.for_portion(
+            SYSTEM_TIME.from_to('2020-01-01', '2020-02-01')
+        )
+    ).set("foo", "bar")
+
+This produces:
+
+.. code-block:: sql
+
+    UPDATE "abc"
+    FOR PORTION OF SYSTEM_TIME FROM '2020-01-01' TO '2020-02-01'
+    SET "foo"='bar'
+
+Here is a delete:
+
+.. code-block:: python
+
+    t = Table("abc")
+    q = Query.from_(
+        t.for_portion(t.valid_period.from_to('2020-01-01', '2020-02-01'))
+    ).delete()
+
+This produces:
+
+.. code-block:: sql
+
+    DELETE FROM "abc"
+    FOR PORTION OF "valid_period" FROM '2020-01-01' TO '2020-02-01'
+
 Creating Tables
 ^^^^^^^^^^^^^^^
 

--- a/pypika/__init__.py
+++ b/pypika/__init__.py
@@ -75,6 +75,7 @@ from pypika.terms import (
     JSON,
     Not,
     NullValue,
+    SystemTimeValue,
     Parameter,
     Rollup,
     Tuple,
@@ -95,3 +96,6 @@ from pypika.utils import (
 __author__ = "Timothy Heys"
 __email__ = "theys@kayak.com"
 __version__ = "0.39.1"
+
+NULL = NullValue()
+SYSTEM_TIME = SystemTimeValue()

--- a/pypika/__init__.py
+++ b/pypika/__init__.py
@@ -95,7 +95,7 @@ from pypika.utils import (
 
 __author__ = "Timothy Heys"
 __email__ = "theys@kayak.com"
-__version__ = "0.41.0"
+__version__ = "0.40.0"
 
 NULL = NullValue()
 SYSTEM_TIME = SystemTimeValue()

--- a/pypika/__init__.py
+++ b/pypika/__init__.py
@@ -95,7 +95,7 @@ from pypika.utils import (
 
 __author__ = "Timothy Heys"
 __email__ = "theys@kayak.com"
-__version__ = "0.39.1"
+__version__ = "0.40.0"
 
 NULL = NullValue()
 SYSTEM_TIME = SystemTimeValue()

--- a/pypika/__init__.py
+++ b/pypika/__init__.py
@@ -95,7 +95,7 @@ from pypika.utils import (
 
 __author__ = "Timothy Heys"
 __email__ = "theys@kayak.com"
-__version__ = "0.40.0"
+__version__ = "0.41.0"
 
 NULL = NullValue()
 SYSTEM_TIME = SystemTimeValue()

--- a/pypika/enums.py
+++ b/pypika/enums.py
@@ -32,6 +32,7 @@ class Matching(Comparator):
     ilike = " ILIKE "
     regex = " REGEX "
     bin_regex = " REGEX BINARY "
+    as_of = " AS OF "
 
 
 class Boolean(Comparator):

--- a/pypika/queries.py
+++ b/pypika/queries.py
@@ -151,20 +151,13 @@ class Table(Selectable):
         table_sql = format_quotes(self._table_name, quote_char)
 
         if self._schema is not None:
-            table_sql = "{schema}.{table}".format(
-                schema=self._schema.get_sql(**kwargs),
-                table=table_sql
-            )
+            table_sql = "{schema}.{table}".format(schema=self._schema.get_sql(**kwargs), table=table_sql)
 
         if self._for:
-            table_sql = "{table} FOR {criterion}".format(
-                table=table_sql,
-                criterion=self._for.get_sql(**kwargs)
-            )
+            table_sql = "{table} FOR {criterion}".format(table=table_sql, criterion=self._for.get_sql(**kwargs))
         elif self._for_portion:
             table_sql = "{table} FOR PORTION OF {criterion}".format(
-                table=table_sql,
-                criterion=self._for_portion.get_sql(**kwargs)
+                table=table_sql, criterion=self._for_portion.get_sql(**kwargs)
             )
 
         return format_alias_sql(table_sql, self.alias, **kwargs)

--- a/pypika/queries.py
+++ b/pypika/queries.py
@@ -24,6 +24,7 @@ from pypika.terms import (
     Tuple,
     ValueWrapper,
     Criterion,
+    PeriodCriterion
 )
 from pypika.utils import (
     JoinException,
@@ -143,6 +144,8 @@ class Table(Selectable):
         self._table_name = name
         self._schema = self._init_schema(schema)
         self._query_cls = query_cls or Query
+        self._for = None
+        self._for_portion = None
         if not issubclass(self._query_cls, Query):
             raise TypeError("Expected 'query_cls' to be subclass of Query")
 
@@ -156,10 +159,38 @@ class Table(Selectable):
 
         if self._schema is not None:
             table_sql = "{schema}.{table}".format(
-                schema=self._schema.get_sql(**kwargs), table=table_sql
+                schema=self._schema.get_sql(**kwargs),
+                table=table_sql
+            )
+
+        if self._for:
+            table_sql = "{table} FOR {criterion}".format(
+                table=table_sql,
+                criterion=self._for.get_sql(**kwargs)
+            )
+        elif self._for_portion:
+            table_sql = "{table} FOR PORTION OF {criterion}".format(
+                table=table_sql,
+                criterion=self._for_portion.get_sql(**kwargs)
             )
 
         return format_alias_sql(table_sql, self.alias, **kwargs)
+
+    @builder
+    def for_(self, temporal_criterion: Criterion) -> "Table":
+        if self._for:
+            raise AttributeError("'Query' object already has attribute for_")
+        if self._for_portion:
+            raise AttributeError("'Query' object already has attribute for_portion")
+        self._for = temporal_criterion
+
+    @builder
+    def for_portion(self, period_criterion: PeriodCriterion) -> "Table":
+        if self._for_portion:
+            raise AttributeError("'Query' object already has attribute for_portion")
+        if self._for:
+            raise AttributeError("'Query' object already has attribute for_")
+        self._for_portion = period_criterion
 
     def __str__(self) -> str:
         return self.get_sql(quote_char='"')

--- a/pypika/terms.py
+++ b/pypika/terms.py
@@ -161,9 +161,7 @@ class Term(Node):
         return BetweenCriterion(self, self.wrap_constant(lower), self.wrap_constant(upper))
 
     def from_to(self, start: Any, end: Any) -> "PeriodCriterion":
-        return PeriodCriterion(
-            self, self.wrap_constant(start), self.wrap_constant(end)
-        )
+        return PeriodCriterion(self, self.wrap_constant(start), self.wrap_constant(end))
 
     def as_of(self, expr: str) -> "BasicCriterion":
         return BasicCriterion(Matching.as_of, self, self.wrap_constant(expr))
@@ -389,7 +387,6 @@ class Values(Term):
 
 
 class LiteralValue(Term):
-
     def __init__(self, value, alias: Optional[str] = None) -> None:
         super().__init__(alias)
         self._value = value
@@ -791,9 +788,9 @@ class BetweenCriterion(RangeCriterion):
 class PeriodCriterion(RangeCriterion):
     def get_sql(self, **kwargs: Any) -> str:
         sql = "{term} FROM {start} TO {end}".format(
-              term=self.term.get_sql(**kwargs),
-              start=self.start.get_sql(**kwargs),
-              end=self.end.get_sql(**kwargs),
+            term=self.term.get_sql(**kwargs),
+            start=self.start.get_sql(**kwargs),
+            end=self.end.get_sql(**kwargs),
         )
         return format_alias_sql(sql, self.alias, **kwargs)
 

--- a/pypika/tests/test_deletes.py
+++ b/pypika/tests/test_deletes.py
@@ -28,27 +28,19 @@ class DeleteTests(unittest.TestCase):
 
     def test_for_portion(self):
         with self.subTest("with system time"):
-            q = Query.from_(
-                self.table_abc.for_portion(
-                    SYSTEM_TIME.from_to('2020-01-01', '2020-02-01')
-                )
-            ).delete()
+            q = Query.from_(self.table_abc.for_portion(SYSTEM_TIME.from_to('2020-01-01', '2020-02-01'))).delete()
 
             self.assertEqual(
-                'DELETE FROM "abc" FOR PORTION OF SYSTEM_TIME FROM \'2020-01-01\' TO \'2020-02-01\'',
-                str(q)
+                'DELETE FROM "abc" FOR PORTION OF SYSTEM_TIME FROM \'2020-01-01\' TO \'2020-02-01\'', str(q)
             )
 
         with self.subTest("with column"):
             q = Query.from_(
-                self.table_abc.for_portion(
-                    self.table_abc.valid_period.from_to('2020-01-01', '2020-02-01')
-                )
+                self.table_abc.for_portion(self.table_abc.valid_period.from_to('2020-01-01', '2020-02-01'))
             ).delete()
 
             self.assertEqual(
-                'DELETE FROM "abc" FOR PORTION OF "valid_period" FROM \'2020-01-01\' TO \'2020-02-01\'',
-                str(q)
+                'DELETE FROM "abc" FOR PORTION OF "valid_period" FROM \'2020-01-01\' TO \'2020-02-01\'', str(q)
             )
 
 

--- a/pypika/tests/test_deletes.py
+++ b/pypika/tests/test_deletes.py
@@ -1,6 +1,6 @@
 import unittest
 
-from pypika import Table, Query, PostgreSQLQuery
+from pypika import Table, Query, PostgreSQLQuery, SYSTEM_TIME
 
 __author__ = "Timothy Heys"
 __email__ = "theys@kayak.com"
@@ -33,6 +33,31 @@ class DeleteTests(unittest.TestCase):
 
         self.assertEqual('DELETE FROM "abc" WHERE "foo"="bar"', str(q1))
         self.assertEqual('DELETE FROM "abc" WHERE "foo"="bar"', str(q2))
+
+    def test_for_portion(self):
+        with self.subTest("with system time"):
+            q = Query.from_(
+                self.table_abc.for_portion(
+                    SYSTEM_TIME.from_to('2020-01-01', '2020-02-01')
+                )
+            ).delete()
+
+            self.assertEqual(
+                'DELETE FROM "abc" FOR PORTION OF SYSTEM_TIME FROM \'2020-01-01\' TO \'2020-02-01\'',
+                str(q)
+            )
+
+        with self.subTest("with column"):
+            q = Query.from_(
+                self.table_abc.for_portion(
+                    self.table_abc.valid_period.from_to('2020-01-01', '2020-02-01')
+                )
+            ).delete()
+
+            self.assertEqual(
+                'DELETE FROM "abc" FOR PORTION OF "valid_period" FROM \'2020-01-01\' TO \'2020-02-01\'',
+                str(q)
+            )
 
 
 class PostgresDeleteTests(unittest.TestCase):

--- a/pypika/tests/test_joins.py
+++ b/pypika/tests/test_joins.py
@@ -11,7 +11,7 @@ from pypika import (
     Table,
     Tables,
     functions as fn,
-    SYSTEM_TIME
+    SYSTEM_TIME,
 )
 
 __author__ = "Timothy Heys"
@@ -298,18 +298,13 @@ class SelectQueryJoinTests(unittest.TestCase):
     def test_temporal_join(self):
         t0 = self.table0.for_(SYSTEM_TIME.as_of('2020-01-01'))
         t1 = self.table1.for_(SYSTEM_TIME.as_of('2020-01-01'))
-        query = (
-            Query.from_(t0)
-            .join(t1)
-            .on(t0.foo == t1.bar)
-            .select("*")
-        )
+        query = Query.from_(t0).join(t1).on(t0.foo == t1.bar).select("*")
 
         self.assertEqual(
             'SELECT * FROM "abc" FOR SYSTEM_TIME AS OF \'2020-01-01\' '
             'JOIN "efg" FOR SYSTEM_TIME AS OF \'2020-01-01\' '
             'ON "abc"."foo"="efg"."bar"',
-            str(query)
+            str(query),
         )
 
 

--- a/pypika/tests/test_joins.py
+++ b/pypika/tests/test_joins.py
@@ -11,6 +11,7 @@ from pypika import (
     Tables,
     SetOperationException,
     functions as fn,
+    SYSTEM_TIME
 )
 
 __author__ = "Timothy Heys"
@@ -368,6 +369,23 @@ class SelectQueryJoinTests(unittest.TestCase):
         )
         self.assertEqual(
             'SELECT "b"."ouch" FROM "a" JOIN "b" ON "a"."foo"="b"."boo"', str(q2)
+        )
+
+    def test_temporal_join(self):
+        t0 = self.table0.for_(SYSTEM_TIME.as_of('2020-01-01'))
+        t1 = self.table1.for_(SYSTEM_TIME.as_of('2020-01-01'))
+        query = (
+            Query.from_(t0)
+            .join(t1)
+            .on(t0.foo == t1.bar)
+            .select("*")
+        )
+
+        self.assertEqual(
+            'SELECT * FROM "abc" FOR SYSTEM_TIME AS OF \'2020-01-01\' '
+            'JOIN "efg" FOR SYSTEM_TIME AS OF \'2020-01-01\' '
+            'ON "abc"."foo"="efg"."bar"',
+            str(query)
         )
 
 

--- a/pypika/tests/test_selects.py
+++ b/pypika/tests/test_selects.py
@@ -334,7 +334,7 @@ class SelectTests(unittest.TestCase):
                 str(q)
             )
 
-        with self.subTest("with as of ALL"):
+        with self.subTest("with ALL"):
             q = Query.from_(t.for_(SYSTEM_TIME.all_())).select("*")
 
             self.assertEqual(
@@ -362,7 +362,7 @@ class SelectTests(unittest.TestCase):
                 str(q)
             )
 
-        with self.subTest("with period as of ALL"):
+        with self.subTest("with ALL"):
             q = Query.from_(t.for_(t.valid_period.all_())).select("*")
 
             self.assertEqual(

--- a/pypika/tests/test_selects.py
+++ b/pypika/tests/test_selects.py
@@ -21,7 +21,7 @@ from pypika import (
     Tables,
     VerticaQuery,
     functions as fn,
-    SYSTEM_TIME
+    SYSTEM_TIME,
 )
 from pypika.terms import ValueWrapper
 
@@ -306,66 +306,37 @@ class SelectTests(unittest.TestCase):
         with self.subTest("with system time as of"):
             q = Query.from_(t.for_(SYSTEM_TIME.as_of('2020-01-01'))).select("*")
 
-            self.assertEqual(
-                'SELECT * FROM "abc" FOR SYSTEM_TIME AS OF \'2020-01-01\'',
-                str(q)
-            )
+            self.assertEqual('SELECT * FROM "abc" FOR SYSTEM_TIME AS OF \'2020-01-01\'', str(q))
 
         with self.subTest("with system time between"):
-            q = Query.from_(
-                t.for_(SYSTEM_TIME.between('2020-01-01', '2020-02-01'))
-            ).select("*")
+            q = Query.from_(t.for_(SYSTEM_TIME.between('2020-01-01', '2020-02-01'))).select("*")
 
-            self.assertEqual(
-                'SELECT * FROM "abc" FOR SYSTEM_TIME BETWEEN \'2020-01-01\' AND \'2020-02-01\'',
-                str(q)
-            )
+            self.assertEqual('SELECT * FROM "abc" FOR SYSTEM_TIME BETWEEN \'2020-01-01\' AND \'2020-02-01\'', str(q))
 
         with self.subTest("with system time from to"):
-            q = Query.from_(
-                t.for_(SYSTEM_TIME.from_to('2020-01-01', '2020-02-01'))
-            ).select("*")
+            q = Query.from_(t.for_(SYSTEM_TIME.from_to('2020-01-01', '2020-02-01'))).select("*")
 
-            self.assertEqual(
-                'SELECT * FROM "abc" FOR SYSTEM_TIME FROM \'2020-01-01\' TO \'2020-02-01\'',
-                str(q)
-            )
+            self.assertEqual('SELECT * FROM "abc" FOR SYSTEM_TIME FROM \'2020-01-01\' TO \'2020-02-01\'', str(q))
 
         with self.subTest("with ALL"):
             q = Query.from_(t.for_(SYSTEM_TIME.all_())).select("*")
 
-            self.assertEqual(
-                'SELECT * FROM "abc" FOR SYSTEM_TIME ALL',
-                str(q)
-            )
+            self.assertEqual('SELECT * FROM "abc" FOR SYSTEM_TIME ALL', str(q))
 
         with self.subTest("with period between"):
-            q = Query.from_(
-                t.for_(t.valid_period.between('2020-01-01', '2020-02-01'))
-            ).select("*")
+            q = Query.from_(t.for_(t.valid_period.between('2020-01-01', '2020-02-01'))).select("*")
 
-            self.assertEqual(
-                'SELECT * FROM "abc" FOR "valid_period" BETWEEN \'2020-01-01\' AND \'2020-02-01\'',
-                str(q)
-            )
+            self.assertEqual('SELECT * FROM "abc" FOR "valid_period" BETWEEN \'2020-01-01\' AND \'2020-02-01\'', str(q))
 
         with self.subTest("with period from to"):
-            q = Query.from_(
-                t.for_(t.valid_period.from_to('2020-01-01', '2020-02-01'))
-            ).select("*")
+            q = Query.from_(t.for_(t.valid_period.from_to('2020-01-01', '2020-02-01'))).select("*")
 
-            self.assertEqual(
-                'SELECT * FROM "abc" FOR "valid_period" FROM \'2020-01-01\' TO \'2020-02-01\'',
-                str(q)
-            )
+            self.assertEqual('SELECT * FROM "abc" FOR "valid_period" FROM \'2020-01-01\' TO \'2020-02-01\'', str(q))
 
         with self.subTest("with ALL"):
             q = Query.from_(t.for_(t.valid_period.all_())).select("*")
 
-            self.assertEqual(
-                'SELECT * FROM "abc" FOR "valid_period" ALL',
-                str(q)
-            )
+            self.assertEqual('SELECT * FROM "abc" FOR "valid_period" ALL', str(q))
 
 
 class WhereTests(unittest.TestCase):

--- a/pypika/tests/test_selects.py
+++ b/pypika/tests/test_selects.py
@@ -21,6 +21,7 @@ from pypika import (
     Tables,
     VerticaQuery,
     functions as fn,
+    SYSTEM_TIME
 )
 from pypika.terms import ValueWrapper
 
@@ -301,6 +302,73 @@ class SelectTests(unittest.TestCase):
               self.table_abc.select(self.table_abc.foo)[10:10],
               Query.from_("abc").select("foo")[10:10],
         )
+
+    def test_temporal_select(self):
+        t = Table("abc")
+
+        with self.subTest("with system time as of"):
+            q = Query.from_(t.for_(SYSTEM_TIME.as_of('2020-01-01'))).select("*")
+
+            self.assertEqual(
+                'SELECT * FROM "abc" FOR SYSTEM_TIME AS OF \'2020-01-01\'',
+                str(q)
+            )
+
+        with self.subTest("with system time between"):
+            q = Query.from_(
+                t.for_(SYSTEM_TIME.between('2020-01-01', '2020-02-01'))
+            ).select("*")
+
+            self.assertEqual(
+                'SELECT * FROM "abc" FOR SYSTEM_TIME BETWEEN \'2020-01-01\' AND \'2020-02-01\'',
+                str(q)
+            )
+
+        with self.subTest("with system time from to"):
+            q = Query.from_(
+                t.for_(SYSTEM_TIME.from_to('2020-01-01', '2020-02-01'))
+            ).select("*")
+
+            self.assertEqual(
+                'SELECT * FROM "abc" FOR SYSTEM_TIME FROM \'2020-01-01\' TO \'2020-02-01\'',
+                str(q)
+            )
+
+        with self.subTest("with as of ALL"):
+            q = Query.from_(t.for_(SYSTEM_TIME.all_())).select("*")
+
+            self.assertEqual(
+                'SELECT * FROM "abc" FOR SYSTEM_TIME ALL',
+                str(q)
+            )
+
+        with self.subTest("with period between"):
+            q = Query.from_(
+                t.for_(t.valid_period.between('2020-01-01', '2020-02-01'))
+            ).select("*")
+
+            self.assertEqual(
+                'SELECT * FROM "abc" FOR "valid_period" BETWEEN \'2020-01-01\' AND \'2020-02-01\'',
+                str(q)
+            )
+
+        with self.subTest("with period from to"):
+            q = Query.from_(
+                t.for_(t.valid_period.from_to('2020-01-01', '2020-02-01'))
+            ).select("*")
+
+            self.assertEqual(
+                'SELECT * FROM "abc" FOR "valid_period" FROM \'2020-01-01\' TO \'2020-02-01\'',
+                str(q)
+            )
+
+        with self.subTest("with period as of ALL"):
+            q = Query.from_(t.for_(t.valid_period.all_())).select("*")
+
+            self.assertEqual(
+                'SELECT * FROM "abc" FOR "valid_period" ALL',
+                str(q)
+            )
 
 
 class WhereTests(unittest.TestCase):

--- a/pypika/tests/test_tables.py
+++ b/pypika/tests/test_tables.py
@@ -1,16 +1,7 @@
 # from pypika.terms import ValueWrapper, SystemTimeValue
 import unittest
 
-from pypika import (
-    Database,
-    Dialects,
-    Schema,
-    SQLLiteQuery,
-    Table,
-    Tables,
-    Query,
-    SYSTEM_TIME
-)
+from pypika import Database, Dialects, Schema, SQLLiteQuery, Table, Tables, Query, SYSTEM_TIME
 
 __author__ = "Timothy Heys"
 __email__ = "theys@kayak.com"
@@ -49,62 +40,38 @@ class TableStructureTests(unittest.TestCase):
 
     def test_table_for_system_time_sql(self):
         with self.subTest("with between criterion"):
-            table = Table("test_table").for_(
-                    SYSTEM_TIME.between('2020-01-01', '2020-02-01')
-            )
+            table = Table("test_table").for_(SYSTEM_TIME.between('2020-01-01', '2020-02-01'))
 
-            self.assertEqual(
-                '"test_table" FOR SYSTEM_TIME BETWEEN \'2020-01-01\' AND \'2020-02-01\'',
-                str(table))
+            self.assertEqual('"test_table" FOR SYSTEM_TIME BETWEEN \'2020-01-01\' AND \'2020-02-01\'', str(table))
 
         with self.subTest("with as of criterion"):
-            table = Table("test_table").for_(
-                    SYSTEM_TIME.as_of('2020-01-01')
-            )
+            table = Table("test_table").for_(SYSTEM_TIME.as_of('2020-01-01'))
 
-            self.assertEqual(
-                '"test_table" FOR SYSTEM_TIME AS OF \'2020-01-01\'',
-                str(table))
+            self.assertEqual('"test_table" FOR SYSTEM_TIME AS OF \'2020-01-01\'', str(table))
 
         with self.subTest("with from to criterion"):
-            table = Table("test_table").for_(
-                    SYSTEM_TIME.from_to('2020-01-01', '2020-02-01')
-            )
+            table = Table("test_table").for_(SYSTEM_TIME.from_to('2020-01-01', '2020-02-01'))
 
-            self.assertEqual(
-                '"test_table" FOR SYSTEM_TIME FROM \'2020-01-01\' TO \'2020-02-01\'',
-                str(table))
+            self.assertEqual('"test_table" FOR SYSTEM_TIME FROM \'2020-01-01\' TO \'2020-02-01\'', str(table))
 
     def test_table_for_period_sql(self):
         with self.subTest("with between criterion"):
             table = Table("test_table")
-            table = table.for_(
-                    table.valid_period.between('2020-01-01', '2020-02-01')
-            )
+            table = table.for_(table.valid_period.between('2020-01-01', '2020-02-01'))
 
-            self.assertEqual(
-                '"test_table" FOR "valid_period" BETWEEN \'2020-01-01\' AND \'2020-02-01\'',
-                str(table))
+            self.assertEqual('"test_table" FOR "valid_period" BETWEEN \'2020-01-01\' AND \'2020-02-01\'', str(table))
 
         with self.subTest("with as of criterion"):
             table = Table("test_table")
-            table = table.for_(
-                    table.valid_period.as_of('2020-01-01')
-            )
+            table = table.for_(table.valid_period.as_of('2020-01-01'))
 
-            self.assertEqual(
-                '"test_table" FOR "valid_period" AS OF \'2020-01-01\'',
-                str(table))
+            self.assertEqual('"test_table" FOR "valid_period" AS OF \'2020-01-01\'', str(table))
 
         with self.subTest("with from to criterion"):
             table = Table("test_table")
-            table = table.for_(
-                    table.valid_period.from_to('2020-01-01', '2020-02-01')
-            )
+            table = table.for_(table.valid_period.from_to('2020-01-01', '2020-02-01'))
 
-            self.assertEqual(
-                '"test_table" FOR "valid_period" FROM \'2020-01-01\' TO \'2020-02-01\'',
-                str(table))
+            self.assertEqual('"test_table" FOR "valid_period" FROM \'2020-01-01\' TO \'2020-02-01\'', str(table))
 
 
 class TableEqualityTests(unittest.TestCase):

--- a/pypika/tests/test_tables.py
+++ b/pypika/tests/test_tables.py
@@ -1,3 +1,4 @@
+# from pypika.terms import ValueWrapper, SystemTimeValue
 import unittest
 
 from pypika import (
@@ -8,6 +9,7 @@ from pypika import (
     Table,
     Tables,
     Query,
+    SYSTEM_TIME
 )
 
 __author__ = "Timothy Heys"
@@ -46,6 +48,65 @@ class TableStructureTests(unittest.TestCase):
         table = Table("test_table", schema=Schema("x_schema", parent=Database("x_db")))
 
         self.assertEqual('"x_db"."x_schema"."test_table"', str(table))
+
+    def test_table_for_system_time_sql(self):
+        with self.subTest("with between criterion"):
+            table = Table("test_table").for_(
+                    SYSTEM_TIME.between('2020-01-01', '2020-02-01')
+            )
+
+            self.assertEqual(
+                '"test_table" FOR SYSTEM_TIME BETWEEN \'2020-01-01\' AND \'2020-02-01\'',
+                str(table))
+
+        with self.subTest("with as of criterion"):
+            table = Table("test_table").for_(
+                    SYSTEM_TIME.as_of('2020-01-01')
+            )
+
+            self.assertEqual(
+                '"test_table" FOR SYSTEM_TIME AS OF \'2020-01-01\'',
+                str(table))
+
+        with self.subTest("with from to criterion"):
+            table = Table("test_table").for_(
+                    SYSTEM_TIME.from_to('2020-01-01', '2020-02-01')
+            )
+
+            self.assertEqual(
+                '"test_table" FOR SYSTEM_TIME FROM \'2020-01-01\' TO \'2020-02-01\'',
+                str(table))
+
+    def test_table_for_period_sql(self):
+        with self.subTest("with between criterion"):
+            table = Table("test_table")
+            table = table.for_(
+                    table.valid_period.between('2020-01-01', '2020-02-01')
+            )
+
+            self.assertEqual(
+                '"test_table" FOR "valid_period" BETWEEN \'2020-01-01\' AND \'2020-02-01\'',
+                str(table))
+
+        with self.subTest("with as of criterion"):
+            table = Table("test_table")
+            table = table.for_(
+                    table.valid_period.as_of('2020-01-01')
+            )
+
+            self.assertEqual(
+                '"test_table" FOR "valid_period" AS OF \'2020-01-01\'',
+                str(table))
+
+        with self.subTest("with from to criterion"):
+            table = Table("test_table")
+            table = table.for_(
+                    table.valid_period.from_to('2020-01-01', '2020-02-01')
+            )
+
+            self.assertEqual(
+                '"test_table" FOR "valid_period" FROM \'2020-01-01\' TO \'2020-02-01\'',
+                str(table))
 
 
 class TableEqualityTests(unittest.TestCase):

--- a/pypika/tests/test_updates.py
+++ b/pypika/tests/test_updates.py
@@ -94,28 +94,25 @@ class UpdateTests(unittest.TestCase):
 
     def test_for_portion(self):
         with self.subTest("with system time"):
-            q = Query.update(
-                self.table_abc.for_portion(
-                    SYSTEM_TIME.from_to('2020-01-01', '2020-02-01')
-                )
-            ).set("foo", "bar")
+            q = Query.update(self.table_abc.for_portion(SYSTEM_TIME.from_to('2020-01-01', '2020-02-01'))).set(
+                "foo", "bar"
+            )
 
             self.assertEqual(
                 'UPDATE "abc" FOR PORTION OF SYSTEM_TIME FROM \'2020-01-01\' TO \'2020-02-01\' SET "foo"=\'bar\'',
-                str(q)
+                str(q),
             )
 
         with self.subTest("with column"):
             q = Query.update(
-                self.table_abc.for_portion(
-                    self.table_abc.valid_period.from_to('2020-01-01', '2020-02-01')
-                )
+                self.table_abc.for_portion(self.table_abc.valid_period.from_to('2020-01-01', '2020-02-01'))
             ).set("foo", "bar")
 
             self.assertEqual(
                 'UPDATE "abc" FOR PORTION OF "valid_period" FROM \'2020-01-01\' TO \'2020-02-01\' SET "foo"=\'bar\'',
-                str(q)
+                str(q),
             )
+
 
 class PostgresUpdateTests(unittest.TestCase):
     table_abc = Table("abc")

--- a/pypika/tests/test_updates.py
+++ b/pypika/tests/test_updates.py
@@ -1,6 +1,6 @@
 import unittest
 
-from pypika import Table, Query, PostgreSQLQuery, AliasedQuery, SQLLiteQuery
+from pypika import Table, Query, PostgreSQLQuery, AliasedQuery, SQLLiteQuery, SYSTEM_TIME
 
 __author__ = "Timothy Heys"
 __email__ = "theys@kayak.com"
@@ -92,6 +92,30 @@ class UpdateTests(unittest.TestCase):
             str(q)
         )
 
+    def test_for_portion(self):
+        with self.subTest("with system time"):
+            q = Query.update(
+                self.table_abc.for_portion(
+                    SYSTEM_TIME.from_to('2020-01-01', '2020-02-01')
+                )
+            ).set("foo", "bar")
+
+            self.assertEqual(
+                'UPDATE "abc" FOR PORTION OF SYSTEM_TIME FROM \'2020-01-01\' TO \'2020-02-01\' SET "foo"=\'bar\'',
+                str(q)
+            )
+
+        with self.subTest("with column"):
+            q = Query.update(
+                self.table_abc.for_portion(
+                    self.table_abc.valid_period.from_to('2020-01-01', '2020-02-01')
+                )
+            ).set("foo", "bar")
+
+            self.assertEqual(
+                'UPDATE "abc" FOR PORTION OF "valid_period" FROM \'2020-01-01\' TO \'2020-02-01\' SET "foo"=\'bar\'',
+                str(q)
+            )
 
 class PostgresUpdateTests(unittest.TestCase):
     table_abc = Table("abc")


### PR DESCRIPTION
I've added support for temporal table querying. I built this on top of my previous pull request BTW :(

I'm not sure how close this is to how you would like it done.

There are a bunch of examples in the README/tutorial near the bottom. The approach I've taken is to add the criteria to the `Table`. Here's an example:

```python
t = Table("abc")
q = Query.from_(t.for_(SYSTEM_TIME.as_of('2020-01-01'))).select("*")
```

This produces:

```sql
'SELECT * FROM "abc" FOR SYSTEM_TIME AS OF '2020-01-01'
```

There is support for all the valid operations including `UPDATE` and `DELETE`.

A side affect of applying the criteria to the `Table` is that joins are also supported.

Rob