### PR TITLE
Drop Python 3.5 support and added Black to requirements and Github Actions

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,0 +1,11 @@
+name: Lint
+
+on: [push, pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - uses: psf/black@stable

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8]
 
     steps:
       - uses: actions/checkout@v1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 
 python:
-    - "3.5"
     - "3.6"
     - "3.7"
     - "3.8"

--- a/README.rst
+++ b/README.rst
@@ -1133,7 +1133,7 @@ This produces:
 License
 -------
 
-Copyright 2016 KAYAK Germany, GmbH
+Copyright 2020 KAYAK Germany, GmbH
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ Installation
 
 .. _installation_start:
 
-|Brand| supports python ``3.5+``.  It may also work on pypy, cython, and jython, but is not being tested for these versions.
+|Brand| supports python ``3.6+``.  It may also work on pypy, cython, and jython, but is not being tested for these versions.
 
 To install |Brand| run the following command:
 

--- a/pypika/clickhouse/array.py
+++ b/pypika/clickhouse/array.py
@@ -9,9 +9,7 @@ from pypika.utils import format_alias_sql
 
 
 class Array(Term):
-    def __init__(
-          self, values: list, converter_cls=None, converter_options: dict = None, alias: str = None
-    ):
+    def __init__(self, values: list, converter_cls=None, converter_options: dict = None, alias: str = None):
         super().__init__(alias)
         self._values = values
         self._converter_cls = converter_cls
@@ -33,11 +31,11 @@ class Array(Term):
 
 class HasAny(Function):
     def __init__(
-          self,
-          left_array: Array or Field,
-          right_array: Array or Field,
-          alias: str = None,
-          schema: str = None,
+        self,
+        left_array: Array or Field,
+        right_array: Array or Field,
+        alias: str = None,
+        schema: str = None,
     ):
         self._left_array = left_array
         self._right_array = right_array
@@ -46,20 +44,13 @@ class HasAny(Function):
         self.args = ()
         self.name = "hasAny"
 
-    def get_sql(
-          self,
-          with_alias=False,
-          with_namespace=False,
-          quote_char=None,
-          dialect=None,
-          **kwargs
-    ):
+    def get_sql(self, with_alias=False, with_namespace=False, quote_char=None, dialect=None, **kwargs):
         left = self._left_array.get_sql()
         right = self._right_array.get_sql()
         sql = "{name}({left},{right})".format(
-              name=self.name,
-              left='"%s"' % left if isinstance(self._left_array, Field) else left,
-              right='"%s"' % right if isinstance(self._right_array, Field) else right,
+            name=self.name,
+            left='"%s"' % left if isinstance(self._left_array, Field) else left,
+            right='"%s"' % right if isinstance(self._right_array, Field) else right,
         )
         return format_alias_sql(sql, self.alias, **kwargs)
 
@@ -71,17 +62,11 @@ class _AbstractArrayFunction(Function, metaclass=abc.ABCMeta):
         self.name = self.clickhouse_function()
         self._array = array
 
-    def get_sql(
-          self,
-          with_namespace=False,
-          quote_char=None,
-          dialect=None,
-          **kwargs
-    ):
+    def get_sql(self, with_namespace=False, quote_char=None, dialect=None, **kwargs):
         array = self._array.get_sql()
         sql = "{name}({array})".format(
-              name=self.name,
-              array='"%s"' % array if isinstance(self._array, Field) else array,
+            name=self.name,
+            array='"%s"' % array if isinstance(self._array, Field) else array,
         )
         return format_alias_sql(sql, self.alias, **kwargs)
 

--- a/pypika/clickhouse/search_string.py
+++ b/pypika/clickhouse/search_string.py
@@ -6,9 +6,7 @@ from pypika.utils import format_alias_sql
 
 class _AbstractSearchString(Function, metaclass=abc.ABCMeta):
     def __init__(self, name, pattern: str, alias: str = None):
-        super(_AbstractSearchString, self).__init__(
-              self.clickhouse_function(), name, alias=alias
-        )
+        super(_AbstractSearchString, self).__init__(self.clickhouse_function(), name, alias=alias)
 
         self._pattern = pattern
 
@@ -17,29 +15,18 @@ class _AbstractSearchString(Function, metaclass=abc.ABCMeta):
     def clickhouse_function(cls) -> str:
         pass
 
-    def get_sql(
-          self,
-          with_alias=False,
-          with_namespace=False,
-          quote_char=None,
-          dialect=None,
-          **kwargs
-    ):
+    def get_sql(self, with_alias=False, with_namespace=False, quote_char=None, dialect=None, **kwargs):
         args = []
         for p in self.args:
             if hasattr(p, "get_sql"):
-                args.append(
-                      'toString("{arg}")'.format(
-                            arg=p.get_sql(with_alias=False, **kwargs)
-                      )
-                )
+                args.append('toString("{arg}")'.format(arg=p.get_sql(with_alias=False, **kwargs)))
             else:
                 args.append(str(p))
 
         sql = "{name}({args},'{pattern}')".format(
-              name=self.name,
-              args=",".join(args),
-              pattern=self._pattern,
+            name=self.name,
+            args=",".join(args),
+            pattern=self._pattern,
         )
         return format_alias_sql(sql, self.alias, **kwargs)
 
@@ -64,9 +51,7 @@ class NotLike(_AbstractSearchString):
 
 class _AbstractMultiSearchString(Function, metaclass=abc.ABCMeta):
     def __init__(self, name, patterns: list, alias: str = None):
-        super(_AbstractMultiSearchString, self).__init__(
-              self.clickhouse_function(), name, alias=alias
-        )
+        super(_AbstractMultiSearchString, self).__init__(self.clickhouse_function(), name, alias=alias)
 
         self._patterns = patterns
 
@@ -75,29 +60,18 @@ class _AbstractMultiSearchString(Function, metaclass=abc.ABCMeta):
     def clickhouse_function(cls) -> str:
         pass
 
-    def get_sql(
-          self,
-          with_alias=False,
-          with_namespace=False,
-          quote_char=None,
-          dialect=None,
-          **kwargs
-    ):
+    def get_sql(self, with_alias=False, with_namespace=False, quote_char=None, dialect=None, **kwargs):
         args = []
         for p in self.args:
             if hasattr(p, "get_sql"):
-                args.append(
-                      'toString("{arg}")'.format(
-                            arg=p.get_sql(with_alias=False, **kwargs)
-                      )
-                )
+                args.append('toString("{arg}")'.format(arg=p.get_sql(with_alias=False, **kwargs)))
             else:
                 args.append(str(p))
 
         sql = "{name}({args},[{patterns}])".format(
-              name=self.name,
-              args=",".join(args),
-              patterns=",".join(["'%s'" % i for i in self._patterns]),
+            name=self.name,
+            args=",".join(args),
+            patterns=",".join(["'%s'" % i for i in self._patterns]),
         )
         return format_alias_sql(sql, self.alias, **kwargs)
 

--- a/pypika/clickhouse/type_conversion.py
+++ b/pypika/clickhouse/type_conversion.py
@@ -19,20 +19,11 @@ class ToFixedString(Function):
         self.schema = schema
         self.args = ()
 
-    def get_sql(
-          self,
-          with_alias=False,
-          with_namespace=False,
-          quote_char=None,
-          dialect=None,
-          **kwargs
-    ):
+    def get_sql(self, with_alias=False, with_namespace=False, quote_char=None, dialect=None, **kwargs):
         sql = "{name}({field},{length})".format(
-              name=self.name,
-              field=self._field
-              if isinstance(self._field, Field)
-              else "'%s'" % str(self._field),
-              length=self._length,
+            name=self.name,
+            field=self._field if isinstance(self._field, Field) else "'%s'" % str(self._field),
+            length=self._length,
         )
         return format_alias_sql(sql, self.alias, **kwargs)
 

--- a/pypika/dialects.py
+++ b/pypika/dialects.py
@@ -1,5 +1,5 @@
 from copy import copy
-from typing import Any, List, Union, Optional
+from typing import Any, Optional, Union
 
 from pypika.enums import Dialects
 from pypika.queries import (
@@ -8,16 +8,7 @@ from pypika.queries import (
     QueryBuilder,
     Table,
 )
-from pypika.terms import (
-    ArithmeticExpression,
-    EmptyCriterion,
-    Field,
-    Function,
-    Star,
-    Term,
-    ValueWrapper,
-    Criterion,
-)
+from pypika.terms import ArithmeticExpression, Criterion, EmptyCriterion, Field, Function, Star, Term, ValueWrapper
 from pypika.utils import (
     QueryException,
     builder,
@@ -30,9 +21,7 @@ class SnowFlakeQueryBuilder(QueryBuilder):
     QUERY_ALIAS_QUOTE_CHAR = ''
 
     def __init__(self, **kwargs: Any) -> None:
-        super().__init__(
-              dialect=Dialects.SNOWFLAKE, **kwargs
-        )
+        super().__init__(dialect=Dialects.SNOWFLAKE, **kwargs)
 
 
 class SnowflakeQuery(Query):
@@ -49,9 +38,7 @@ class MySQLQueryBuilder(QueryBuilder):
     QUOTE_CHAR = "`"
 
     def __init__(self, **kwargs: Any) -> None:
-        super().__init__(
-              dialect=Dialects.MYSQL, wrap_set_operation_queries=False, **kwargs
-        )
+        super().__init__(dialect=Dialects.MYSQL, wrap_set_operation_queries=False, **kwargs)
         self._duplicate_updates = []
         self._ignore_duplicates = False
         self._modifiers = []
@@ -89,12 +76,10 @@ class MySQLQueryBuilder(QueryBuilder):
 
     def _on_duplicate_key_update_sql(self, **kwargs: Any) -> str:
         return " ON DUPLICATE KEY UPDATE {updates}".format(
-              updates=",".join(
-                    "{field}={value}".format(
-                          field=field.get_sql(**kwargs), value=value.get_sql(**kwargs)
-                    )
-                    for field, value in self._duplicate_updates
-              )
+            updates=",".join(
+                "{field}={value}".format(field=field.get_sql(**kwargs), value=value.get_sql(**kwargs))
+                for field, value in self._duplicate_updates
+            )
         )
 
     def _on_duplicate_key_ignore_sql(self) -> str:
@@ -116,12 +101,9 @@ class MySQLQueryBuilder(QueryBuilder):
         with the addition of the a modifier if present.
         """
         return "SELECT {distinct}{modifier}{select}".format(
-              distinct="DISTINCT " if self._distinct else "",
-              modifier="{} ".format(" ".join(self._modifiers)) if self._modifiers else "",
-              select=",".join(
-                    term.get_sql(with_alias=True, subquery=True, **kwargs)
-                    for term in self._selects
-              ),
+            distinct="DISTINCT " if self._distinct else "",
+            modifier="{} ".format(" ".join(self._modifiers)) if self._modifiers else "",
+            select=",".join(term.get_sql(with_alias=True, subquery=True, **kwargs) for term in self._selects),
         )
 
 
@@ -187,9 +169,7 @@ class VerticaQueryBuilder(QueryBuilder):
         sql = super().get_sql(*args, **kwargs)
 
         if self._hint is not None:
-            sql = "".join(
-                  [sql[:7], "/*+label({hint})*/".format(hint=self._hint), sql[6:]]
-            )
+            sql = "".join([sql[:7], "/*+label({hint})*/".format(hint=self._hint), sql[6:]])
 
         return sql
 
@@ -216,9 +196,9 @@ class VerticaCreateQueryBuilder(CreateQueryBuilder):
 
     def _create_table_sql(self, **kwargs: Any) -> str:
         return "CREATE {local}{temporary}TABLE {table}".format(
-              local="LOCAL " if self._local else "",
-              temporary="TEMPORARY " if self._temporary else "",
-              table=self._create_table.get_sql(**kwargs),
+            local="LOCAL " if self._local else "",
+            temporary="TEMPORARY " if self._temporary else "",
+            table=self._create_table.get_sql(**kwargs),
         )
 
     def _table_options_sql(self, **kwargs) -> str:
@@ -228,8 +208,8 @@ class VerticaCreateQueryBuilder(CreateQueryBuilder):
 
     def _as_select_sql(self, **kwargs: Any) -> str:
         return "{preserve_rows} AS ({query})".format(
-              preserve_rows=self._preserve_rows_sql(),
-              query=self._as_select.get_sql(**kwargs),
+            preserve_rows=self._preserve_rows_sql(),
+            query=self._as_select.get_sql(**kwargs),
         )
 
     def _preserve_rows_sql(self) -> str:
@@ -294,9 +274,7 @@ class OracleQueryBuilder(QueryBuilder):
         super().__init__(dialect=Dialects.ORACLE, **kwargs)
 
     def get_sql(self, *args: Any, **kwargs: Any) -> str:
-        return super().get_sql(
-              *args, groupby_alias=False, **kwargs
-        )
+        return super().get_sql(*args, groupby_alias=False, **kwargs)
 
 
 class OracleQuery(Query):
@@ -403,9 +381,7 @@ class PostgreQueryBuilder(QueryBuilder):
     def _distinct_sql(self, **kwargs: Any) -> str:
         if self._distinct_on:
             return "DISTINCT ON({distinct_on}) ".format(
-                  distinct_on=",".join(
-                        term.get_sql(with_alias=True, **kwargs) for term in self._distinct_on
-                  )
+                distinct_on=",".join(term.get_sql(with_alias=True, **kwargs) for term in self._distinct_on)
             )
         return super()._distinct_sql(**kwargs)
 
@@ -424,14 +400,11 @@ class PostgreQueryBuilder(QueryBuilder):
 
         conflict_query = " ON CONFLICT"
         if self._on_conflict_fields:
-            fields = [f.get_sql(with_alias=True, **kwargs)
-                      for f in self._on_conflict_fields]
+            fields = [f.get_sql(with_alias=True, **kwargs) for f in self._on_conflict_fields]
             conflict_query += " (" + ', '.join(fields) + ")"
 
         if self._on_conflict_wheres:
-            conflict_query += " WHERE {where}".format(
-                  where=self._on_conflict_wheres.get_sql(subquery=True, **kwargs)
-            )
+            conflict_query += " WHERE {where}".format(where=self._on_conflict_wheres.get_sql(subquery=True, **kwargs))
 
         return conflict_query
 
@@ -442,20 +415,24 @@ class PostgreQueryBuilder(QueryBuilder):
             updates = []
             for field, value in self._on_conflict_do_updates:
                 if value:
-                    updates.append("{field}={value}".format(
-                        field=field.get_sql(**kwargs),
-                        value=value.get_sql(with_namespace=True, **kwargs),
-                    ))
+                    updates.append(
+                        "{field}={value}".format(
+                            field=field.get_sql(**kwargs),
+                            value=value.get_sql(with_namespace=True, **kwargs),
+                        )
+                    )
                 else:
-                    updates.append("{field}=EXCLUDED.{value}".format(
-                        field=field.get_sql(**kwargs),
-                        value=field.get_sql(**kwargs),
-                    ))
+                    updates.append(
+                        "{field}=EXCLUDED.{value}".format(
+                            field=field.get_sql(**kwargs),
+                            value=field.get_sql(**kwargs),
+                        )
+                    )
             action_sql = " DO UPDATE SET {updates}".format(updates=",".join(updates))
 
             if self._on_conflict_do_update_wheres:
                 action_sql += " WHERE {where}".format(
-                      where=self._on_conflict_do_update_wheres.get_sql(subquery=True, with_namespace=True, **kwargs)
+                    where=self._on_conflict_do_update_wheres.get_sql(subquery=True, with_namespace=True, **kwargs)
                 )
             return action_sql
 
@@ -479,16 +456,11 @@ class PostgreQueryBuilder(QueryBuilder):
         for field in term.fields_():
             if not any([self._insert_table, self._update_table, self._delete_from]):
                 raise QueryException("Returning can't be used in this query")
-            if (
-                  field.table not in {self._insert_table, self._update_table}
-                  and term not in self._from
-            ):
+            if field.table not in {self._insert_table, self._update_table} and term not in self._from:
                 raise QueryException("You can't return from other tables")
 
     def _set_returns_for_star(self) -> None:
-        self._returns = [
-            returning for returning in self._returns if not hasattr(returning, "table")
-        ]
+        self._returns = [returning for returning in self._returns if not hasattr(returning, "table")]
         self._return_star = True
 
     def _return_field(self, term: Union[str, Field]) -> None:
@@ -524,17 +496,13 @@ class PostgreQueryBuilder(QueryBuilder):
 
     def _returning_sql(self, **kwargs: Any) -> str:
         return " RETURNING {returning}".format(
-              returning=",".join(
-                    term.get_sql(with_alias=True, **kwargs) for term in self._returns
-              ),
+            returning=",".join(term.get_sql(with_alias=True, **kwargs) for term in self._returns),
         )
 
     def get_sql(self, with_alias: bool = False, subquery: bool = False, **kwargs: Any) -> str:
         self._set_kwargs_defaults(kwargs)
 
-        querystring = super(PostgreQueryBuilder, self).get_sql(
-              with_alias, subquery, **kwargs
-        )
+        querystring = super(PostgreQueryBuilder, self).get_sql(with_alias, subquery, **kwargs)
 
         querystring += self._on_conflict_sql(**kwargs)
         querystring += self._on_conflict_action_sql(**kwargs)
@@ -607,9 +575,7 @@ class MSSQLQueryBuilder(QueryBuilder):
         return querystring
 
     def get_sql(self, *args: Any, **kwargs: Any) -> str:
-        return super().get_sql(
-            *args, groupby_alias=False, **kwargs
-        )
+        return super().get_sql(*args, groupby_alias=False, **kwargs)
 
     def _top_sql(self) -> str:
         if self._top:
@@ -619,12 +585,9 @@ class MSSQLQueryBuilder(QueryBuilder):
 
     def _select_sql(self, **kwargs: Any) -> str:
         return "SELECT {distinct}{top}{select}".format(
-              top=self._top_sql(),
-              distinct="DISTINCT " if self._distinct else "",
-              select=",".join(
-                    term.get_sql(with_alias=True, subquery=True, **kwargs)
-                    for term in self._selects
-              ),
+            top=self._top_sql(),
+            distinct="DISTINCT " if self._distinct else "",
+            select=",".join(term.get_sql(with_alias=True, subquery=True, **kwargs) for term in self._selects),
         )
 
 
@@ -639,7 +602,6 @@ class MSSQLQuery(Query):
 
 
 class ClickHouseQueryBuilder(QueryBuilder):
-
     @staticmethod
     def _delete_sql(**kwargs: Any) -> str:
         return 'ALTER TABLE'
@@ -648,17 +610,10 @@ class ClickHouseQueryBuilder(QueryBuilder):
         return "ALTER TABLE {table}".format(table=self._update_table.get_sql(**kwargs))
 
     def _from_sql(self, with_namespace: bool = False, **kwargs: Any) -> str:
-        selectable = ",".join(
-            clause.get_sql(subquery=True, with_alias=True, **kwargs)
-            for clause in self._from
-        )
+        selectable = ",".join(clause.get_sql(subquery=True, with_alias=True, **kwargs) for clause in self._from)
         if self._delete_from:
-            return " {selectable} DELETE".format(
-                selectable=selectable
-            )
-        return " FROM {selectable}".format(
-            selectable=selectable
-        )
+            return " {selectable} DELETE".format(selectable=selectable)
+        return " FROM {selectable}".format(selectable=selectable)
 
     def _set_sql(self, **kwargs: Any) -> str:
         return " UPDATE {set}".format(
@@ -675,9 +630,12 @@ class ClickHouseQuery(Query):
     """
     Defines a query class for use with Yandex ClickHouse.
     """
+
     @classmethod
     def _builder(cls, **kwargs: Any) -> QueryBuilder:
-        return ClickHouseQueryBuilder(dialect=Dialects.CLICKHOUSE, wrap_set_operation_queries=False, as_keyword=True, **kwargs)
+        return ClickHouseQueryBuilder(
+            dialect=Dialects.CLICKHOUSE, wrap_set_operation_queries=False, as_keyword=True, **kwargs
+        )
 
 
 class SQLLiteValueWrapper(ValueWrapper):
@@ -694,6 +652,4 @@ class SQLLiteQuery(Query):
 
     @classmethod
     def _builder(cls, **kwargs: Any) -> QueryBuilder:
-        return QueryBuilder(
-              dialect=Dialects.SQLLITE, wrapper_cls=SQLLiteValueWrapper, **kwargs
-        )
+        return QueryBuilder(dialect=Dialects.SQLLITE, wrapper_cls=SQLLiteValueWrapper, **kwargs)

--- a/pypika/functions.py
+++ b/pypika/functions.py
@@ -96,15 +96,11 @@ class Floor(Function):
 
 class ApproximatePercentile(AggregateFunction):
     def __init__(self, term, percentile, alias=None):
-        super(ApproximatePercentile, self).__init__(
-            "APPROXIMATE_PERCENTILE", term, alias=alias
-        )
+        super(ApproximatePercentile, self).__init__("APPROXIMATE_PERCENTILE", term, alias=alias)
         self.percentile = float(percentile)
 
     def get_special_params_sql(self, **kwargs):
-        return "USING PARAMETERS percentile={percentile}".format(
-            percentile=self.percentile
-        )
+        return "USING PARAMETERS percentile={percentile}".format(percentile=self.percentile)
 
 
 # Type Functions
@@ -114,11 +110,7 @@ class Cast(Function):
         self.as_type = as_type
 
     def get_special_params_sql(self, **kwargs):
-        type_sql = (
-            self.as_type.get_sql(**kwargs)
-            if hasattr(self.as_type, "get_sql")
-            else str(self.as_type).upper()
-        )
+        type_sql = self.as_type.get_sql(**kwargs) if hasattr(self.as_type, "get_sql") else str(self.as_type).upper()
 
         return "AS {type}".format(type=type_sql)
 
@@ -154,9 +146,7 @@ class Date(Function):
 
 class DateDiff(Function):
     def __init__(self, interval, start_date, end_date, alias=None):
-        super(DateDiff, self).__init__(
-            "DATEDIFF", interval, start_date, end_date, alias=alias
-        )
+        super(DateDiff, self).__init__("DATEDIFF", interval, start_date, end_date, alias=alias)
 
 
 class TimeDiff(Function):
@@ -166,9 +156,7 @@ class TimeDiff(Function):
 
 class DateAdd(Function):
     def __init__(self, date_part, interval, term, alias=None):
-        super(DateAdd, self).__init__(
-            "DATE_ADD", date_part, interval, term, alias=alias
-        )
+        super(DateAdd, self).__init__("DATE_ADD", date_part, interval, term, alias=alias)
 
 
 class ToDate(Function):
@@ -183,9 +171,7 @@ class Timestamp(Function):
 
 class TimestampAdd(Function):
     def __init__(self, date_part, interval, term, alias=None):
-        super(TimestampAdd, self).__init__(
-            "TIMESTAMPADD", date_part, interval, term, alias=alias
-        )
+        super(TimestampAdd, self).__init__("TIMESTAMPADD", date_part, interval, term, alias=alias)
 
 
 # String Functions
@@ -247,23 +233,17 @@ class Trim(Function):
 
 class SplitPart(Function):
     def __init__(self, term, delimiter, index, alias=None):
-        super(SplitPart, self).__init__(
-            "SPLIT_PART", term, delimiter, index, alias=alias
-        )
+        super(SplitPart, self).__init__("SPLIT_PART", term, delimiter, index, alias=alias)
 
 
 class RegexpMatches(Function):
     def __init__(self, term, pattern, modifiers=None, alias=None):
-        super(RegexpMatches, self).__init__(
-            "REGEXP_MATCHES", term, pattern, modifiers, alias=alias
-        )
+        super(RegexpMatches, self).__init__("REGEXP_MATCHES", term, pattern, modifiers, alias=alias)
 
 
 class RegexpLike(Function):
     def __init__(self, term, pattern, modifiers=None, alias=None):
-        super(RegexpLike, self).__init__(
-            "REGEXP_LIKE", term, pattern, modifiers, alias=alias
-        )
+        super(RegexpLike, self).__init__("REGEXP_LIKE", term, pattern, modifiers, alias=alias)
 
 
 # Date/Time Functions

--- a/pypika/queries.py
+++ b/pypika/queries.py
@@ -1,18 +1,11 @@
 from copy import copy
 from functools import reduce
-from typing import (
-    Optional,
-    Any,
-    Union,
-    Type,
-    Sequence,
-    List,
-    Tuple as TypedTuple,
-)
+from typing import Any, List, Optional, Sequence, Tuple as TypedTuple, Type, Union
 
-from pypika.enums import JoinType, SetOperation, Dialects
+from pypika.enums import Dialects, JoinType, SetOperation
 from pypika.terms import (
     ArithmeticExpression,
+    Criterion,
     EmptyCriterion,
     Field,
     Function,
@@ -23,7 +16,6 @@ from pypika.terms import (
     Term,
     Tuple,
     ValueWrapper,
-    Criterion,
 )
 from pypika.utils import (
     JoinException,
@@ -91,11 +83,7 @@ class Schema:
         self._parent = parent
 
     def __eq__(self, other: "Schema") -> bool:
-        return (
-            isinstance(other, Schema)
-            and self._name == other._name
-            and self._parent == other._parent
-        )
+        return isinstance(other, Schema) and self._name == other._name and self._parent == other._parent
 
     def __ne__(self, other: "Schema") -> bool:
         return not self.__eq__(other)
@@ -131,14 +119,18 @@ class Table(Selectable):
         if isinstance(schema, Schema):
             return schema
         if isinstance(schema, (list, tuple)):
-            return reduce(
-                lambda obj, s: Schema(s, parent=obj), schema[1:], Schema(schema[0])
-            )
+            return reduce(lambda obj, s: Schema(s, parent=obj), schema[1:], Schema(schema[0]))
         if schema is not None:
             return Schema(schema)
         return None
 
-    def __init__(self, name: str, schema: Optional[Union[Schema, str]] = None, alias: Optional[str] = None, query_cls: Optional[Type["Query"]] = None) -> None:
+    def __init__(
+        self,
+        name: str,
+        schema: Optional[Union[Schema, str]] = None,
+        alias: Optional[str] = None,
+        query_cls: Optional[Type["Query"]] = None,
+    ) -> None:
         super().__init__(alias)
         self._table_name = name
         self._schema = self._init_schema(schema)
@@ -155,9 +147,7 @@ class Table(Selectable):
         table_sql = format_quotes(self._table_name, quote_char)
 
         if self._schema is not None:
-            table_sql = "{schema}.{table}".format(
-                schema=self._schema.get_sql(**kwargs), table=table_sql
-            )
+            table_sql = "{schema}.{table}".format(schema=self._schema.get_sql(**kwargs), table=table_sql)
 
         return format_alias_sql(table_sql, self.alias, **kwargs)
 
@@ -235,12 +225,15 @@ def make_tables(*names: Union[TypedTuple[str, str], str], **kwargs: Any) -> List
     for name in names:
         if isinstance(name, tuple) and len(name) == 2:
             t = Table(
-                name=name[0], alias=name[1], schema=kwargs.get("schema"),
+                name=name[0],
+                alias=name[1],
+                schema=kwargs.get("schema"),
                 query_cls=kwargs.get("query_cls"),
             )
         else:
             t = Table(
-                name=name, schema=kwargs.get("schema"),
+                name=name,
+                schema=kwargs.get("schema"),
                 query_cls=kwargs.get("query_cls"),
             )
         tables.append(t)
@@ -248,15 +241,14 @@ def make_tables(*names: Union[TypedTuple[str, str], str], **kwargs: Any) -> List
 
 
 class Column:
-    """Represents a column.
-    """
-    
+    """Represents a column."""
+
     def __init__(
-            self,
-            column_name: str,
-            column_type: Optional[str] = None,
-            nullable: Optional[bool] = None,
-            default: Optional[Term] = None
+        self,
+        column_name: str,
+        column_type: Optional[str] = None,
+        nullable: Optional[bool] = None,
+        default: Optional[Term] = None,
     ) -> None:
         self.name = column_name
         self.type = column_type
@@ -315,7 +307,7 @@ class PeriodFor:
         period_for_sql = "PERIOD FOR {name} ({start_column_name},{end_column_name})".format(
             name=format_quotes(self.name, quote_char),
             start_column_name=self.start_column.get_name_sql(**kwargs),
-            end_column_name=self.end_column.get_name_sql(**kwargs)
+            end_column_name=self.end_column.get_name_sql(**kwargs),
         )
 
         return period_for_sql
@@ -457,7 +449,12 @@ class _SetOperation(Selectable, Term):
     """
 
     def __init__(
-        self, base_query: "QueryBuilder", set_operation_query: "QueryBuilder", set_operation: SetOperation, alias: Optional[str] = None, wrapper_cls: Type[ValueWrapper] = ValueWrapper,
+        self,
+        base_query: "QueryBuilder",
+        set_operation_query: "QueryBuilder",
+        set_operation: SetOperation,
+        alias: Optional[str] = None,
+        wrapper_cls: Type[ValueWrapper] = ValueWrapper,
     ):
         super().__init__(alias)
         self.base_query = base_query
@@ -528,9 +525,7 @@ class _SetOperation(Selectable, Term):
         # This might be overridden if quote_char is set explicitly in kwargs
         kwargs.setdefault("quote_char", self.base_query.QUOTE_CHAR)
 
-        base_querystring = self.base_query.get_sql(
-            subquery=self.base_query.wrap_set_operation_queries, **kwargs
-        )
+        base_querystring = self.base_query.get_sql(subquery=self.base_query.wrap_set_operation_queries, **kwargs)
 
         querystring = base_querystring
         for set_operation, set_operation_query in self._set_operation:
@@ -563,9 +558,7 @@ class _SetOperation(Selectable, Term):
             querystring = "({query})".format(query=querystring, **kwargs)
 
         if with_alias:
-            return format_alias_sql(
-                querystring, self.alias or self._table_name, **kwargs
-            )
+            return format_alias_sql(querystring, self.alias or self._table_name, **kwargs)
 
         return querystring
 
@@ -588,9 +581,7 @@ class _SetOperation(Selectable, Term):
             )
 
             clauses.append(
-                "{term} {orient}".format(term=term, orient=directionality.value)
-                if directionality is not None
-                else term
+                "{term} {orient}".format(term=term, orient=directionality.value) if directionality is not None else term
             )
 
         return " ORDER BY {orderby}".format(orderby=",".join(clauses))
@@ -700,14 +691,9 @@ class QueryBuilder(Selectable, Term):
             A copy of the query with the table added.
         """
 
-        self._from.append(
-            Table(selectable) if isinstance(selectable, str) else selectable
-        )
+        self._from.append(Table(selectable) if isinstance(selectable, str) else selectable)
 
-        if (
-            isinstance(selectable, (QueryBuilder, _SetOperation))
-            and selectable.alias is None
-        ):
+        if isinstance(selectable, (QueryBuilder, _SetOperation)) and selectable.alias is None:
             if isinstance(selectable, QueryBuilder):
                 sub_query_count = selectable._subquery_count
             else:
@@ -730,53 +716,25 @@ class QueryBuilder(Selectable, Term):
         :return:
             A copy of the query with the tables replaced.
         """
-        self._from = [
-            new_table if table == current_table else table for table in self._from
-        ]
+        self._from = [new_table if table == current_table else table for table in self._from]
         self._insert_table = new_table if self._insert_table else None
         self._update_table = new_table if self._update_table else None
 
-        self._with = [
-            alias_query.replace_table(current_table, new_table)
-            for alias_query in self._with
-        ]
-        self._selects = [
-            select.replace_table(current_table, new_table) for select in self._selects
-        ]
-        self._columns = [
-            column.replace_table(current_table, new_table) for column in self._columns
-        ]
+        self._with = [alias_query.replace_table(current_table, new_table) for alias_query in self._with]
+        self._selects = [select.replace_table(current_table, new_table) for select in self._selects]
+        self._columns = [column.replace_table(current_table, new_table) for column in self._columns]
         self._values = [
-            [value.replace_table(current_table, new_table) for value in value_list]
-            for value_list in self._values
+            [value.replace_table(current_table, new_table) for value in value_list] for value_list in self._values
         ]
 
-        self._wheres = (
-            self._wheres.replace_table(current_table, new_table)
-            if self._wheres
-            else None
-        )
-        self._prewheres = (
-            self._prewheres.replace_table(current_table, new_table)
-            if self._prewheres
-            else None
-        )
-        self._groupbys = [
-            groupby.replace_table(current_table, new_table)
-            for groupby in self._groupbys
-        ]
-        self._havings = (
-            self._havings.replace_table(current_table, new_table)
-            if self._havings
-            else None
-        )
+        self._wheres = self._wheres.replace_table(current_table, new_table) if self._wheres else None
+        self._prewheres = self._prewheres.replace_table(current_table, new_table) if self._prewheres else None
+        self._groupbys = [groupby.replace_table(current_table, new_table) for groupby in self._groupbys]
+        self._havings = self._havings.replace_table(current_table, new_table) if self._havings else None
         self._orderbys = [
-            (orderby[0].replace_table(current_table, new_table), orderby[1])
-            for orderby in self._orderbys
+            (orderby[0].replace_table(current_table, new_table), orderby[1]) for orderby in self._orderbys
         ]
-        self._joins = [
-            join.replace_table(current_table, new_table) for join in self._joins
-        ]
+        self._joins = [join.replace_table(current_table, new_table) for join in self._joins]
 
         if current_table in self._select_star_tables:
             self._select_star_tables.remove(current_table)
@@ -807,9 +765,7 @@ class QueryBuilder(Selectable, Term):
             elif isinstance(term, (Function, ArithmeticExpression)):
                 self._select_other(term)
             else:
-                self._select_other(
-                    self.wrap_constant(term, wrapper_cls=self._wrapper_cls)
-                )
+                self._select_other(self.wrap_constant(term, wrapper_cls=self._wrapper_cls))
 
     @builder
     def delete(self) -> "QueryBuilder":
@@ -939,17 +895,13 @@ class QueryBuilder(Selectable, Term):
         if self._mysql_rollup:
             raise AttributeError("'Query' object has no attribute '%s'" % "rollup")
 
-        terms = [
-            Tuple(*term) if isinstance(term, (list, tuple, set)) else term
-            for term in terms
-        ]
+        terms = [Tuple(*term) if isinstance(term, (list, tuple, set)) else term for term in terms]
 
         if for_mysql:
             # MySQL rolls up all of the dimensions always
             if not terms and not self._groupbys:
                 raise RollupException(
-                    "At least one group is required. Call Query.groupby(term) or pass"
-                    "as parameter to rollup."
+                    "At least one group is required. Call Query.groupby(term) or pass" "as parameter to rollup."
                 )
 
             self._mysql_rollup = True
@@ -965,11 +917,7 @@ class QueryBuilder(Selectable, Term):
     @builder
     def orderby(self, *fields: Any, **kwargs: Any) -> "QueryBuilder":
         for field in fields:
-            field = (
-                Field(field, table=self._from[0])
-                if isinstance(field, str)
-                else self.wrap_constant(field)
-            )
+            field = Field(field, table=self._from[0]) if isinstance(field, str) else self.wrap_constant(field)
 
             self._orderbys.append((field, kwargs.get("order")))
 
@@ -1018,8 +966,7 @@ class QueryBuilder(Selectable, Term):
 
     @builder
     def union(self, other: "QueryBuilder") -> _SetOperation:
-        return _SetOperation(
-            self, other, SetOperation.union, wrapper_cls=self._wrapper_cls)
+        return _SetOperation(self, other, SetOperation.union, wrapper_cls=self._wrapper_cls)
 
     @builder
     def union_all(self, other: "QueryBuilder") -> _SetOperation:
@@ -1063,15 +1010,11 @@ class QueryBuilder(Selectable, Term):
 
     @staticmethod
     def _list_aliases(field_set: Sequence[Field], quote_char: Optional[str] = None) -> List[str]:
-        return [
-            field.alias or field.get_sql(quote_char=quote_char) for field in field_set
-        ]
+        return [field.alias or field.get_sql(quote_char=quote_char) for field in field_set]
 
     def _select_field_str(self, term: str) -> None:
         if 0 == len(self._from):
-            raise QueryException(
-                "Cannot select {term}, no FROM table specified.".format(term=term)
-            )
+            raise QueryException("Cannot select {term}, no FROM table specified.".format(term=term))
 
         if term == "*":
             self._select_star = True
@@ -1091,9 +1034,7 @@ class QueryBuilder(Selectable, Term):
 
         if isinstance(term, Star):
             self._selects = [
-                select
-                for select in self._selects
-                if not hasattr(select, "table") or term.table != select.table
+                select for select in self._selects if not hasattr(select, "table") or term.table != select.table
             ]
             self._select_star_tables.add(term.table)
 
@@ -1110,10 +1051,7 @@ class QueryBuilder(Selectable, Term):
         base_tables = self._from + [self._update_table] + self._with
         join.validate(base_tables, self._joins)
 
-        table_in_query = any(
-            isinstance(clause, Table) and join.item in base_tables
-            for clause in base_tables
-        )
+        table_in_query = any(isinstance(clause, Table) and join.item in base_tables for clause in base_tables)
         if isinstance(join.item, Table) and join.item.alias is None and table_in_query:
             # On the odd chance that we join the same table as the FROM table and don't set an alias
             # FIXME only works once
@@ -1158,12 +1096,7 @@ class QueryBuilder(Selectable, Term):
             terms = [terms]
 
         for values in terms:
-            self._values.append(
-                [
-                    value if isinstance(value, Term) else self.wrap_constant(value)
-                    for value in values
-                ]
-            )
+            self._values.append([value if isinstance(value, Term) else self.wrap_constant(value) for value in values])
 
     def __str__(self) -> str:
         return self.get_sql(dialect=self.dialect)
@@ -1195,12 +1128,7 @@ class QueryBuilder(Selectable, Term):
 
     def get_sql(self, with_alias: bool = False, subquery: bool = False, **kwargs: Any) -> str:
         self._set_kwargs_defaults(kwargs)
-        if not (
-            self._selects
-            or self._insert_table
-            or self._delete_from
-            or self._update_table
-        ):
+        if not (self._selects or self._insert_table or self._delete_from or self._update_table):
             return ""
         if self._insert_table and not (self._selects or self._values):
             return ""
@@ -1214,13 +1142,13 @@ class QueryBuilder(Selectable, Term):
         has_update_from = self._update_table and self._from
 
         kwargs["with_namespace"] = any(
-              [
-                  has_joins,
-                  has_multiple_from_clauses,
-                  has_subquery_from_clause,
-                  has_reference_to_foreign_table,
-                  has_update_from
-              ]
+            [
+                has_joins,
+                has_multiple_from_clauses,
+                has_subquery_from_clause,
+                has_reference_to_foreign_table,
+                has_update_from,
+            ]
         )
 
         if self._update_table:
@@ -1232,9 +1160,7 @@ class QueryBuilder(Selectable, Term):
             querystring += self._update_sql(**kwargs)
 
             if self._joins:
-                querystring += " " + " ".join(
-                    join.get_sql(**kwargs) for join in self._joins
-                )
+                querystring += " " + " ".join(join.get_sql(**kwargs) for join in self._joins)
 
             querystring += self._set_sql(**kwargs)
 
@@ -1293,9 +1219,7 @@ class QueryBuilder(Selectable, Term):
             querystring += self._use_index_sql(**kwargs)
 
         if self._joins:
-            querystring += " " + " ".join(
-                join.get_sql(**kwargs) for join in self._joins
-            )
+            querystring += " " + " ".join(join.get_sql(**kwargs) for join in self._joins)
 
         if self._prewheres:
             querystring += self._prewhere_sql(**kwargs)
@@ -1323,9 +1247,9 @@ class QueryBuilder(Selectable, Term):
             querystring = "({query})".format(query=querystring)
 
         if with_alias:
-            kwargs['alias_quote_char'] = (self.ALIAS_QUOTE_CHAR
-                                          if self.QUERY_ALIAS_QUOTE_CHAR is None
-                                          else self.QUERY_ALIAS_QUOTE_CHAR)
+            kwargs['alias_quote_char'] = (
+                self.ALIAS_QUOTE_CHAR if self.QUERY_ALIAS_QUOTE_CHAR is None else self.QUERY_ALIAS_QUOTE_CHAR
+            )
             return format_alias_sql(querystring, self.alias, **kwargs)
 
         return querystring
@@ -1341,10 +1265,7 @@ class QueryBuilder(Selectable, Term):
 
     def _with_sql(self, **kwargs: Any) -> str:
         return "WITH " + ",".join(
-            clause.name
-            + " AS ("
-            + clause.get_sql(subquery=False, with_alias=False, **kwargs)
-            + ") "
+            clause.name + " AS (" + clause.get_sql(subquery=False, with_alias=False, **kwargs) + ") "
             for clause in self._with
         )
 
@@ -1367,10 +1288,7 @@ class QueryBuilder(Selectable, Term):
     def _select_sql(self, **kwargs: Any) -> str:
         return "SELECT {distinct}{select}".format(
             distinct=self._distinct_sql(**kwargs),
-            select=",".join(
-                term.get_sql(with_alias=True, subquery=True, **kwargs)
-                for term in self._selects
-            ),
+            select=",".join(term.get_sql(with_alias=True, subquery=True, **kwargs) for term in self._selects),
         )
 
     def _insert_sql(self, **kwargs: Any) -> str:
@@ -1398,19 +1316,13 @@ class QueryBuilder(Selectable, Term):
             Remove from kwargs, never format the column terms with namespaces since only one table can be inserted into
         """
         return " ({columns})".format(
-            columns=",".join(
-                term.get_sql(with_namespace=False, **kwargs) for term in self._columns
-            )
+            columns=",".join(term.get_sql(with_namespace=False, **kwargs) for term in self._columns)
         )
 
     def _values_sql(self, **kwargs: Any) -> str:
         return " VALUES ({values})".format(
             values="),(".join(
-                ",".join(
-                    term.get_sql(with_alias=True, subquery=True, **kwargs)
-                    for term in row
-                )
-                for row in self._values
+                ",".join(term.get_sql(with_alias=True, subquery=True, **kwargs) for term in row) for row in self._values
             )
         )
 
@@ -1421,10 +1333,7 @@ class QueryBuilder(Selectable, Term):
 
     def _from_sql(self, with_namespace: bool = False, **kwargs: Any) -> str:
         return " FROM {selectable}".format(
-            selectable=",".join(
-                clause.get_sql(subquery=True, with_alias=True, **kwargs)
-                for clause in self._from
-            )
+            selectable=",".join(clause.get_sql(subquery=True, with_alias=True, **kwargs) for clause in self._from)
         )
 
     def _force_index_sql(self, **kwargs: Any) -> str:
@@ -1439,18 +1348,18 @@ class QueryBuilder(Selectable, Term):
 
     def _prewhere_sql(self, quote_char: Optional[str] = None, **kwargs: Any) -> str:
         return " PREWHERE {prewhere}".format(
-            prewhere=self._prewheres.get_sql(
-                quote_char=quote_char, subquery=True, **kwargs
-            )
+            prewhere=self._prewheres.get_sql(quote_char=quote_char, subquery=True, **kwargs)
         )
 
     def _where_sql(self, quote_char: Optional[str] = None, **kwargs: Any) -> str:
-        return " WHERE {where}".format(
-            where=self._wheres.get_sql(quote_char=quote_char, subquery=True, **kwargs)
-        )
+        return " WHERE {where}".format(where=self._wheres.get_sql(quote_char=quote_char, subquery=True, **kwargs))
 
     def _group_sql(
-        self, quote_char: Optional[str] = None, alias_quote_char: Optional[str] = None, groupby_alias: bool = True, **kwargs: Any
+        self,
+        quote_char: Optional[str] = None,
+        alias_quote_char: Optional[str] = None,
+        groupby_alias: bool = True,
+        **kwargs: Any,
     ) -> str:
         """
         Produces the GROUP BY part of the query.  This is a list of fields. The clauses are stored in the query under
@@ -1465,17 +1374,9 @@ class QueryBuilder(Selectable, Term):
         selected_aliases = {s.alias for s in self._selects}
         for field in self._groupbys:
             if groupby_alias and field.alias and field.alias in selected_aliases:
-                clauses.append(
-                    format_quotes(field.alias, alias_quote_char or quote_char)
-                )
+                clauses.append(format_quotes(field.alias, alias_quote_char or quote_char))
             else:
-                clauses.append(
-                    field.get_sql(
-                        quote_char=quote_char,
-                        alias_quote_char=alias_quote_char,
-                        **kwargs
-                    )
-                )
+                clauses.append(field.get_sql(quote_char=quote_char, alias_quote_char=alias_quote_char, **kwargs))
 
         sql = " GROUP BY {groupby}".format(groupby=",".join(clauses))
 
@@ -1485,7 +1386,11 @@ class QueryBuilder(Selectable, Term):
         return sql
 
     def _orderby_sql(
-        self, quote_char: Optional[str] = None, alias_quote_char: Optional[str] = None, orderby_alias: bool = True, **kwargs: Any
+        self,
+        quote_char: Optional[str] = None,
+        alias_quote_char: Optional[str] = None,
+        orderby_alias: bool = True,
+        **kwargs: Any,
     ) -> str:
         """
         Produces the ORDER BY part of the query.  This is a list of fields and possibly their directionality, ASC or
@@ -1503,15 +1408,11 @@ class QueryBuilder(Selectable, Term):
             term = (
                 format_quotes(field.alias, alias_quote_char or quote_char)
                 if orderby_alias and field.alias and field.alias in selected_aliases
-                else field.get_sql(
-                    quote_char=quote_char, alias_quote_char=alias_quote_char, **kwargs
-                )
+                else field.get_sql(quote_char=quote_char, alias_quote_char=alias_quote_char, **kwargs)
             )
 
             clauses.append(
-                "{term} {orient}".format(term=term, orient=directionality.value)
-                if directionality is not None
-                else term
+                "{term} {orient}".format(term=term, orient=directionality.value) if directionality is not None else term
             )
 
         return " ORDER BY {orderby}".format(orderby=",".join(clauses))
@@ -1520,9 +1421,7 @@ class QueryBuilder(Selectable, Term):
         return " WITH ROLLUP"
 
     def _having_sql(self, quote_char: Optional[str] = None, **kwargs: Any) -> str:
-        return " HAVING {having}".format(
-            having=self._havings.get_sql(quote_char=quote_char, **kwargs)
-        )
+        return " HAVING {having}".format(having=self._havings.get_sql(quote_char=quote_char, **kwargs))
 
     def _offset_sql(self) -> str:
         return " OFFSET {offset}".format(offset=self._offset)
@@ -1542,7 +1441,9 @@ class QueryBuilder(Selectable, Term):
 
 
 class Joiner:
-    def __init__(self, query: QueryBuilder, item: Union[Table, "QueryBuilder", AliasedQuery], how: JoinType, type_label: str) -> None:
+    def __init__(
+        self, query: QueryBuilder, item: Union[Table, "QueryBuilder", AliasedQuery], how: JoinType, type_label: str
+    ) -> None:
         self.query = query
         self.item = item
         self.how = how
@@ -1561,15 +1462,12 @@ class Joiner:
     def on_field(self, *fields: Any) -> QueryBuilder:
         if not fields:
             raise JoinException(
-                "Parameter 'fields' is required for a "
-                "{type} JOIN but was not supplied.".format(type=self.type_label)
+                "Parameter 'fields' is required for a " "{type} JOIN but was not supplied.".format(type=self.type_label)
             )
 
         criterion = None
         for field in fields:
-            consituent = Field(field, table=self.query._from[0]) == Field(
-                field, table=self.item
-            )
+            consituent = Field(field, table=self.query._from[0]) == Field(field, table=self.item)
             criterion = consituent if criterion is None else criterion & consituent
 
         self.query.do_join(JoinOn(self.item, self.how, criterion))
@@ -1582,9 +1480,7 @@ class Joiner:
                 "a using clause but was not supplied.".format(type=self.type_label)
             )
 
-        self.query.do_join(
-            JoinUsing(self.item, self.how, [Field(field) for field in fields])
-        )
+        self.query.do_join(JoinUsing(self.item, self.how, [Field(field) for field in fields]))
         return self.query
 
     def cross(self) -> QueryBuilder:
@@ -1601,7 +1497,7 @@ class Join:
 
     def get_sql(self, **kwargs: Any) -> str:
         sql = "JOIN {table}".format(
-              table=self.item.get_sql(subquery=True, with_alias=True, **kwargs),
+            table=self.item.get_sql(subquery=True, with_alias=True, **kwargs),
         )
 
         if self.how.value:
@@ -1699,9 +1595,7 @@ class JoinUsing(Join):
             A copy of the join with the tables replaced.
         """
         self.item = new_table if self.item == current_table else self.item
-        self.fields = [
-            field.replace_table(current_table, new_table) for field in self.fields
-        ]
+        self.fields = [field.replace_table(current_table, new_table) for field in self.fields]
 
 
 class CreateQueryBuilder:
@@ -1795,7 +1689,9 @@ class CreateQueryBuilder:
             self._columns.append(column)
 
     @builder
-    def period_for(self, name, start_column: Union[str, Column], end_column: Union[str, Column]) -> "CreateQueryBuilder":
+    def period_for(
+        self, name, start_column: Union[str, Column], end_column: Union[str, Column]
+    ) -> "CreateQueryBuilder":
         """
         Adds a PERIOD FOR clause.
 
@@ -1807,7 +1703,7 @@ class CreateQueryBuilder:
 
         :param end_column:
             The column that ends the period.
-        
+
         :return:
             CreateQueryBuilder.
         """
@@ -1822,14 +1718,11 @@ class CreateQueryBuilder:
             Type:  Union[str, TypedTuple[str, str], Column]
 
             A list of columns.
-        
+
         :return:
             CreateQueryBuilder.
         """
-        self._uniques.append([
-            (column if isinstance(column, Column) else Column(column))
-            for column in columns
-        ])
+        self._uniques.append([(column if isinstance(column, Column) else Column(column)) for column in columns])
 
     @builder
     def primary_key(self, *columns: Union[str, Column]) -> "CreateQueryBuilder":
@@ -1843,16 +1736,13 @@ class CreateQueryBuilder:
 
         :raises AttributeError:
             If the primary key is already defined.
-        
+
         :return:
             CreateQueryBuilder.
         """
         if self._primary_key:
             raise AttributeError("'Query' object already has attribute primary_key")
-        self._primary_key = [
-            (column if isinstance(column, Column) else Column(column))
-            for column in columns
-        ]
+        self._primary_key = [(column if isinstance(column, Column) else Column(column)) for column in columns]
 
     @builder
     def as_select(self, query_builder: QueryBuilder) -> "CreateQueryBuilder":
@@ -1864,7 +1754,7 @@ class CreateQueryBuilder:
 
         :raises AttributeError:
             If columns have been defined for the table.
-        
+
         :return:
             CreateQueryBuilder.
         """
@@ -1900,9 +1790,7 @@ class CreateQueryBuilder:
         table_options = self._table_options_sql(**kwargs)
 
         return "{create_table} ({body}){table_options}".format(
-            create_table=create_table,
-            body=body,
-            table_options=table_options
+            create_table=create_table, body=body, table_options=table_options
         )
 
     def _create_table_sql(self, **kwargs: Any) -> str:
@@ -1916,37 +1804,24 @@ class CreateQueryBuilder:
 
         if self._with_system_versioning:
             table_options += ' WITH SYSTEM VERSIONING'
-            
+
         return table_options
 
     def _column_clauses(self, **kwargs) -> List[str]:
-        return [
-            column.get_sql(**kwargs)
-            for column in self._columns
-        ]
+        return [column.get_sql(**kwargs) for column in self._columns]
 
     def _period_for_clauses(self, **kwargs) -> List[str]:
-        return [
-            period_for.get_sql(**kwargs)
-            for period_for in self._period_fors
-        ]
+        return [period_for.get_sql(**kwargs) for period_for in self._period_fors]
 
     def _unique_key_clauses(self, **kwargs) -> List[str]:
         return [
-            "UNIQUE ({unique})".format(
-                unique=",".join(
-                    column.get_name_sql(**kwargs)
-                    for column in unique)
-            )
+            "UNIQUE ({unique})".format(unique=",".join(column.get_name_sql(**kwargs) for column in unique))
             for unique in self._uniques
         ]
 
     def _primary_key_clause(self, **kwargs) -> str:
         return "PRIMARY KEY ({columns})".format(
-            columns=",".join(
-                column.get_name_sql(**kwargs)
-                for column in self._primary_key
-            )
+            columns=",".join(column.get_name_sql(**kwargs) for column in self._primary_key)
         )
 
     def _body_sql(self, **kwargs) -> str:
@@ -1961,7 +1836,9 @@ class CreateQueryBuilder:
         return ",".join(clauses)
 
     def _as_select_sql(self, **kwargs: Any) -> str:
-        return " AS ({query})".format(query=self._as_select.get_sql(**kwargs), )
+        return " AS ({query})".format(
+            query=self._as_select.get_sql(**kwargs),
+        )
 
     def __str__(self) -> str:
         return self.get_sql()

--- a/pypika/tests/clickhouse/test_array.py
+++ b/pypika/tests/clickhouse/test_array.py
@@ -18,21 +18,24 @@ from pypika.clickhouse.type_conversion import (
 
 class TestArray(unittest.TestCase):
     @parameterized.expand(
-          [
-              (
-                    "['ridley', 'scott', 'jimi', 'hendrix']",
-                    Array(["ridley", "scott", "jimi", "hendrix"]),
-              ),
-              ("[1, 2, 3, 4]", Array([1, 2, 3, 4]),),
-              (
-                    "[toInt64('1'),toInt64('2'),toInt64('3'),toInt64('4')]",
-                    Array(["1", "2", "3", "4"], ToInt64),
-              ),
-              (
-                    "[toFixedString('mogwai',10),toFixedString('mono',10),toFixedString('bonobo',10)] arr",
-                    Array(["mogwai", "mono", "bonobo"], ToFixedString, {"length": 10}).as_('arr'),
-              ),
-          ]
+        [
+            (
+                "['ridley', 'scott', 'jimi', 'hendrix']",
+                Array(["ridley", "scott", "jimi", "hendrix"]),
+            ),
+            (
+                "[1, 2, 3, 4]",
+                Array([1, 2, 3, 4]),
+            ),
+            (
+                "[toInt64('1'),toInt64('2'),toInt64('3'),toInt64('4')]",
+                Array(["1", "2", "3", "4"], ToInt64),
+            ),
+            (
+                "[toFixedString('mogwai',10),toFixedString('mono',10),toFixedString('bonobo',10)] arr",
+                Array(["mogwai", "mono", "bonobo"], ToFixedString, {"length": 10}).as_('arr'),
+            ),
+        ]
     )
     def test_get_sql(self, expected: str, array: Array):
         self.assertEqual(expected, array.get_sql())
@@ -40,20 +43,20 @@ class TestArray(unittest.TestCase):
 
 class TestHasAny(unittest.TestCase):
     @parameterized.expand(
-          [
-              (
-                    'hasAny("mental_abilities","physical_abilities")',
-                    HasAny(Field("mental_abilities"), Field("physical_abilities")),
-              ),
-              ("hasAny([1, 2, 3, 4],[3])", HasAny(Array([1, 2, 3, 4]), Array([3]))),
-              (
-                    "hasAny(\"bands\",[toFixedString('port-royal',20),toFixedString('hammock',20)])",
-                    HasAny(
-                          Field("bands"),
-                          Array(["port-royal", "hammock"], ToFixedString, {"length": 20}),
-                    ),
-              ),
-          ]
+        [
+            (
+                'hasAny("mental_abilities","physical_abilities")',
+                HasAny(Field("mental_abilities"), Field("physical_abilities")),
+            ),
+            ("hasAny([1, 2, 3, 4],[3])", HasAny(Array([1, 2, 3, 4]), Array([3]))),
+            (
+                "hasAny(\"bands\",[toFixedString('port-royal',20),toFixedString('hammock',20)])",
+                HasAny(
+                    Field("bands"),
+                    Array(["port-royal", "hammock"], ToFixedString, {"length": 20}),
+                ),
+            ),
+        ]
     )
     def test_get_sql(self, expected: str, func: HasAny):
         self.assertEqual(expected, func.get_sql())
@@ -61,10 +64,13 @@ class TestHasAny(unittest.TestCase):
 
 class TestLength(unittest.TestCase):
     @parameterized.expand(
-          [
-              ('length("tags")', Length(Field("tags")),),
-              ("length([1, 2, 3])", Length(Array([1, 2, 3]))),
-          ]
+        [
+            (
+                'length("tags")',
+                Length(Field("tags")),
+            ),
+            ("length([1, 2, 3])", Length(Array([1, 2, 3]))),
+        ]
     )
     def test_get_sql(self, expected: str, func: Length):
         self.assertEqual(expected, func.get_sql())
@@ -72,10 +78,13 @@ class TestLength(unittest.TestCase):
 
 class TestEmpty(unittest.TestCase):
     @parameterized.expand(
-          [
-              ('empty("tags")', Empty(Field("tags")),),
-              ("empty([1, 2, 3])", Empty(Array([1, 2, 3]))),
-          ]
+        [
+            (
+                'empty("tags")',
+                Empty(Field("tags")),
+            ),
+            ("empty([1, 2, 3])", Empty(Array([1, 2, 3]))),
+        ]
     )
     def test_get_sql(self, expected: str, func: Empty):
         self.assertEqual(expected, func.get_sql())
@@ -83,10 +92,13 @@ class TestEmpty(unittest.TestCase):
 
 class TestNotEmpty(unittest.TestCase):
     @parameterized.expand(
-          [
-              ('notEmpty("tags")', NotEmpty(Field("tags")),),
-              ("notEmpty([1, 2, 3])", NotEmpty(Array([1, 2, 3]))),
-          ]
+        [
+            (
+                'notEmpty("tags")',
+                NotEmpty(Field("tags")),
+            ),
+            ("notEmpty([1, 2, 3])", NotEmpty(Array([1, 2, 3]))),
+        ]
     )
     def test_get_sql(self, expected: str, func: NotEmpty):
         self.assertEqual(expected, func.get_sql())

--- a/pypika/tests/clickhouse/test_condition.py
+++ b/pypika/tests/clickhouse/test_condition.py
@@ -2,11 +2,9 @@ import unittest
 
 from parameterized import parameterized
 
-from pypika.clickhouse.condition import MultiIf
-from pypika.clickhouse.type_conversion import ToFixedString
-
 from pypika import Field
-from pypika.clickhouse.condition import If
+from pypika.clickhouse.condition import If, MultiIf
+from pypika.clickhouse.type_conversion import ToFixedString
 
 
 class TestIfCondition(unittest.TestCase):

--- a/pypika/tests/clickhouse/test_nullable_arg.py
+++ b/pypika/tests/clickhouse/test_nullable_arg.py
@@ -1,16 +1,19 @@
 import unittest
 
 from parameterized import parameterized
-from pypika.clickhouse.type_conversion import ToFixedString
 
 from pypika import Field
 from pypika.clickhouse.nullable_arg import IfNull
+from pypika.clickhouse.type_conversion import ToFixedString
 
 
 class TestSearchString(unittest.TestCase):
     @parameterized.expand(
         [
-            (IfNull(Field("name"), Field("login")), "ifNull(name,login)",),
+            (
+                IfNull(Field("name"), Field("login")),
+                "ifNull(name,login)",
+            ),
             (
                 IfNull(Field("builder"), ToFixedString("pypika", 100)),
                 "ifNull(builder,toFixedString('pypika',100))",

--- a/pypika/tests/clickhouse/test_type_conversion.py
+++ b/pypika/tests/clickhouse/test_type_conversion.py
@@ -2,44 +2,84 @@ import unittest
 
 from parameterized import parameterized
 
-from pypika import ClickHouseQuery
-from pypika import Field
-from pypika import Table
+from pypika import ClickHouseQuery, Field, Table
 from pypika.clickhouse.type_conversion import (
-    ToString,
-    ToInt8,
-    ToInt16,
-    ToInt32,
-    ToInt64,
-    ToUInt8,
-    ToUInt16,
-    ToUInt32,
-    ToUInt64,
-    ToFloat32,
-    ToFloat64,
     ToDate,
     ToDateTime,
     ToFixedString,
+    ToFloat32,
+    ToFloat64,
+    ToInt16,
+    ToInt32,
+    ToInt64,
+    ToInt8,
+    ToString,
+    ToUInt16,
+    ToUInt32,
+    ToUInt64,
+    ToUInt8,
 )
 
 
 class TestBasicTypeConverters(unittest.TestCase):
     @parameterized.expand(
         [
-            ('toString("field_name")', ToString(Field("field_name")),),
-            ('toInt8("field_name")', ToInt8(Field("field_name")),),
-            ('toInt16("field_name")', ToInt16(Field("field_name")),),
-            ('toInt32("field_name")', ToInt32(Field("field_name")),),
-            ('toInt64("field_name")', ToInt64(Field("field_name")),),
-            ('toUInt8("field_name")', ToUInt8(Field("field_name")),),
-            ('toUInt16("field_name")', ToUInt16(Field("field_name")),),
-            ('toUInt32("field_name")', ToUInt32(Field("field_name")),),
-            ('toUInt64("field_name")', ToUInt64(Field("field_name")),),
-            ('toFloat32("field_name")', ToFloat32(Field("field_name")),),
-            ('toFloat64("field_name")', ToFloat64(Field("field_name")),),
-            ('toFloat64("field_name")', ToFloat64(Field("field_name")),),
-            ('toDate("field_name")', ToDate(Field("field_name")),),
-            ('toDateTime("field_name")', ToDateTime(Field("field_name")),),
+            (
+                'toString("field_name")',
+                ToString(Field("field_name")),
+            ),
+            (
+                'toInt8("field_name")',
+                ToInt8(Field("field_name")),
+            ),
+            (
+                'toInt16("field_name")',
+                ToInt16(Field("field_name")),
+            ),
+            (
+                'toInt32("field_name")',
+                ToInt32(Field("field_name")),
+            ),
+            (
+                'toInt64("field_name")',
+                ToInt64(Field("field_name")),
+            ),
+            (
+                'toUInt8("field_name")',
+                ToUInt8(Field("field_name")),
+            ),
+            (
+                'toUInt16("field_name")',
+                ToUInt16(Field("field_name")),
+            ),
+            (
+                'toUInt32("field_name")',
+                ToUInt32(Field("field_name")),
+            ),
+            (
+                'toUInt64("field_name")',
+                ToUInt64(Field("field_name")),
+            ),
+            (
+                'toFloat32("field_name")',
+                ToFloat32(Field("field_name")),
+            ),
+            (
+                'toFloat64("field_name")',
+                ToFloat64(Field("field_name")),
+            ),
+            (
+                'toFloat64("field_name")',
+                ToFloat64(Field("field_name")),
+            ),
+            (
+                'toDate("field_name")',
+                ToDate(Field("field_name")),
+            ),
+            (
+                'toDateTime("field_name")',
+                ToDateTime(Field("field_name")),
+            ),
             (
                 'toFixedString("field_name",100)',
                 ToFixedString(Field("field_name"), 100),
@@ -51,21 +91,66 @@ class TestBasicTypeConverters(unittest.TestCase):
 
     @parameterized.expand(
         [
-            ("toString('100')", ToString("100"),),
-            ("toInt8('100')", ToInt8("100"),),
-            ("toInt16('100')", ToInt16("100"),),
-            ("toInt32('100')", ToInt32("100"),),
-            ("toInt64('100')", ToInt64("100"),),
-            ("toUInt8('100')", ToUInt8("100"),),
-            ("toUInt16('100')", ToUInt16("100"),),
-            ("toUInt32('100')", ToUInt32("100"),),
-            ("toUInt64('100')", ToUInt64("100"),),
-            ("toFloat32('100')", ToFloat32("100"),),
-            ("toFloat64('100')", ToFloat64("100"),),
-            ("toFloat64('100')", ToFloat64("100"),),
-            ("toDate('100')", ToDate("100"),),
-            ("toDateTime('100')", ToDateTime("100"),),
-            ("toFixedString('100',100)", ToFixedString("100", 100),),
+            (
+                "toString('100')",
+                ToString("100"),
+            ),
+            (
+                "toInt8('100')",
+                ToInt8("100"),
+            ),
+            (
+                "toInt16('100')",
+                ToInt16("100"),
+            ),
+            (
+                "toInt32('100')",
+                ToInt32("100"),
+            ),
+            (
+                "toInt64('100')",
+                ToInt64("100"),
+            ),
+            (
+                "toUInt8('100')",
+                ToUInt8("100"),
+            ),
+            (
+                "toUInt16('100')",
+                ToUInt16("100"),
+            ),
+            (
+                "toUInt32('100')",
+                ToUInt32("100"),
+            ),
+            (
+                "toUInt64('100')",
+                ToUInt64("100"),
+            ),
+            (
+                "toFloat32('100')",
+                ToFloat32("100"),
+            ),
+            (
+                "toFloat64('100')",
+                ToFloat64("100"),
+            ),
+            (
+                "toFloat64('100')",
+                ToFloat64("100"),
+            ),
+            (
+                "toDate('100')",
+                ToDate("100"),
+            ),
+            (
+                "toDateTime('100')",
+                ToDateTime("100"),
+            ),
+            (
+                "toFixedString('100',100)",
+                ToFixedString("100", 100),
+            ),
         ]
     )
     def test_basic_types_value(self, expected, func):
@@ -77,8 +162,12 @@ class TestToFixedString(unittest.TestCase):
         table = Table("example")
         query = (
             ClickHouseQuery.from_(table)
-            .select(table.name,)
-            .where(table.name == ToFixedString("name", 50),)
+            .select(
+                table.name,
+            )
+            .where(
+                table.name == ToFixedString("name", 50),
+            )
         )
 
         self.assertEqual(

--- a/pypika/tests/dialects/test_clickhouse.py
+++ b/pypika/tests/dialects/test_clickhouse.py
@@ -27,16 +27,8 @@ class ClickHouseDeleteTests(TestCase):
         self.assertEqual('ALTER TABLE "schema1"."abc" DELETE', str(q))
 
     def test_where_field_equals(self):
-        q1 = (
-            ClickHouseQuery.from_(self.table_abc)
-            .where(self.table_abc.foo == self.table_abc.bar)
-            .delete()
-        )
-        q2 = (
-            ClickHouseQuery.from_(self.table_abc)
-            .where(self.table_abc.foo.eq(self.table_abc.bar))
-            .delete()
-        )
+        q1 = ClickHouseQuery.from_(self.table_abc).where(self.table_abc.foo == self.table_abc.bar).delete()
+        q2 = ClickHouseQuery.from_(self.table_abc).where(self.table_abc.foo.eq(self.table_abc.bar)).delete()
 
         self.assertEqual('ALTER TABLE "abc" DELETE WHERE "foo"="bar"', str(q1))
         self.assertEqual('ALTER TABLE "abc" DELETE WHERE "foo"="bar"', str(q2))
@@ -46,10 +38,6 @@ class ClickHouseUpdateTests(TestCase):
     table_abc = Table("abc")
 
     def test_update(self):
-        q = (
-            ClickHouseQuery.update(self.table_abc).where(self.table_abc.foo == 0).set("foo", "bar")
-        )
+        q = ClickHouseQuery.update(self.table_abc).where(self.table_abc.foo == 0).set("foo", "bar")
 
-        self.assertEqual(
-            'ALTER TABLE "abc" UPDATE "foo"=\'bar\' WHERE "foo"=0', str(q)
-        )
+        self.assertEqual('ALTER TABLE "abc" UPDATE "foo"=\'bar\' WHERE "foo"=0', str(q))

--- a/pypika/tests/dialects/test_mysql.py
+++ b/pypika/tests/dialects/test_mysql.py
@@ -1,10 +1,6 @@
 import unittest
 
-from pypika import (
-    Table,
-    MySQLQuery,
-    QueryException,
-)
+from pypika import MySQLQuery, QueryException, Table
 
 
 class SelectTests(unittest.TestCase):
@@ -21,62 +17,33 @@ class SelectTests(unittest.TestCase):
         self.assertEqual("SELECT DISTINCT `def` FROM `abc`", str(q))
 
     def test_modifier_select(self):
-        q = (
-            MySQLQuery.from_("abc")
-            .select("def")
-            .select("ghi")
-            .modifier("SQL_CALC_FOUND_ROWS")
-        )
+        q = MySQLQuery.from_("abc").select("def").select("ghi").modifier("SQL_CALC_FOUND_ROWS")
 
         self.assertEqual("SELECT SQL_CALC_FOUND_ROWS `def`,`ghi` FROM `abc`", str(q))
 
     def test_multiple_modifier_select(self):
-        q = (
-            MySQLQuery.from_("abc")
-            .select("def")
-            .modifier("HIGH_PRIORITY")
-            .modifier("SQL_CALC_FOUND_ROWS")
-        )
+        q = MySQLQuery.from_("abc").select("def").modifier("HIGH_PRIORITY").modifier("SQL_CALC_FOUND_ROWS")
 
-        self.assertEqual(
-            "SELECT HIGH_PRIORITY SQL_CALC_FOUND_ROWS `def` FROM `abc`", str(q)
-        )
+        self.assertEqual("SELECT HIGH_PRIORITY SQL_CALC_FOUND_ROWS `def` FROM `abc`", str(q))
 
 
 class UpdateTests(unittest.TestCase):
     table_abc = Table("abc")
 
     def test_update(self):
-        q = (
-            MySQLQuery.into("abc")
-            .insert(1, [1, "a", True])
-        )
+        q = MySQLQuery.into("abc").insert(1, [1, "a", True])
 
-        self.assertEqual(
-            "INSERT INTO `abc` VALUES (1,[1,'a',true])", str(q)
-        )
+        self.assertEqual("INSERT INTO `abc` VALUES (1,[1,'a',true])", str(q))
 
     def test_on_duplicate_key_ignore_update(self):
-        q = (
-            MySQLQuery.into("abc")
-            .insert(1, [1, "a", True])
-            .on_duplicate_key_ignore()
-        )
+        q = MySQLQuery.into("abc").insert(1, [1, "a", True]).on_duplicate_key_ignore()
 
-        self.assertEqual(
-            "INSERT INTO `abc` VALUES (1,[1,'a',true]) ON DUPLICATE KEY IGNORE", str(q)
-        )
+        self.assertEqual("INSERT INTO `abc` VALUES (1,[1,'a',true]) ON DUPLICATE KEY IGNORE", str(q))
 
     def test_on_duplicate_key_update_update(self):
-        q = (
-            MySQLQuery.into("abc")
-            .insert(1, [1, "a", True])
-            .on_duplicate_key_update(self.table_abc.a, 'b')
-        )
+        q = MySQLQuery.into("abc").insert(1, [1, "a", True]).on_duplicate_key_update(self.table_abc.a, 'b')
 
-        self.assertEqual(
-            "INSERT INTO `abc` VALUES (1,[1,'a',true]) ON DUPLICATE KEY UPDATE `a`='b'", str(q)
-        )
+        self.assertEqual("INSERT INTO `abc` VALUES (1,[1,'a',true]) ON DUPLICATE KEY UPDATE `a`='b'", str(q))
 
     def test_conflict_handlers_update(self):
         with self.assertRaises(QueryException):

--- a/pypika/tests/dialects/test_postgresql.py
+++ b/pypika/tests/dialects/test_postgresql.py
@@ -57,56 +57,32 @@ class JSONOperatorsTests(unittest.TestCase):
     table_abc = Table("abc")
 
     def test_get_json_value_by_key(self):
-        q = (
-            PostgreSQLQuery.from_(self.table_abc)
-            .select("*")
-            .where(self.table_abc.json.get_json_value("dates"))
-        )
+        q = PostgreSQLQuery.from_(self.table_abc).select("*").where(self.table_abc.json.get_json_value("dates"))
 
         self.assertEqual('SELECT * FROM "abc" WHERE "json"->\'dates\'', str(q))
 
     def test_get_json_value_by_index(self):
-        q = (
-            PostgreSQLQuery.from_(self.table_abc)
-            .select("*")
-            .where(self.table_abc.json.get_json_value(1))
-        )
+        q = PostgreSQLQuery.from_(self.table_abc).select("*").where(self.table_abc.json.get_json_value(1))
 
         self.assertEqual('SELECT * FROM "abc" WHERE "json"->1', str(q))
 
     def test_get_text_value_by_key(self):
-        q = (
-            PostgreSQLQuery.from_(self.table_abc)
-            .select("*")
-            .where(self.table_abc.json.get_text_value("dates"))
-        )
+        q = PostgreSQLQuery.from_(self.table_abc).select("*").where(self.table_abc.json.get_text_value("dates"))
 
         self.assertEqual('SELECT * FROM "abc" WHERE "json"->>\'dates\'', str(q))
 
     def test_get_text_value_by_index(self):
-        q = (
-            PostgreSQLQuery.from_(self.table_abc)
-            .select("*")
-            .where(self.table_abc.json.get_text_value(1))
-        )
+        q = PostgreSQLQuery.from_(self.table_abc).select("*").where(self.table_abc.json.get_text_value(1))
 
         self.assertEqual('SELECT * FROM "abc" WHERE "json"->>1', str(q))
 
     def test_get_path_json_value(self):
-        q = (
-            PostgreSQLQuery.from_(self.table_abc)
-            .select("*")
-            .where(self.table_abc.json.get_path_json_value("{a,b}"))
-        )
+        q = PostgreSQLQuery.from_(self.table_abc).select("*").where(self.table_abc.json.get_path_json_value("{a,b}"))
 
         self.assertEqual('SELECT * FROM "abc" WHERE "json"#>\'{a,b}\'', str(q))
 
     def test_get_path_text_value(self):
-        q = (
-            PostgreSQLQuery.from_(self.table_abc)
-            .select("*")
-            .where(self.table_abc.json.get_path_text_value("{a,b}"))
-        )
+        q = PostgreSQLQuery.from_(self.table_abc).select("*").where(self.table_abc.json.get_path_text_value("{a,b}"))
 
         self.assertEqual('SELECT * FROM "abc" WHERE "json"#>>\'{a,b}\'', str(q))
 
@@ -134,9 +110,7 @@ class JSONBOperatorsTests(unittest.TestCase):
         )
 
         self.assertEqual(
-            "SELECT * "
-            'FROM "abc" '
-            'WHERE "json"@>\'{"dates":"2018-07-10 - 2018-07-17"}\'',
+            "SELECT * " 'FROM "abc" ' 'WHERE "json"@>\'{"dates":"2018-07-10 - 2018-07-17"}\'',
             str(q),
         )
 
@@ -147,14 +121,16 @@ class JSONBOperatorsTests(unittest.TestCase):
             .where(
                 self.table_abc.json.contained_by(
                     OrderedDict(
-                        [("dates", "2018-07-10 - 2018-07-17"), ("imported", "8"),]
+                        [
+                            ("dates", "2018-07-10 - 2018-07-17"),
+                            ("imported", "8"),
+                        ]
                     )
                 )
             )
         )
         self.assertEqual(
-            'SELECT * FROM "abc" '
-            'WHERE "json"<@\'{"dates":"2018-07-10 - 2018-07-17","imported":"8"}\'',
+            'SELECT * FROM "abc" ' 'WHERE "json"<@\'{"dates":"2018-07-10 - 2018-07-17","imported":"8"}\'',
             str(q),
         )
 
@@ -165,18 +141,13 @@ class JSONBOperatorsTests(unittest.TestCase):
             .where(self.table_abc.json.contained_by(["One", "Two", "Three"]))
         )
 
-        self.assertEqual(
-            'SELECT * FROM "abc" WHERE "json"<@\'["One","Two","Three"]\'', str(q)
-        )
+        self.assertEqual('SELECT * FROM "abc" WHERE "json"<@\'["One","Two","Three"]\'', str(q))
 
     def test_json_contained_by_with_complex_criterion(self):
         q = (
             PostgreSQLQuery.from_(self.table_abc)
             .select("*")
-            .where(
-                self.table_abc.json.contained_by(["One", "Two", "Three"])
-                & (self.table_abc.id == 26)
-            )
+            .where(self.table_abc.json.contained_by(["One", "Two", "Three"]) & (self.table_abc.id == 26))
         )
 
         self.assertEqual(
@@ -185,24 +156,14 @@ class JSONBOperatorsTests(unittest.TestCase):
         )
 
     def test_json_has_key(self):
-        q = (
-            PostgreSQLQuery.from_(self.table_abc)
-            .select("*")
-            .where(self.table_abc.json.has_key("dates"))
-        )
+        q = PostgreSQLQuery.from_(self.table_abc).select("*").where(self.table_abc.json.has_key("dates"))
 
         self.assertEqual('SELECT * FROM "abc" WHERE "json"?\'dates\'', str(q))
 
     def test_json_has_keys(self):
-        q = (
-            PostgreSQLQuery.from_(self.table_abc)
-            .select("*")
-            .where(self.table_abc.json.has_keys(["dates", "imported"]))
-        )
+        q = PostgreSQLQuery.from_(self.table_abc).select("*").where(self.table_abc.json.has_keys(["dates", "imported"]))
 
-        self.assertEqual(
-            "SELECT * FROM \"abc\" WHERE \"json\"?&ARRAY['dates','imported']", str(q)
-        )
+        self.assertEqual("SELECT * FROM \"abc\" WHERE \"json\"?&ARRAY['dates','imported']", str(q))
 
     def test_json_has_any_keys(self):
         q = (
@@ -211,24 +172,16 @@ class JSONBOperatorsTests(unittest.TestCase):
             .where(self.table_abc.json.has_any_keys(["dates", "imported"]))
         )
 
-        self.assertEqual(
-            "SELECT * FROM \"abc\" WHERE \"json\"?|ARRAY['dates','imported']", str(q)
-        )
+        self.assertEqual("SELECT * FROM \"abc\" WHERE \"json\"?|ARRAY['dates','imported']", str(q))
 
 
 class DistinctOnTests(unittest.TestCase):
     table_abc = Table("abc")
 
     def test_distinct_on(self):
-        q = (
-            PostgreSQLQuery.from_(self.table_abc)
-            .distinct_on("lname", self.table_abc.fname)
-            .select("lname", "id")
-        )
+        q = PostgreSQLQuery.from_(self.table_abc).distinct_on("lname", self.table_abc.fname).select("lname", "id")
 
-        self.assertEqual(
-            '''SELECT DISTINCT ON("lname","fname") "lname","id" FROM "abc"''', str(q)
-        )
+        self.assertEqual('''SELECT DISTINCT ON("lname","fname") "lname","id" FROM "abc"''', str(q))
 
 
 class ArrayTests(unittest.TestCase):

--- a/pypika/tests/dialects/test_snowflake.py
+++ b/pypika/tests/dialects/test_snowflake.py
@@ -19,36 +19,20 @@ class QuoteTests(unittest.TestCase):
         foo = self.table_abc.as_("foo")
         bar = self.table_efg.as_("bar")
 
-        q = (
-            SnowflakeQuery.from_(foo)
-            .join(bar)
-            .on(foo.fk == bar.id)
-            .select(foo.a, bar.b)
-        )
+        q = SnowflakeQuery.from_(foo).join(bar).on(foo.fk == bar.id).select(foo.a, bar.b)
 
         self.assertEqual(
-            "SELECT foo.a,bar.b "
-            'FROM abc "foo" '
-            'JOIN efg "bar" '
-            "ON foo.fk=bar.id",
+            "SELECT foo.a,bar.b " 'FROM abc "foo" ' 'JOIN efg "bar" ' "ON foo.fk=bar.id",
             q.get_sql(with_namespace=True),
         )
 
     def test_use_double_quotes_on_alias_but_not_on_terms(self):
         idx = self.table_abc.index.as_("idx")
         val = fn.Sum(self.table_abc.value).as_("val")
-        q = (
-            SnowflakeQuery.from_(self.table_abc)
-            .select(idx, val)
-            .groupby(idx)
-            .orderby(idx)
-        )
+        q = SnowflakeQuery.from_(self.table_abc).select(idx, val).groupby(idx).orderby(idx)
 
         self.assertEqual(
-            'SELECT index "idx",SUM(value) "val" '
-            "FROM abc "
-            'GROUP BY "idx" '
-            'ORDER BY "idx"',
+            'SELECT index "idx",SUM(value) "val" ' "FROM abc " 'GROUP BY "idx" ' 'ORDER BY "idx"',
             q.get_sql(with_namespace=True),
         )
 
@@ -60,9 +44,6 @@ class QuoteTests(unittest.TestCase):
         q = SnowflakeQuery.from_(q1).join(q2).on(q1.b == q2.b).select("*")
 
         self.assertEqual(
-            "SELECT * "
-            'FROM (SELECT b FROM abc) sq0 '
-            'JOIN (SELECT b FROM efg) sq1 '
-            "ON sq0.b=sq1.b",
+            "SELECT * " 'FROM (SELECT b FROM abc) sq0 ' 'JOIN (SELECT b FROM efg) sq1 ' "ON sq0.b=sq1.b",
             q.get_sql(),
         )

--- a/pypika/tests/dialects/test_vertica.py
+++ b/pypika/tests/dialects/test_vertica.py
@@ -1,11 +1,6 @@
 import unittest
 
-from pypika import (
-    Table,
-    Tables,
-    Columns,
-    VerticaQuery,
-)
+from pypika import Columns, Table, Tables, VerticaQuery
 
 
 class VerticaQueryTests(unittest.TestCase):
@@ -19,9 +14,7 @@ class VerticaQueryTests(unittest.TestCase):
     def test_insert_query_with_hint(self):
         query = VerticaQuery.into(self.table_abc).insert(1).hint("test_hint")
 
-        self.assertEqual(
-            'INSERT /*+label(test_hint)*/ INTO "abc" VALUES (1)', str(query)
-        )
+        self.assertEqual('INSERT /*+label(test_hint)*/ INTO "abc" VALUES (1)', str(query))
 
     def test_update_query_with_hint(self):
         q = VerticaQuery.update(self.table_abc).set("foo", "bar").hint("test_hint")
@@ -58,30 +51,16 @@ class CopyCSVTests(unittest.TestCase):
 class CreateTemporaryTableTests(unittest.TestCase):
     new_table, existing_table = Tables("abc", "efg")
     foo, bar = Columns(("a", "INT"), ("b", "VARCHAR(100)"))
-    select = VerticaQuery.from_(existing_table).select(
-        existing_table.foo, existing_table.bar
-    )
+    select = VerticaQuery.from_(existing_table).select(existing_table.foo, existing_table.bar)
 
     def test_create_local_temporary_table(self):
         with self.subTest("with columns"):
-            q = (
-                VerticaQuery.create_table(self.new_table)
-                .temporary()
-                .local()
-                .columns(self.foo, self.bar)
-            )
+            q = VerticaQuery.create_table(self.new_table).temporary().local().columns(self.foo, self.bar)
 
-            self.assertEqual(
-                'CREATE LOCAL TEMPORARY TABLE "abc" ("a" INT,"b" VARCHAR(100))', str(q)
-            )
+            self.assertEqual('CREATE LOCAL TEMPORARY TABLE "abc" ("a" INT,"b" VARCHAR(100))', str(q))
 
         with self.subTest("with select"):
-            q = (
-                VerticaQuery.create_table(self.new_table)
-                .temporary()
-                .local()
-                .as_select(self.select)
-            )
+            q = VerticaQuery.create_table(self.new_table).temporary().local().as_select(self.select)
 
             self.assertEqual(
                 'CREATE LOCAL TEMPORARY TABLE "abc" AS (SELECT "foo","bar" FROM "efg")',
@@ -94,12 +73,7 @@ class CreateTemporaryTableTests(unittest.TestCase):
 
     def test_create_temporary_table_preserve_rows(self):
         with self.subTest("with columns"):
-            q = (
-                VerticaQuery.create_table(self.new_table)
-                .temporary()
-                .preserve_rows()
-                .columns(self.foo, self.bar)
-            )
+            q = VerticaQuery.create_table(self.new_table).temporary().preserve_rows().columns(self.foo, self.bar)
 
             self.assertEqual(
                 'CREATE TEMPORARY TABLE "abc" ("a" INT,"b" VARCHAR(100)) ON COMMIT PRESERVE ROWS',
@@ -107,12 +81,7 @@ class CreateTemporaryTableTests(unittest.TestCase):
             )
 
         with self.subTest("with select"):
-            q = (
-                VerticaQuery.create_table(self.new_table)
-                .temporary()
-                .preserve_rows()
-                .as_select(self.select)
-            )
+            q = VerticaQuery.create_table(self.new_table).temporary().preserve_rows().as_select(self.select)
 
             self.assertEqual(
                 'CREATE TEMPORARY TABLE "abc" ON COMMIT PRESERVE ROWS AS (SELECT "foo","bar" FROM "efg")',

--- a/pypika/tests/test_aggregate.py
+++ b/pypika/tests/test_aggregate.py
@@ -54,11 +54,7 @@ class IsAggregateTests(unittest.TestCase):
         self.assertTrue(v.is_aggregate)
 
     def test__agg_case_criterion_is_aggregate(self):
-        v = (
-            Case()
-            .when(fn.Sum(Field("foo")) > 666, 'More than 666')
-            .else_('Less than 666')
-        )
+        v = Case().when(fn.Sum(Field("foo")) > 666, 'More than 666').else_('Less than 666')
 
         self.assertTrue(v.is_aggregate)
 
@@ -73,11 +69,7 @@ class IsAggregateTests(unittest.TestCase):
         self.assertTrue(v.is_aggregate)
 
     def test__mixed_case_is_not_aggregate(self):
-        v = (
-            Case()
-            .when(Field("foo") == 1, fn.Sum(Field("bar")))
-            .when(Field("foo") == 2, Field("fiz"))
-        )
+        v = Case().when(Field("foo") == 1, fn.Sum(Field("bar"))).when(Field("foo") == 2, Field("fiz"))
 
         self.assertFalse(v.is_aggregate)
 
@@ -92,12 +84,7 @@ class IsAggregateTests(unittest.TestCase):
         self.assertFalse(v.is_aggregate)
 
     def test__case_mixed_constant_is_not_aggregate(self):
-        v = (
-            Case()
-            .when(Field("foo") == 1, fn.Sum(Field("bar")))
-            .when(Field("foo") == 2, fn.Sum(Field("fiz")))
-            .else_(1)
-        )
+        v = Case().when(Field("foo") == 1, fn.Sum(Field("bar"))).when(Field("foo") == 2, fn.Sum(Field("fiz"))).else_(1)
 
         self.assertTrue(v.is_aggregate)
 
@@ -107,12 +94,7 @@ class IsAggregateTests(unittest.TestCase):
         self.assertFalse(v.is_aggregate)
 
     def test__case_with_single_aggregate_field_in_one_criterion_is_aggregate(self):
-        v = (
-            Case()
-            .when(Field("foo") == 1, 1)
-            .when(fn.Sum(Field("foo")) == 2, 2)
-            .else_(3)
-        )
+        v = Case().when(Field("foo") == 1, 1).when(fn.Sum(Field("foo")) == 2, 2).else_(3)
 
         self.assertTrue(v.is_aggregate)
 
@@ -126,9 +108,7 @@ class IsAggregateTests(unittest.TestCase):
         t = Table("abc")
         is_placebo = t.campaign_extra_info == "placebo"
 
-        pixel_mobile_search = Case().when(
-            is_placebo, t.action_fb_pixel_search + t.action_fb_mobile_search
-        )
+        pixel_mobile_search = Case().when(is_placebo, t.action_fb_pixel_search + t.action_fb_mobile_search)
         unique_impressions = Case().when(is_placebo, t.unique_impressions)
 
         v = fn.Sum(pixel_mobile_search) / fn.Sum(unique_impressions) - 1.96 * fn.Sqrt(

--- a/pypika/tests/test_analytic_queries.py
+++ b/pypika/tests/test_analytic_queries.py
@@ -16,10 +16,7 @@ class RankTests(unittest.TestCase):
         q = Query.from_(self.table_abc).select(expr)
 
         self.assertEqual(
-            "SELECT "
-            "RANK() "
-            'OVER(PARTITION BY "foo" ORDER BY "date") '
-            'FROM "abc"',
+            "SELECT " "RANK() " 'OVER(PARTITION BY "foo" ORDER BY "date") ' 'FROM "abc"',
             str(q),
         )
 
@@ -29,10 +26,7 @@ class RankTests(unittest.TestCase):
         q = Query.from_(self.table_abc).select(expr)
 
         self.assertEqual(
-            "SELECT "
-            "DENSE_RANK() "
-            'OVER(PARTITION BY "foo" ORDER BY "date") '
-            'FROM "abc"',
+            "SELECT " "DENSE_RANK() " 'OVER(PARTITION BY "foo" ORDER BY "date") ' 'FROM "abc"',
             str(q),
         )
 
@@ -42,42 +36,27 @@ class RankTests(unittest.TestCase):
         q = Query.from_(self.table_abc).select(expr)
 
         self.assertEqual(
-            "SELECT "
-            "ROW_NUMBER() "
-            'OVER(PARTITION BY "foo" ORDER BY "date") '
-            'FROM "abc"',
+            "SELECT " "ROW_NUMBER() " 'OVER(PARTITION BY "foo" ORDER BY "date") ' 'FROM "abc"',
             str(q),
         )
 
     def test_rank_with_alias(self):
-        expr = (
-            an.Rank().over(self.table_abc.foo).orderby(self.table_abc.date).as_("rank")
-        )
+        expr = an.Rank().over(self.table_abc.foo).orderby(self.table_abc.date).as_("rank")
 
         q = Query.from_(self.table_abc).select(expr)
 
         self.assertEqual(
-            "SELECT "
-            "RANK() "
-            'OVER(PARTITION BY "foo" ORDER BY "date") "rank" '
-            'FROM "abc"',
+            "SELECT " "RANK() " 'OVER(PARTITION BY "foo" ORDER BY "date") "rank" ' 'FROM "abc"',
             str(q),
         )
 
     def test_multiple_partitions(self):
-        expr = (
-            an.Rank()
-            .orderby(self.table_abc.date)
-            .over(self.table_abc.foo, self.table_abc.bar)
-        )
+        expr = an.Rank().orderby(self.table_abc.date).over(self.table_abc.foo, self.table_abc.bar)
 
         q = Query.from_(self.table_abc).select(expr)
 
         self.assertEqual(
-            "SELECT "
-            "RANK() "
-            'OVER(PARTITION BY "foo","bar" ORDER BY "date") '
-            'FROM "abc"',
+            "SELECT " "RANK() " 'OVER(PARTITION BY "foo","bar" ORDER BY "date") ' 'FROM "abc"',
             str(q),
         )
 
@@ -93,18 +72,14 @@ class RankTests(unittest.TestCase):
 
         q = Query.from_(self.table_abc).select(expr)
 
-        self.assertEqual(
-            "SELECT " "NTILE(5) " 'OVER(PARTITION BY "foo") ' 'FROM "abc"', str(q)
-        )
+        self.assertEqual("SELECT " "NTILE(5) " 'OVER(PARTITION BY "foo") ' 'FROM "abc"', str(q))
 
     def test_ntile_with_order(self):
         expr = an.NTile(5).orderby(self.table_abc.date)
 
         q = Query.from_(self.table_abc).select(expr)
 
-        self.assertEqual(
-            "SELECT " "NTILE(5) " 'OVER(ORDER BY "date") ' 'FROM "abc"', str(q)
-        )
+        self.assertEqual("SELECT " "NTILE(5) " 'OVER(ORDER BY "date") ' 'FROM "abc"', str(q))
 
     def test_ntile_with_partition_and_order(self):
         expr = an.NTile(5).over(self.table_abc.foo).orderby(self.table_abc.date)
@@ -112,63 +87,37 @@ class RankTests(unittest.TestCase):
         q = Query.from_(self.table_abc).select(expr)
 
         self.assertEqual(
-            "SELECT "
-            "NTILE(5) "
-            'OVER(PARTITION BY "foo" ORDER BY "date") '
-            'FROM "abc"',
+            "SELECT " "NTILE(5) " 'OVER(PARTITION BY "foo" ORDER BY "date") ' 'FROM "abc"',
             str(q),
         )
 
     def test_first_value(self):
-        expr = (
-            an.FirstValue(self.table_abc.fizz)
-            .over(self.table_abc.foo)
-            .orderby(self.table_abc.date)
-        )
+        expr = an.FirstValue(self.table_abc.fizz).over(self.table_abc.foo).orderby(self.table_abc.date)
 
         q = Query.from_(self.table_abc).select(expr)
 
         self.assertEqual(
-            "SELECT "
-            'FIRST_VALUE("fizz") '
-            'OVER(PARTITION BY "foo" ORDER BY "date") '
-            'FROM "abc"',
+            "SELECT " 'FIRST_VALUE("fizz") ' 'OVER(PARTITION BY "foo" ORDER BY "date") ' 'FROM "abc"',
             str(q),
         )
 
     def test_first_value_ignore_nulls(self):
-        expr = (
-            an.FirstValue(self.table_abc.fizz)
-            .over(self.table_abc.foo)
-            .orderby(self.table_abc.date)
-            .ignore_nulls()
-        )
+        expr = an.FirstValue(self.table_abc.fizz).over(self.table_abc.foo).orderby(self.table_abc.date).ignore_nulls()
 
         q = Query.from_(self.table_abc).select(expr)
 
         self.assertEqual(
-            "SELECT "
-            'FIRST_VALUE("fizz" IGNORE NULLS) '
-            'OVER(PARTITION BY "foo" ORDER BY "date") '
-            'FROM "abc"',
+            "SELECT " 'FIRST_VALUE("fizz" IGNORE NULLS) ' 'OVER(PARTITION BY "foo" ORDER BY "date") ' 'FROM "abc"',
             str(q),
         )
 
     def test_first_value_ignore_nulls_first(self):
-        expr = (
-            an.FirstValue(self.table_abc.fizz)
-            .ignore_nulls()
-            .over(self.table_abc.foo)
-            .orderby(self.table_abc.date)
-        )
+        expr = an.FirstValue(self.table_abc.fizz).ignore_nulls().over(self.table_abc.foo).orderby(self.table_abc.date)
 
         q = Query.from_(self.table_abc).select(expr)
 
         self.assertEqual(
-            "SELECT "
-            'FIRST_VALUE("fizz" IGNORE NULLS) '
-            'OVER(PARTITION BY "foo" ORDER BY "date") '
-            'FROM "abc"',
+            "SELECT " 'FIRST_VALUE("fizz" IGNORE NULLS) ' 'OVER(PARTITION BY "foo" ORDER BY "date") ' 'FROM "abc"',
             str(q),
         )
 
@@ -182,27 +131,17 @@ class RankTests(unittest.TestCase):
         q = Query.from_(self.table_abc).select(expr)
 
         self.assertEqual(
-            "SELECT "
-            'FIRST_VALUE("fizz","buzz") '
-            'OVER(PARTITION BY "foo" ORDER BY "date") '
-            'FROM "abc"',
+            "SELECT " 'FIRST_VALUE("fizz","buzz") ' 'OVER(PARTITION BY "foo" ORDER BY "date") ' 'FROM "abc"',
             str(q),
         )
 
     def test_last_value(self):
-        expr = (
-            an.LastValue(self.table_abc.fizz)
-            .over(self.table_abc.foo)
-            .orderby(self.table_abc.date)
-        )
+        expr = an.LastValue(self.table_abc.fizz).over(self.table_abc.foo).orderby(self.table_abc.date)
 
         q = Query.from_(self.table_abc).select(expr)
 
         self.assertEqual(
-            "SELECT "
-            'LAST_VALUE("fizz") '
-            'OVER(PARTITION BY "foo" ORDER BY "date") '
-            'FROM "abc"',
+            "SELECT " 'LAST_VALUE("fizz") ' 'OVER(PARTITION BY "foo" ORDER BY "date") ' 'FROM "abc"',
             str(q),
         )
 
@@ -226,207 +165,130 @@ class RankTests(unittest.TestCase):
         )
 
     def test_orderby_asc(self):
-        expr = (
-            an.LastValue(self.table_abc.fizz)
-            .over(self.table_abc.foo)
-            .orderby(self.table_abc.date, order=Order.asc)
-        )
+        expr = an.LastValue(self.table_abc.fizz).over(self.table_abc.foo).orderby(self.table_abc.date, order=Order.asc)
 
         q = Query.from_(self.table_abc).select(expr)
 
         self.assertEqual(
-            "SELECT "
-            'LAST_VALUE("fizz") '
-            'OVER(PARTITION BY "foo" ORDER BY "date" ASC) '
-            'FROM "abc"',
+            "SELECT " 'LAST_VALUE("fizz") ' 'OVER(PARTITION BY "foo" ORDER BY "date" ASC) ' 'FROM "abc"',
             str(q),
         )
 
     def test_orderby_desc(self):
-        expr = (
-            an.LastValue(self.table_abc.fizz)
-            .over(self.table_abc.foo)
-            .orderby(self.table_abc.date, order=Order.desc)
-        )
+        expr = an.LastValue(self.table_abc.fizz).over(self.table_abc.foo).orderby(self.table_abc.date, order=Order.desc)
 
         q = Query.from_(self.table_abc).select(expr)
 
         self.assertEqual(
-            "SELECT "
-            'LAST_VALUE("fizz") '
-            'OVER(PARTITION BY "foo" ORDER BY "date" DESC) '
-            'FROM "abc"',
+            "SELECT " 'LAST_VALUE("fizz") ' 'OVER(PARTITION BY "foo" ORDER BY "date" DESC) ' 'FROM "abc"',
             str(q),
         )
 
     def test_last_value_multi_argument(self):
         expr = (
-            an.LastValue(self.table_abc.fizz, self.table_abc.buzz)
-            .over(self.table_abc.foo)
-            .orderby(self.table_abc.date)
+            an.LastValue(self.table_abc.fizz, self.table_abc.buzz).over(self.table_abc.foo).orderby(self.table_abc.date)
         )
 
         q = Query.from_(self.table_abc).select(expr)
 
         self.assertEqual(
-            "SELECT "
-            'LAST_VALUE("fizz","buzz") '
-            'OVER(PARTITION BY "foo" ORDER BY "date") '
-            'FROM "abc"',
+            "SELECT " 'LAST_VALUE("fizz","buzz") ' 'OVER(PARTITION BY "foo" ORDER BY "date") ' 'FROM "abc"',
             str(q),
         )
 
     def test_last_value_ignore_nulls(self):
-        expr = (
-            an.LastValue(self.table_abc.fizz)
-            .over(self.table_abc.foo)
-            .orderby(self.table_abc.date)
-            .ignore_nulls()
-        )
+        expr = an.LastValue(self.table_abc.fizz).over(self.table_abc.foo).orderby(self.table_abc.date).ignore_nulls()
 
         q = Query.from_(self.table_abc).select(expr)
 
         self.assertEqual(
-            "SELECT "
-            'LAST_VALUE("fizz" IGNORE NULLS) '
-            'OVER(PARTITION BY "foo" ORDER BY "date") '
-            'FROM "abc"',
+            "SELECT " 'LAST_VALUE("fizz" IGNORE NULLS) ' 'OVER(PARTITION BY "foo" ORDER BY "date") ' 'FROM "abc"',
             str(q),
         )
 
     def test_median(self):
-        expr = (
-            an.Median(self.table_abc.fizz)
-            .over(self.table_abc.foo, self.table_abc.bar)
-            .orderby(self.table_abc.date)
-        )
+        expr = an.Median(self.table_abc.fizz).over(self.table_abc.foo, self.table_abc.bar).orderby(self.table_abc.date)
 
         q = Query.from_(self.table_abc).select(expr)
 
         self.assertEqual(
-            "SELECT "
-            'MEDIAN("fizz") '
-            'OVER(PARTITION BY "foo","bar" ORDER BY "date") '
-            'FROM "abc"',
+            "SELECT " 'MEDIAN("fizz") ' 'OVER(PARTITION BY "foo","bar" ORDER BY "date") ' 'FROM "abc"',
             str(q),
         )
 
     def test_avg(self):
-        expr = (
-            an.Avg(self.table_abc.fizz)
-            .over(self.table_abc.foo, self.table_abc.bar)
-            .orderby(self.table_abc.date)
-        )
+        expr = an.Avg(self.table_abc.fizz).over(self.table_abc.foo, self.table_abc.bar).orderby(self.table_abc.date)
 
         q = Query.from_(self.table_abc).select(expr)
 
         self.assertEqual(
-            "SELECT "
-            'AVG("fizz") '
-            'OVER(PARTITION BY "foo","bar" ORDER BY "date") '
-            'FROM "abc"',
+            "SELECT " 'AVG("fizz") ' 'OVER(PARTITION BY "foo","bar" ORDER BY "date") ' 'FROM "abc"',
             str(q),
         )
 
     def test_stddev(self):
-        expr = (
-            an.StdDev(self.table_abc.fizz)
-            .over(self.table_abc.foo, self.table_abc.bar)
-            .orderby(self.table_abc.date)
-        )
+        expr = an.StdDev(self.table_abc.fizz).over(self.table_abc.foo, self.table_abc.bar).orderby(self.table_abc.date)
 
         q = Query.from_(self.table_abc).select(expr)
 
         self.assertEqual(
-            "SELECT "
-            'STDDEV("fizz") '
-            'OVER(PARTITION BY "foo","bar" ORDER BY "date") '
-            'FROM "abc"',
+            "SELECT " 'STDDEV("fizz") ' 'OVER(PARTITION BY "foo","bar" ORDER BY "date") ' 'FROM "abc"',
             str(q),
         )
 
     def test_stddev_pop(self):
         expr = (
-            an.StdDevPop(self.table_abc.fizz)
-            .over(self.table_abc.foo, self.table_abc.bar)
-            .orderby(self.table_abc.date)
+            an.StdDevPop(self.table_abc.fizz).over(self.table_abc.foo, self.table_abc.bar).orderby(self.table_abc.date)
         )
 
         q = Query.from_(self.table_abc).select(expr)
 
         self.assertEqual(
-            "SELECT "
-            'STDDEV_POP("fizz") '
-            'OVER(PARTITION BY "foo","bar" ORDER BY "date") '
-            'FROM "abc"',
+            "SELECT " 'STDDEV_POP("fizz") ' 'OVER(PARTITION BY "foo","bar" ORDER BY "date") ' 'FROM "abc"',
             str(q),
         )
 
     def test_stddev_samp(self):
         expr = (
-            an.StdDevSamp(self.table_abc.fizz)
-            .over(self.table_abc.foo, self.table_abc.bar)
-            .orderby(self.table_abc.date)
+            an.StdDevSamp(self.table_abc.fizz).over(self.table_abc.foo, self.table_abc.bar).orderby(self.table_abc.date)
         )
 
         q = Query.from_(self.table_abc).select(expr)
 
         self.assertEqual(
-            "SELECT "
-            'STDDEV_SAMP("fizz") '
-            'OVER(PARTITION BY "foo","bar" ORDER BY "date") '
-            'FROM "abc"',
+            "SELECT " 'STDDEV_SAMP("fizz") ' 'OVER(PARTITION BY "foo","bar" ORDER BY "date") ' 'FROM "abc"',
             str(q),
         )
 
     def test_variance(self):
         expr = (
-            an.Variance(self.table_abc.fizz)
-            .over(self.table_abc.foo, self.table_abc.bar)
-            .orderby(self.table_abc.date)
+            an.Variance(self.table_abc.fizz).over(self.table_abc.foo, self.table_abc.bar).orderby(self.table_abc.date)
         )
 
         q = Query.from_(self.table_abc).select(expr)
 
         self.assertEqual(
-            "SELECT "
-            'VARIANCE("fizz") '
-            'OVER(PARTITION BY "foo","bar" ORDER BY "date") '
-            'FROM "abc"',
+            "SELECT " 'VARIANCE("fizz") ' 'OVER(PARTITION BY "foo","bar" ORDER BY "date") ' 'FROM "abc"',
             str(q),
         )
 
     def test_var_pop(self):
-        expr = (
-            an.VarPop(self.table_abc.fizz)
-            .over(self.table_abc.foo, self.table_abc.bar)
-            .orderby(self.table_abc.date)
-        )
+        expr = an.VarPop(self.table_abc.fizz).over(self.table_abc.foo, self.table_abc.bar).orderby(self.table_abc.date)
 
         q = Query.from_(self.table_abc).select(expr)
 
         self.assertEqual(
-            "SELECT "
-            'VAR_POP("fizz") '
-            'OVER(PARTITION BY "foo","bar" ORDER BY "date") '
-            'FROM "abc"',
+            "SELECT " 'VAR_POP("fizz") ' 'OVER(PARTITION BY "foo","bar" ORDER BY "date") ' 'FROM "abc"',
             str(q),
         )
 
     def test_var_samp(self):
-        expr = (
-            an.VarSamp(self.table_abc.fizz)
-            .over(self.table_abc.foo, self.table_abc.bar)
-            .orderby(self.table_abc.date)
-        )
+        expr = an.VarSamp(self.table_abc.fizz).over(self.table_abc.foo, self.table_abc.bar).orderby(self.table_abc.date)
 
         q = Query.from_(self.table_abc).select(expr)
 
         self.assertEqual(
-            "SELECT "
-            'VAR_SAMP("fizz") '
-            'OVER(PARTITION BY "foo","bar" ORDER BY "date") '
-            'FROM "abc"',
+            "SELECT " 'VAR_SAMP("fizz") ' 'OVER(PARTITION BY "foo","bar" ORDER BY "date") ' 'FROM "abc"',
             str(q),
         )
 
@@ -447,12 +309,7 @@ class RankTests(unittest.TestCase):
         )
 
     def test_sum_rows_unbounded_preceeding(self):
-        expr = (
-            an.Sum(self.table_abc.fizz)
-            .over(self.table_abc.foo)
-            .orderby(self.table_abc.date)
-            .rows(an.Preceding())
-        )
+        expr = an.Sum(self.table_abc.fizz).over(self.table_abc.foo).orderby(self.table_abc.date).rows(an.Preceding())
 
         q = Query.from_(self.table_abc).select(expr)
 
@@ -468,53 +325,28 @@ class RankTests(unittest.TestCase):
         )
 
     def test_max_rows_x_preceeding(self):
-        expr = (
-            an.Max(self.table_abc.fizz)
-            .over(self.table_abc.foo)
-            .orderby(self.table_abc.date)
-            .rows(an.Preceding(5))
-        )
+        expr = an.Max(self.table_abc.fizz).over(self.table_abc.foo).orderby(self.table_abc.date).rows(an.Preceding(5))
 
         q = Query.from_(self.table_abc).select(expr)
 
         self.assertEqual(
-            "SELECT "
-            'MAX("fizz") '
-            "OVER("
-            'PARTITION BY "foo" ORDER BY "date" '
-            "ROWS 5 PRECEDING"
-            ") "
-            'FROM "abc"',
+            "SELECT " 'MAX("fizz") ' "OVER(" 'PARTITION BY "foo" ORDER BY "date" ' "ROWS 5 PRECEDING" ") " 'FROM "abc"',
             str(q),
         )
 
     def test_min_rows_current_row(self):
-        expr = (
-            an.Min(self.table_abc.fizz)
-            .over(self.table_abc.foo)
-            .orderby(self.table_abc.date)
-            .rows(an.CURRENT_ROW)
-        )
+        expr = an.Min(self.table_abc.fizz).over(self.table_abc.foo).orderby(self.table_abc.date).rows(an.CURRENT_ROW)
 
         q = Query.from_(self.table_abc).select(expr)
 
         self.assertEqual(
-            "SELECT "
-            'MIN("fizz") '
-            "OVER("
-            'PARTITION BY "foo" ORDER BY "date" '
-            "ROWS CURRENT ROW"
-            ") "
-            'FROM "abc"',
+            "SELECT " 'MIN("fizz") ' "OVER(" 'PARTITION BY "foo" ORDER BY "date" ' "ROWS CURRENT ROW" ") " 'FROM "abc"',
             str(q),
         )
 
     def test_varpop_range_unbounded_preceeding(self):
         expr = (
-            an.VarPop(self.table_abc.fizz)
-            .over(self.table_abc.foo)
-            .orderby(self.table_abc.date)
-            .range(an.Preceding())
+            an.VarPop(self.table_abc.fizz).over(self.table_abc.foo).orderby(self.table_abc.date).range(an.Preceding())
         )
 
         q = Query.from_(self.table_abc).select(expr)
@@ -531,12 +363,7 @@ class RankTests(unittest.TestCase):
         )
 
     def test_max_range_x_preceeding(self):
-        expr = (
-            an.Max(self.table_abc.fizz)
-            .over(self.table_abc.foo)
-            .orderby(self.table_abc.date)
-            .range(an.Preceding(5))
-        )
+        expr = an.Max(self.table_abc.fizz).over(self.table_abc.foo).orderby(self.table_abc.date).range(an.Preceding(5))
 
         q = Query.from_(self.table_abc).select(expr)
 
@@ -552,12 +379,7 @@ class RankTests(unittest.TestCase):
         )
 
     def test_min_range_current_row(self):
-        expr = (
-            an.Min(self.table_abc.fizz)
-            .over(self.table_abc.foo)
-            .orderby(self.table_abc.date)
-            .range(an.CURRENT_ROW)
-        )
+        expr = an.Min(self.table_abc.fizz).over(self.table_abc.foo).orderby(self.table_abc.date).range(an.CURRENT_ROW)
 
         q = Query.from_(self.table_abc).select(expr)
 
@@ -706,67 +528,58 @@ class RankTests(unittest.TestCase):
 
     def test_rows_called_twice_raises_attribute_error(self):
         with self.assertRaises(AttributeError):
-            an.Sum(self.table_abc.fizz).over(self.table_abc.foo).orderby(
-                self.table_abc.date
-            ).rows(an.Preceding()).rows(an.Preceding())
+            an.Sum(self.table_abc.fizz).over(self.table_abc.foo).orderby(self.table_abc.date).rows(an.Preceding()).rows(
+                an.Preceding()
+            )
 
     def test_range_called_twice_raises_attribute_error(self):
         with self.assertRaises(AttributeError):
-            an.Sum(self.table_abc.fizz).over(self.table_abc.foo).orderby(
-                self.table_abc.date
-            ).range(an.Preceding()).range(an.Preceding())
+            an.Sum(self.table_abc.fizz).over(self.table_abc.foo).orderby(self.table_abc.date).range(
+                an.Preceding()
+            ).range(an.Preceding())
 
     def test_rows_then_range_raises_attribute_error(self):
         with self.assertRaises(AttributeError):
-            an.Sum(self.table_abc.fizz).over(self.table_abc.foo).orderby(
-                self.table_abc.date
-            ).rows(an.Preceding()).range(an.Preceding())
+            an.Sum(self.table_abc.fizz).over(self.table_abc.foo).orderby(self.table_abc.date).rows(
+                an.Preceding()
+            ).range(an.Preceding())
 
     def test_range_then_rows_raises_attribute_error(self):
         with self.assertRaises(AttributeError):
-            an.Sum(self.table_abc.fizz).over(self.table_abc.foo).orderby(
-                self.table_abc.date
-            ).range(an.Preceding()).rows(an.Preceding())
+            an.Sum(self.table_abc.fizz).over(self.table_abc.foo).orderby(self.table_abc.date).range(
+                an.Preceding()
+            ).rows(an.Preceding())
 
     def test_lag_generates_correct_sql(self):
         with self.subTest('without partition by'):
-            q = Query.from_(self.table_abc) \
-                .select(Lag(self.table_abc.date, 1, '2000-01-01')
-                        .orderby(self.table_abc.date))
+            q = Query.from_(self.table_abc).select(
+                Lag(self.table_abc.date, 1, '2000-01-01').orderby(self.table_abc.date)
+            )
 
             self.assertEqual('SELECT LAG("date",1,\'2000-01-01\') OVER(ORDER BY "date") FROM "abc"', str(q))
 
         with self.subTest('with partition by'):
-            q = Query.from_(self.table_abc) \
-                .select(
-                Lag(self.table_abc.date, 1, '2000-01-01')
-                    .over(self.table_abc.foo)
-                    .orderby(self.table_abc.date)
+            q = Query.from_(self.table_abc).select(
+                Lag(self.table_abc.date, 1, '2000-01-01').over(self.table_abc.foo).orderby(self.table_abc.date)
             )
 
             self.assertEqual(
-                'SELECT LAG("date",1,\'2000-01-01\') OVER(PARTITION BY "foo" ORDER BY "date") FROM "abc"',
-                str(q)
+                'SELECT LAG("date",1,\'2000-01-01\') OVER(PARTITION BY "foo" ORDER BY "date") FROM "abc"', str(q)
             )
 
     def test_lead_generates_correct_sql(self):
         with self.subTest('without partition by'):
-            q = Query.from_(self.table_abc) \
-                .select(
+            q = Query.from_(self.table_abc).select(
                 Lead(self.table_abc.date, 1, '2000-01-01').orderby(self.table_abc.date)
             )
 
             self.assertEqual('SELECT LEAD("date",1,\'2000-01-01\') OVER(ORDER BY "date") FROM "abc"', str(q))
 
         with self.subTest('with partition by'):
-            q = Query.from_(self.table_abc) \
-                .select(
-                Lead(self.table_abc.date, 1, '2000-01-01')
-                    .over(self.table_abc.foo)
-                    .orderby(self.table_abc.date)
+            q = Query.from_(self.table_abc).select(
+                Lead(self.table_abc.date, 1, '2000-01-01').over(self.table_abc.foo).orderby(self.table_abc.date)
             )
 
             self.assertEqual(
-                'SELECT LEAD("date",1,\'2000-01-01\') OVER(PARTITION BY "foo" ORDER BY "date") FROM "abc"',
-                str(q)
+                'SELECT LEAD("date",1,\'2000-01-01\') OVER(PARTITION BY "foo" ORDER BY "date") FROM "abc"', str(q)
             )

--- a/pypika/tests/test_create.py
+++ b/pypika/tests/test_create.py
@@ -1,11 +1,6 @@
 import unittest
 
-from pypika import (
-    Tables,
-    Column,
-    Columns,
-    Query,
-)
+from pypika import Column, Columns, Query, Tables
 from pypika.terms import ValueWrapper
 
 
@@ -40,7 +35,7 @@ class CreateTableTests(unittest.TestCase):
                 '"valid_from" DATETIME,'
                 '"valid_to" DATETIME,'
                 'PERIOD FOR "valid_period" ("valid_from","valid_to"))',
-                str(q)
+                str(q),
             )
 
         with self.subTest("without temporary keyword"):
@@ -49,36 +44,21 @@ class CreateTableTests(unittest.TestCase):
             self.assertEqual('CREATE TABLE "abc" ("a" INT,"b" VARCHAR(100))', str(q))
 
         with self.subTest("with temporary keyword"):
-            q = (
-                Query.create_table(self.new_table)
-                .temporary()
-                .columns(self.foo, self.bar)
-            )
+            q = Query.create_table(self.new_table).temporary().columns(self.foo, self.bar)
 
-            self.assertEqual(
-                'CREATE TEMPORARY TABLE "abc" ("a" INT,"b" VARCHAR(100))', str(q)
-            )
+            self.assertEqual('CREATE TEMPORARY TABLE "abc" ("a" INT,"b" VARCHAR(100))', str(q))
 
         with self.subTest("with primary key"):
-            q = Query.create_table(
-                self.new_table
-            ).columns(
-                self.foo, self.bar
-            ).primary_key(
-                self.foo, self.bar
-            )
+            q = Query.create_table(self.new_table).columns(self.foo, self.bar).primary_key(self.foo, self.bar)
 
             self.assertEqual('CREATE TABLE "abc" ("a" INT,"b" VARCHAR(100),PRIMARY KEY ("a","b"))', str(q))
 
         with self.subTest("with unique keys"):
-            q = Query.create_table(
-                self.new_table
-            ).columns(
-                self.foo, self.bar
-            ).unique(
-                self.foo, self.bar
-            ).unique(
-                self.foo
+            q = (
+                Query.create_table(self.new_table)
+                .columns(self.foo, self.bar)
+                .unique(self.foo, self.bar)
+                .unique(self.foo)
             )
 
             self.assertEqual('CREATE TABLE "abc" ("a" INT,"b" VARCHAR(100),UNIQUE ("a","b"),UNIQUE ("a"))', str(q))
@@ -89,16 +69,12 @@ class CreateTableTests(unittest.TestCase):
             self.assertEqual('CREATE TABLE "abc" ("a" INT,"b" VARCHAR(100)) WITH SYSTEM VERSIONING', str(q))
 
     def test_create_table_with_select(self):
-        select = Query.from_(self.existing_table).select(
-            self.existing_table.foo, self.existing_table.bar
-        )
+        select = Query.from_(self.existing_table).select(self.existing_table.foo, self.existing_table.bar)
 
         with self.subTest("without temporary keyword"):
             q = Query.create_table(self.new_table).as_select(select)
 
-            self.assertEqual(
-                'CREATE TABLE "abc" AS (SELECT "foo","bar" FROM "efg")', str(q)
-            )
+            self.assertEqual('CREATE TABLE "abc" AS (SELECT "foo","bar" FROM "efg")', str(q))
 
         with self.subTest("with temporary keyword"):
             q = Query.create_table(self.new_table).temporary().as_select(select)
@@ -114,21 +90,15 @@ class CreateTableTests(unittest.TestCase):
         self.assertEqual("", str(q))
 
     def test_create_table_with_select_and_columns_fails(self):
-        select = Query.from_(self.existing_table).select(
-            self.existing_table.foo, self.existing_table.bar
-        )
+        select = Query.from_(self.existing_table).select(self.existing_table.foo, self.existing_table.bar)
 
         with self.subTest("for columns before as_select"):
             with self.assertRaises(AttributeError):
-                Query.create_table(self.new_table).columns(
-                    self.foo, self.bar
-                ).as_select(select)
+                Query.create_table(self.new_table).columns(self.foo, self.bar).as_select(select)
 
         with self.subTest("for as_select before columns"):
             with self.assertRaises(AttributeError):
-                Query.create_table(self.new_table).as_select(select).columns(
-                    self.foo, self.bar
-                )
+                Query.create_table(self.new_table).as_select(select).columns(self.foo, self.bar)
 
     def test_create_table_as_select_not_query_raises_error(self):
         with self.assertRaises(TypeError):

--- a/pypika/tests/test_criterions.py
+++ b/pypika/tests/test_criterions.py
@@ -25,9 +25,7 @@ class CriterionTests(unittest.TestCase):
         c1 = (Field("foo") == Field("bar")).as_("criterion")
 
         self.assertEqual('"foo"="bar"', str(c1))
-        self.assertEqual(
-            '"foo"="bar" "criterion"', c1.get_sql(with_alias=True, quote_char='"', alias_quote_char='"')
-        )
+        self.assertEqual('"foo"="bar" "criterion"', c1.get_sql(with_alias=True, quote_char='"', alias_quote_char='"'))
 
     def test__criterion_eq_number(self):
         c1 = Field("foo") == 1
@@ -355,32 +353,20 @@ class BetweenTests(unittest.TestCase):
         c3 = Field("foo")[date(2000, 1, 1) : date(2000, 12, 31)]
 
         self.assertEqual("\"foo\" BETWEEN '2000-01-01' AND '2000-12-31'", str(c1))
-        self.assertEqual(
-            "\"btw\".\"foo\" BETWEEN '2000-01-01' AND '2000-12-31'", str(c2)
-        )
+        self.assertEqual("\"btw\".\"foo\" BETWEEN '2000-01-01' AND '2000-12-31'", str(c2))
         self.assertEqual("\"foo\" BETWEEN '2000-01-01' AND '2000-12-31'", str(c3))
 
     def test__between_datetime(self):
-        c1 = Field("foo").between(
-            datetime(2000, 1, 1, 0, 0, 0), datetime(2000, 12, 31, 23, 59, 59)
-        )
-        c2 = Field("foo", table=self.t).between(
-            datetime(2000, 1, 1, 0, 0, 0), datetime(2000, 12, 31, 23, 59, 59)
-        )
-        c3 = Field("foo")[
-            datetime(2000, 1, 1, 0, 0, 0) : datetime(2000, 12, 31, 23, 59, 59)
-        ]
+        c1 = Field("foo").between(datetime(2000, 1, 1, 0, 0, 0), datetime(2000, 12, 31, 23, 59, 59))
+        c2 = Field("foo", table=self.t).between(datetime(2000, 1, 1, 0, 0, 0), datetime(2000, 12, 31, 23, 59, 59))
+        c3 = Field("foo")[datetime(2000, 1, 1, 0, 0, 0) : datetime(2000, 12, 31, 23, 59, 59)]
 
-        self.assertEqual(
-            "\"foo\" BETWEEN '2000-01-01T00:00:00' AND '2000-12-31T23:59:59'", str(c1)
-        )
+        self.assertEqual("\"foo\" BETWEEN '2000-01-01T00:00:00' AND '2000-12-31T23:59:59'", str(c1))
         self.assertEqual(
             "\"btw\".\"foo\" BETWEEN '2000-01-01T00:00:00' AND '2000-12-31T23:59:59'",
             str(c2),
         )
-        self.assertEqual(
-            "\"foo\" BETWEEN '2000-01-01T00:00:00' AND '2000-12-31T23:59:59'", str(c3)
-        )
+        self.assertEqual("\"foo\" BETWEEN '2000-01-01T00:00:00' AND '2000-12-31T23:59:59'", str(c3))
 
     def test__function_between(self):
         c1 = fn.Coalesce(Field("foo"), 0)[0:1]
@@ -432,19 +418,11 @@ class IsInTests(unittest.TestCase):
         self.assertEqual("\"isin\".\"foo\" IN ('2000-01-01','2000-12-31')", str(c2))
 
     def test__in_datetime(self):
-        c1 = Field("foo").isin(
-            [datetime(2000, 1, 1, 0, 0, 0), datetime(2000, 12, 31, 23, 59, 59)]
-        )
-        c2 = Field("foo", table=self.t).isin(
-            [datetime(2000, 1, 1, 0, 0, 0), datetime(2000, 12, 31, 23, 59, 59)]
-        )
+        c1 = Field("foo").isin([datetime(2000, 1, 1, 0, 0, 0), datetime(2000, 12, 31, 23, 59, 59)])
+        c2 = Field("foo", table=self.t).isin([datetime(2000, 1, 1, 0, 0, 0), datetime(2000, 12, 31, 23, 59, 59)])
 
-        self.assertEqual(
-            "\"foo\" IN ('2000-01-01T00:00:00','2000-12-31T23:59:59')", str(c1)
-        )
-        self.assertEqual(
-            "\"isin\".\"foo\" IN ('2000-01-01T00:00:00','2000-12-31T23:59:59')", str(c2)
-        )
+        self.assertEqual("\"foo\" IN ('2000-01-01T00:00:00','2000-12-31T23:59:59')", str(c1))
+        self.assertEqual("\"isin\".\"foo\" IN ('2000-01-01T00:00:00','2000-12-31T23:59:59')", str(c2))
 
     def test__function_isin(self):
         c1 = fn.Coalesce(Field("foo"), 0).isin([0, 1])
@@ -490,21 +468,13 @@ class NotInTests(unittest.TestCase):
         c2 = Field("foo", table=self.t).notin([date(2000, 1, 1), date(2000, 12, 31)])
 
         self.assertEqual("\"foo\" NOT IN ('2000-01-01','2000-12-31')", str(c1))
-        self.assertEqual(
-            "\"notin\".\"foo\" NOT IN ('2000-01-01','2000-12-31')", str(c2)
-        )
+        self.assertEqual("\"notin\".\"foo\" NOT IN ('2000-01-01','2000-12-31')", str(c2))
 
     def test__notin_datetime(self):
-        c1 = Field("foo").notin(
-            [datetime(2000, 1, 1, 0, 0, 0), datetime(2000, 12, 31, 23, 59, 59)]
-        )
-        c2 = Field("foo", table=self.t).notin(
-            [datetime(2000, 1, 1, 0, 0, 0), datetime(2000, 12, 31, 23, 59, 59)]
-        )
+        c1 = Field("foo").notin([datetime(2000, 1, 1, 0, 0, 0), datetime(2000, 12, 31, 23, 59, 59)])
+        c2 = Field("foo", table=self.t).notin([datetime(2000, 1, 1, 0, 0, 0), datetime(2000, 12, 31, 23, 59, 59)])
 
-        self.assertEqual(
-            "\"foo\" NOT IN ('2000-01-01T00:00:00','2000-12-31T23:59:59')", str(c1)
-        )
+        self.assertEqual("\"foo\" NOT IN ('2000-01-01T00:00:00','2000-12-31T23:59:59')", str(c1))
         self.assertEqual(
             "\"notin\".\"foo\" NOT IN ('2000-01-01T00:00:00','2000-12-31T23:59:59')",
             str(c2),
@@ -611,27 +581,21 @@ class ComplexCriterionTests(unittest.TestCase):
 
     def test_and(self):
         c1 = (Field("foo") == 1) & (Field("bar") == 2)
-        c2 = (Field("foo", table=self.table_abc) == 1) & (
-            Field("bar", table=self.table_efg) == 2
-        )
+        c2 = (Field("foo", table=self.table_abc) == 1) & (Field("bar", table=self.table_efg) == 2)
 
         self.assertEqual('"foo"=1 AND "bar"=2', str(c1))
         self.assertEqual('"cx0"."foo"=1 AND "cx1"."bar"=2', str(c2))
 
     def test_or(self):
         c1 = (Field("foo") == 1) | (Field("bar") == 2)
-        c2 = (Field("foo", table=self.table_abc) == 1) | (
-            Field("bar", table=self.table_efg) == 2
-        )
+        c2 = (Field("foo", table=self.table_abc) == 1) | (Field("bar", table=self.table_efg) == 2)
 
         self.assertEqual('"foo"=1 OR "bar"=2', str(c1))
         self.assertEqual('"cx0"."foo"=1 OR "cx1"."bar"=2', str(c2))
 
     def test_xor(self):
         c1 = (Field("foo") == 1) ^ (Field("bar") == 2)
-        c2 = (Field("foo", table=self.table_abc) == 1) ^ (
-            Field("bar", table=self.table_efg) == 2
-        )
+        c2 = (Field("foo", table=self.table_abc) == 1) ^ (Field("bar", table=self.table_efg) == 2)
 
         self.assertEqual('"foo"=1 XOR "bar"=2', str(c1))
         self.assertEqual('"cx0"."foo"=1 XOR "cx1"."bar"=2', str(c2))
@@ -708,23 +672,17 @@ class CriterionOperationsTests(unittest.TestCase):
         self.assertEqual('"cx1"."foo"', str(f))
 
     def test_arithmeticfunction_replace_table(self):
-        f = (self.table_abc.foo + self.table_abc.bar).replace_table(
-            self.table_abc, self.table_efg
-        )
+        f = (self.table_abc.foo + self.table_abc.bar).replace_table(self.table_abc, self.table_efg)
 
         self.assertEqual('"cx1"."foo"+"cx1"."bar"', str(f))
 
     def test_criterion_replace_table(self):
-        f = (self.table_abc.foo < self.table_abc.bar).replace_table(
-            self.table_abc, self.table_efg
-        )
+        f = (self.table_abc.foo < self.table_abc.bar).replace_table(self.table_abc, self.table_efg)
 
         self.assertEqual('"cx1"."foo"<"cx1"."bar"', str(f))
 
     def test_complexcriterion_replace_table(self):
-        f = (self.table_abc.foo < self.table_abc.bar) & (
-            self.table_abc.fiz > self.table_abc.buz
-        )
+        f = (self.table_abc.foo < self.table_abc.bar) & (self.table_abc.fiz > self.table_abc.buz)
         f = f.replace_table(self.table_abc, self.table_efg)
 
         self.assertEqual('"cx1"."foo"<"cx1"."bar" AND "cx1"."fiz">"cx1"."buz"', str(f))

--- a/pypika/tests/test_custom_functions.py
+++ b/pypika/tests/test_custom_functions.py
@@ -1,6 +1,6 @@
 import unittest
 
-from pypika import FunctionException, Query, Table, functions as fn, CustomFunction
+from pypika import CustomFunction, FunctionException, Query, Table
 
 __author__ = "Airton Zanon"
 __email__ = "me@airton.dev"
@@ -33,9 +33,7 @@ class TestFunctionalCustomFunction(unittest.TestCase):
 
         DateDiff = CustomFunction("DATE_DIFF", ["interval", "start_date", "end_date"])
 
-        q = Query.from_(service).select(
-            DateDiff("day", service.created_date, service.updated_date)
-        )
+        q = Query.from_(service).select(DateDiff("day", service.created_date, service.updated_date))
 
         self.assertEqual(
             'SELECT DATE_DIFF(\'day\',"created_date","updated_date") FROM "service"',

--- a/pypika/tests/test_deletes.py
+++ b/pypika/tests/test_deletes.py
@@ -1,6 +1,6 @@
 import unittest
 
-from pypika import Table, Query, PostgreSQLQuery
+from pypika import PostgreSQLQuery, Query, Table
 
 __author__ = "Timothy Heys"
 __email__ = "theys@kayak.com"
@@ -20,16 +20,8 @@ class DeleteTests(unittest.TestCase):
         self.assertEqual('DELETE FROM "schema1"."abc"', str(q))
 
     def test_where_field_equals(self):
-        q1 = (
-            Query.from_(self.table_abc)
-            .where(self.table_abc.foo == self.table_abc.bar)
-            .delete()
-        )
-        q2 = (
-            Query.from_(self.table_abc)
-            .where(self.table_abc.foo.eq(self.table_abc.bar))
-            .delete()
-        )
+        q1 = Query.from_(self.table_abc).where(self.table_abc.foo == self.table_abc.bar).delete()
+        q2 = Query.from_(self.table_abc).where(self.table_abc.foo.eq(self.table_abc.bar)).delete()
 
         self.assertEqual('DELETE FROM "abc" WHERE "foo"="bar"', str(q1))
         self.assertEqual('DELETE FROM "abc" WHERE "foo"="bar"', str(q2))

--- a/pypika/tests/test_formats.py
+++ b/pypika/tests/test_formats.py
@@ -19,7 +19,8 @@ class QuoteTests(unittest.TestCase):
         )
 
         subquery2 = Query.from_(self.table_efg).select(
-            self.table_efg.foo.as_("foo_two"), self.table_efg.bar,
+            self.table_efg.foo.as_("foo_two"),
+            self.table_efg.bar,
         )
 
         self.query = (

--- a/pypika/tests/test_functions.py
+++ b/pypika/tests/test_functions.py
@@ -21,9 +21,7 @@ __email__ = "theys@kayak.com"
 class FunctionTests(unittest.TestCase):
     def test_dialect_propagation(self):
         func = fn.Function("func", ["a"], ["b"])
-        self.assertEqual(
-            "func(ARRAY['a'],ARRAY['b'])", func.get_sql(dialect=Dialects.POSTGRESQL)
-        )
+        self.assertEqual("func(ARRAY['a'],ARRAY['b'])", func.get_sql(dialect=Dialects.POSTGRESQL))
 
     def test_is_aggregate_None_for_non_aggregate_function_or_function_with_no_aggregate_functions(self):
         self.assertIsNone(fn.Coalesce('a', 0).is_aggregate)
@@ -320,21 +318,15 @@ class ConditionTests(unittest.TestCase):
     def test__case__else(self):
         q = Q.from_("abc").select(Case().when(F("foo") == 1, "a").else_("b"))
 
-        self.assertEqual(
-            "SELECT CASE WHEN \"foo\"=1 THEN 'a' ELSE 'b' END FROM \"abc\"", str(q)
-        )
+        self.assertEqual("SELECT CASE WHEN \"foo\"=1 THEN 'a' ELSE 'b' END FROM \"abc\"", str(q))
 
     def test__case__field(self):
         q = Q.from_("abc").select(Case().when(F("foo") == 1, F("bar")).else_(F("buz")))
 
-        self.assertEqual(
-            'SELECT CASE WHEN "foo"=1 THEN "bar" ELSE "buz" END FROM "abc"', str(q)
-        )
+        self.assertEqual('SELECT CASE WHEN "foo"=1 THEN "bar" ELSE "buz" END FROM "abc"', str(q))
 
     def test__case__multi(self):
-        q = Q.from_("abc").select(
-            Case().when(F("foo") > 0, F("fiz")).when(F("bar") <= 0, F("buz")).else_(1)
-        )
+        q = Q.from_("abc").select(Case().when(F("foo") > 0, F("fiz")).when(F("bar") <= 0, F("buz")).else_(1))
 
         self.assertEqual(
             'SELECT CASE WHEN "foo">0 THEN "fiz" WHEN "bar"<=0 THEN "buz" ELSE 1 END FROM "abc"',
@@ -575,9 +567,7 @@ class DateFunctionsTests(unittest.TestCase):
     def _test_extract_datepart(self, date_part):
         q = Q.from_(self.t).select(fn.Extract(date_part, self.t.foo))
 
-        self.assertEqual(
-            'SELECT EXTRACT(%s FROM "foo") FROM "abc"' % date_part.value, str(q)
-        )
+        self.assertEqual('SELECT EXTRACT(%s FROM "foo") FROM "abc"' % date_part.value, str(q))
 
     def test_extract_microsecond(self):
         self._test_extract_datepart(DatePart.microsecond)
@@ -607,17 +597,10 @@ class DateFunctionsTests(unittest.TestCase):
         self._test_extract_datepart(DatePart.year)
 
     def test_extract_join(self):
-        q = (
-            Q.from_(self.t)
-            .join(self.t2)
-            .on(self.t.id == self.t2.t_id)
-            .select(fn.Extract(DatePart.year, self.t.foo))
-        )
+        q = Q.from_(self.t).join(self.t2).on(self.t.id == self.t2.t_id).select(fn.Extract(DatePart.year, self.t.foo))
 
         self.assertEqual(
-            'SELECT EXTRACT(YEAR FROM "abc"."foo") FROM "abc" '
-            'JOIN "efg" ON "abc"."id"="efg"."t_id"',
-            str(q)
+            'SELECT EXTRACT(YEAR FROM "abc"."foo") FROM "abc" ' 'JOIN "efg" ON "abc"."id"="efg"."t_id"', str(q)
         )
 
     def test_timestampadd(self):
@@ -668,9 +651,7 @@ class DateFunctionsTests(unittest.TestCase):
         q3 = Query.from_(self.t).select(fn.ToDate(F("foo"), "yyyy-mm-dd"))
 
         self.assertEqual(str(q1), "TO_DATE('2019-06-21','yyyy-mm-dd')")
-        self.assertEqual(
-            str(q2), "SELECT TO_DATE('2019-06-21','yyyy-mm-dd') FROM \"abc\""
-        )
+        self.assertEqual(str(q2), "SELECT TO_DATE('2019-06-21','yyyy-mm-dd') FROM \"abc\"")
         self.assertEqual(str(q3), 'SELECT TO_DATE("foo",\'yyyy-mm-dd\') FROM "abc"')
 
 

--- a/pypika/tests/test_groupby_modifiers.py
+++ b/pypika/tests/test_groupby_modifiers.py
@@ -1,6 +1,6 @@
 import unittest
 
-from pypika import Table, Query, Rollup, functions as fn, RollupException
+from pypika import Query, Rollup, RollupException, Table, functions as fn
 
 __author__ = "Timothy Heys"
 __email__ = "theys@kayak.com"
@@ -16,9 +16,7 @@ class RollupTests(unittest.TestCase):
             .rollup(self.table.foo, vendor="mysql")
         )
 
-        self.assertEqual(
-            'SELECT "foo",SUM("bar") FROM "abc" GROUP BY "foo" WITH ROLLUP', str(q)
-        )
+        self.assertEqual('SELECT "foo",SUM("bar") FROM "abc" GROUP BY "foo" WITH ROLLUP', str(q))
 
     def test_mysql_rollup_two_groupbys(self):
         q = (
@@ -34,34 +32,29 @@ class RollupTests(unittest.TestCase):
 
     def test_no_rollup_before_groupby(self):
         with self.assertRaises(RollupException):
-            Query.from_(self.table).select(
-                self.table.foo, fn.Sum(self.table.bar)
-            ).rollup(vendor="mysql")
+            Query.from_(self.table).select(self.table.foo, fn.Sum(self.table.bar)).rollup(vendor="mysql")
 
     def test_no_rollup_after_rollup_mysql(self):
         with self.assertRaises(AttributeError):
-            Query.from_(self.table).select(
-                self.table.foo, self.table.fiz, fn.Sum(self.table.bar)
-            ).rollup(self.table.foo, vendor="mysql").rollup(
-                self.table.fiz, vendor="mysql"
-            )
+            Query.from_(self.table).select(self.table.foo, self.table.fiz, fn.Sum(self.table.bar)).rollup(
+                self.table.foo, vendor="mysql"
+            ).rollup(self.table.fiz, vendor="mysql")
 
     def test_verticaoracle_func_one_groupby(self):
-        q = (
-            Query.from_(self.table)
-            .select(self.table.foo, fn.Sum(self.table.bar))
-            .groupby(Rollup(self.table.foo))
-        )
+        q = Query.from_(self.table).select(self.table.foo, fn.Sum(self.table.bar)).groupby(Rollup(self.table.foo))
 
-        self.assertEqual(
-            'SELECT "foo",SUM("bar") FROM "abc" GROUP BY ROLLUP("foo")', str(q)
-        )
+        self.assertEqual('SELECT "foo",SUM("bar") FROM "abc" GROUP BY ROLLUP("foo")', str(q))
 
     def test_verticaoracle_func_two_groupbys(self):
         q = (
             Query.from_(self.table)
             .select(self.table.foo, self.table.fiz, fn.Sum(self.table.bar))
-            .groupby(Rollup(self.table.foo, self.table.fiz,))
+            .groupby(
+                Rollup(
+                    self.table.foo,
+                    self.table.fiz,
+                )
+            )
         )
 
         self.assertEqual(
@@ -72,10 +65,14 @@ class RollupTests(unittest.TestCase):
     def test_verticaoracle_func_partial(self):
         q = (
             Query.from_(self.table)
-            .select(
-                self.table.foo, self.table.fiz, self.table.buz, fn.Sum(self.table.bar)
+            .select(self.table.foo, self.table.fiz, self.table.buz, fn.Sum(self.table.bar))
+            .groupby(
+                Rollup(
+                    self.table.foo,
+                    self.table.fiz,
+                ),
+                self.table.buz,
             )
-            .groupby(Rollup(self.table.foo, self.table.fiz,), self.table.buz,)
         )
 
         self.assertEqual(
@@ -84,21 +81,18 @@ class RollupTests(unittest.TestCase):
         )
 
     def test_verticaoracle_from_groupbys(self):
-        q = (
-            Query.from_(self.table)
-            .select(self.table.foo, fn.Sum(self.table.bar))
-            .rollup(self.table.foo)
-        )
+        q = Query.from_(self.table).select(self.table.foo, fn.Sum(self.table.bar)).rollup(self.table.foo)
 
-        self.assertEqual(
-            'SELECT "foo",SUM("bar") FROM "abc" GROUP BY ROLLUP("foo")', str(q)
-        )
+        self.assertEqual('SELECT "foo",SUM("bar") FROM "abc" GROUP BY ROLLUP("foo")', str(q))
 
     def test_verticaoracle_from_two_groupbys(self):
         q = (
             Query.from_(self.table)
             .select(self.table.foo, self.table.fiz, fn.Sum(self.table.bar))
-            .rollup(self.table.foo, self.table.fiz,)
+            .rollup(
+                self.table.foo,
+                self.table.fiz,
+            )
         )
 
         self.assertEqual(
@@ -110,8 +104,12 @@ class RollupTests(unittest.TestCase):
         q = (
             Query.from_(self.table)
             .select(self.table.foo, self.table.fiz, fn.Sum(self.table.bar))
-            .groupby(self.table.foo,)
-            .rollup(self.table.fiz,)
+            .groupby(
+                self.table.foo,
+            )
+            .rollup(
+                self.table.fiz,
+            )
         )
 
         self.assertEqual(
@@ -123,8 +121,12 @@ class RollupTests(unittest.TestCase):
         q = (
             Query.from_(self.table)
             .select(self.table.foo, self.table.fiz, fn.Sum(self.table.bar))
-            .rollup(self.table.foo,)
-            .rollup(self.table.fiz,)
+            .rollup(
+                self.table.foo,
+            )
+            .rollup(
+                self.table.fiz,
+            )
         )
 
         self.assertEqual(
@@ -135,20 +137,29 @@ class RollupTests(unittest.TestCase):
     def test_verticaoracle_rollups_with_parity(self):
         q = (
             Query.from_(self.table)
-            .select(self.table.buz,)
-            .rollup([self.table.foo, self.table.bar], self.table.fiz,)
+            .select(
+                self.table.buz,
+            )
+            .rollup(
+                [self.table.foo, self.table.bar],
+                self.table.fiz,
+            )
         )
 
-        self.assertEqual(
-            'SELECT "buz" FROM "abc" GROUP BY ROLLUP(("foo","bar"),"fiz")', str(q)
-        )
+        self.assertEqual('SELECT "buz" FROM "abc" GROUP BY ROLLUP(("foo","bar"),"fiz")', str(q))
 
     def test_verticaoracle_rollups_with_multiple_rollups_and_parity(self):
         q = (
             Query.from_(self.table)
-            .select(self.table.buz,)
-            .rollup([self.table.foo, self.table.bar],)
-            .rollup([self.table.fiz, self.table.buz],)
+            .select(
+                self.table.buz,
+            )
+            .rollup(
+                [self.table.foo, self.table.bar],
+            )
+            .rollup(
+                [self.table.fiz, self.table.buz],
+            )
         )
 
         self.assertEqual(

--- a/pypika/tests/test_immutability.py
+++ b/pypika/tests/test_immutability.py
@@ -18,11 +18,7 @@ class ImmutabilityTests(unittest.TestCase):
 
     def test_queries_after_join(self):
         query1 = Query.from_(self.table_a).select(self.table_a.foo)
-        query2 = (
-            query1.join(self.table_b)
-            .on(self.table_a.foo == self.table_b.bar)
-            .select(self.table_b.buz)
-        )
+        query2 = query1.join(self.table_b).on(self.table_a.foo == self.table_b.bar).select(self.table_b.buz)
 
         self.assertEqual('SELECT "foo" FROM "a"', str(query1))
         self.assertEqual(

--- a/pypika/tests/test_inserts.py
+++ b/pypika/tests/test_inserts.py
@@ -44,7 +44,8 @@ class InsertIntoTests(unittest.TestCase):
 
     def test_insert_multiple_rows_with_array_value(self):
         query = Query.into(self.table_abc).insert(
-            (1, ["a", "b", "c"]), (2, ["c", "d", "e"]),
+            (1, ["a", "b", "c"]),
+            (2, ["c", "d", "e"]),
         )
 
         self.assertEqual(
@@ -65,23 +66,15 @@ class InsertIntoTests(unittest.TestCase):
     def test_insert_all_columns_multi_rows(self):
         query = Query.into(self.table_abc).insert((1, "a", True), (2, "b", False))
 
-        self.assertEqual(
-            "INSERT INTO \"abc\" VALUES (1,'a',true),(2,'b',false)", str(query)
-        )
+        self.assertEqual("INSERT INTO \"abc\" VALUES (1,'a',true),(2,'b',false)", str(query))
 
     def test_insert_all_columns_multi_rows_chained(self):
         query = Query.into(self.table_abc).insert(1, "a", True).insert(2, "b", False)
 
-        self.assertEqual(
-            "INSERT INTO \"abc\" VALUES (1,'a',true),(2,'b',false)", str(query)
-        )
+        self.assertEqual("INSERT INTO \"abc\" VALUES (1,'a',true),(2,'b',false)", str(query))
 
     def test_insert_all_columns_multi_rows_chained_mixed(self):
-        query = (
-            Query.into(self.table_abc)
-            .insert((1, "a", True), (2, "b", False))
-            .insert(3, "c", True)
-        )
+        query = Query.into(self.table_abc).insert((1, "a", True), (2, "b", False)).insert(3, "c", True)
 
         self.assertEqual(
             'INSERT INTO "abc" VALUES ' "(1,'a',true),(2,'b',false)," "(3,'c',true)",
@@ -90,15 +83,11 @@ class InsertIntoTests(unittest.TestCase):
 
     def test_insert_all_columns_multi_rows_chained_multiple_rows(self):
         query = (
-            Query.into(self.table_abc)
-            .insert((1, "a", True), (2, "b", False))
-            .insert((3, "c", True), (4, "d", False))
+            Query.into(self.table_abc).insert((1, "a", True), (2, "b", False)).insert((3, "c", True), (4, "d", False))
         )
 
         self.assertEqual(
-            'INSERT INTO "abc" VALUES '
-            "(1,'a',true),(2,'b',false),"
-            "(3,'c',true),(4,'d',false)",
+            'INSERT INTO "abc" VALUES ' "(1,'a',true),(2,'b',false)," "(3,'c',true),(4,'d',false)",
             str(query),
         )
 
@@ -109,20 +98,12 @@ class InsertIntoTests(unittest.TestCase):
             .insert(1, "a", True)
         )
 
-        self.assertEqual(
-            'INSERT INTO "abc" ("foo","bar","buz") VALUES (1,\'a\',true)', str(query)
-        )
+        self.assertEqual('INSERT INTO "abc" ("foo","bar","buz") VALUES (1,\'a\',true)', str(query))
 
     def test_insert_empty_columns(self):
-        query = (
-            Query.into(self.table_abc)
-            .columns()
-            .insert(1, "a", True)
-        )
+        query = Query.into(self.table_abc).columns().insert(1, "a", True)
 
-        self.assertEqual(
-            'INSERT INTO "abc" VALUES (1,\'a\',true)', str(query)
-        )
+        self.assertEqual('INSERT INTO "abc" VALUES (1,\'a\',true)', str(query))
 
     def test_insert_selected_columns_type_list(self):
         query = (
@@ -131,20 +112,12 @@ class InsertIntoTests(unittest.TestCase):
             .insert(1, "a", True)
         )
 
-        self.assertEqual(
-            'INSERT INTO "abc" ("foo","bar","buz") VALUES (1,\'a\',true)', str(query)
-        )
+        self.assertEqual('INSERT INTO "abc" ("foo","bar","buz") VALUES (1,\'a\',true)', str(query))
 
     def test_insert_empty_columns_type_list(self):
-        query = (
-            Query.into(self.table_abc)
-            .columns([])
-            .insert(1, "a", True)
-        )
+        query = Query.into(self.table_abc).columns([]).insert(1, "a", True)
 
-        self.assertEqual(
-            'INSERT INTO "abc" VALUES (1,\'a\',true)', str(query)
-        )
+        self.assertEqual('INSERT INTO "abc" VALUES (1,\'a\',true)', str(query))
 
     def test_insert_selected_columns_type_tuple(self):
         query = (
@@ -153,20 +126,12 @@ class InsertIntoTests(unittest.TestCase):
             .insert(1, "a", True)
         )
 
-        self.assertEqual(
-            'INSERT INTO "abc" ("foo","bar","buz") VALUES (1,\'a\',true)', str(query)
-        )
+        self.assertEqual('INSERT INTO "abc" ("foo","bar","buz") VALUES (1,\'a\',true)', str(query))
 
     def test_insert_empty_columns_type_tuple(self):
-        query = (
-            Query.into(self.table_abc)
-            .columns(())
-            .insert(1, "a", True)
-        )
+        query = Query.into(self.table_abc).columns(()).insert(1, "a", True)
 
-        self.assertEqual(
-            'INSERT INTO "abc" VALUES (1,\'a\',true)', str(query)
-        )
+        self.assertEqual('INSERT INTO "abc" VALUES (1,\'a\',true)', str(query))
 
     def test_insert_none_skipped(self):
         query = Query.into(self.table_abc).insert()
@@ -189,38 +154,25 @@ class InsertIntoTests(unittest.TestCase):
 
     def test_insert_column_using_alias_with_chain(self):
         q = self.table_abc.insert(1, "a", True).insert(2, "b", False)
-        self.assertEqual(
-            "INSERT INTO \"abc\" VALUES (1,'a',true),(2,'b',false)", str(q)
-        )
+        self.assertEqual("INSERT INTO \"abc\" VALUES (1,'a',true),(2,'b',false)", str(q))
 
     def test_insert_with_statement(self):
         sub_query = Query().select(self.table_abc.id).from_(self.table_abc)
         aliased = AliasedQuery('sub_qs')
 
-        q = (
-            Query().with_(sub_query, 'sub_qs')
-            .into(self.table_abc)
-            .select(aliased.id)
-            .from_(aliased)
-        )
+        q = Query().with_(sub_query, 'sub_qs').into(self.table_abc).select(aliased.id).from_(aliased)
         self.assertEqual(
-            'WITH sub_qs AS (SELECT "id" FROM "abc") INSERT INTO "abc" SELECT "sub_qs"."id" FROM sub_qs', str(q))
+            'WITH sub_qs AS (SELECT "id" FROM "abc") INSERT INTO "abc" SELECT "sub_qs"."id" FROM sub_qs', str(q)
+        )
 
 
 class PostgresInsertIntoOnConflictTests(unittest.TestCase):
     table_abc = Table("abc")
 
     def test_insert_on_conflict_do_nothing_field(self):
-        query = (
-            PostgreSQLQuery.into(self.table_abc)
-            .insert(1)
-            .on_conflict(self.table_abc.id)
-            .do_nothing()
-        )
+        query = PostgreSQLQuery.into(self.table_abc).insert(1).on_conflict(self.table_abc.id).do_nothing()
 
-        self.assertEqual(
-            'INSERT INTO "abc" VALUES (1) ON CONFLICT ("id") DO NOTHING', str(query)
-        )
+        self.assertEqual('INSERT INTO "abc" VALUES (1) ON CONFLICT ("id") DO NOTHING', str(query))
 
     def test_insert_on_conflict_do_nothing_multiple_fields(self):
         query = (
@@ -230,45 +182,22 @@ class PostgresInsertIntoOnConflictTests(unittest.TestCase):
             .do_nothing()
         )
 
-        self.assertEqual(
-            'INSERT INTO "abc" VALUES (1) ON CONFLICT ("id", "sub_id") DO NOTHING', str(query)
-        )
+        self.assertEqual('INSERT INTO "abc" VALUES (1) ON CONFLICT ("id", "sub_id") DO NOTHING', str(query))
 
     def test_insert_on_conflict_do_nothing_field_str(self):
-        query = (
-            PostgreSQLQuery.into(self.table_abc)
-            .insert(1)
-            .on_conflict("id")
-            .do_nothing()
-        )
+        query = PostgreSQLQuery.into(self.table_abc).insert(1).on_conflict("id").do_nothing()
 
-        self.assertEqual(
-            'INSERT INTO "abc" VALUES (1) ON CONFLICT ("id") DO NOTHING', str(query)
-        )
+        self.assertEqual('INSERT INTO "abc" VALUES (1) ON CONFLICT ("id") DO NOTHING', str(query))
 
     def test_insert_on_conflict_do_nothing_multiple_fields_str(self):
-        query = (
-            PostgreSQLQuery.into(self.table_abc)
-            .insert(1)
-            .on_conflict("id", "sub_id")
-            .do_nothing()
-        )
+        query = PostgreSQLQuery.into(self.table_abc).insert(1).on_conflict("id", "sub_id").do_nothing()
 
-        self.assertEqual(
-            'INSERT INTO "abc" VALUES (1) ON CONFLICT ("id", "sub_id") DO NOTHING', str(query)
-        )
+        self.assertEqual('INSERT INTO "abc" VALUES (1) ON CONFLICT ("id", "sub_id") DO NOTHING', str(query))
 
     def test_insert_on_conflict_do_nothing_mixed_fields(self):
-        query = (
-            PostgreSQLQuery.into(self.table_abc)
-            .insert(1)
-            .on_conflict("id", self.table_abc.sub_id)
-            .do_nothing()
-        )
+        query = PostgreSQLQuery.into(self.table_abc).insert(1).on_conflict("id", self.table_abc.sub_id).do_nothing()
 
-        self.assertEqual(
-            'INSERT INTO "abc" VALUES (1) ON CONFLICT ("id", "sub_id") DO NOTHING', str(query)
-        )
+        self.assertEqual('INSERT INTO "abc" VALUES (1) ON CONFLICT ("id", "sub_id") DO NOTHING', str(query))
 
     def test_insert_on_conflict_do_update_field(self):
         query = (
@@ -297,12 +226,7 @@ class PostgresInsertIntoOnConflictTests(unittest.TestCase):
         )
 
     def test_insert_on_conflict_do_update_field_str(self):
-        query = (
-            PostgreSQLQuery.into(self.table_abc)
-            .insert(1, "m")
-            .on_conflict("id")
-            .do_update("name", "m")
-        )
+        query = PostgreSQLQuery.into(self.table_abc).insert(1, "m").on_conflict("id").do_update("name", "m")
 
         self.assertEqual(
             "INSERT INTO \"abc\" VALUES (1,'m') ON CONFLICT (\"id\") DO UPDATE SET \"name\"='m'",
@@ -310,12 +234,7 @@ class PostgresInsertIntoOnConflictTests(unittest.TestCase):
         )
 
     def test_insert_on_conflict_do_update_multiple_fields_str(self):
-        query = (
-            PostgreSQLQuery.into(self.table_abc)
-            .insert(1, "m")
-            .on_conflict("id", "sub_id")
-            .do_update("name", "m")
-        )
+        query = PostgreSQLQuery.into(self.table_abc).insert(1, "m").on_conflict("id", "sub_id").do_update("name", "m")
 
         self.assertEqual(
             "INSERT INTO \"abc\" VALUES (1,'m') ON CONFLICT (\"id\", \"sub_id\") DO UPDATE SET \"name\"='m'",
@@ -337,11 +256,7 @@ class PostgresInsertIntoOnConflictTests(unittest.TestCase):
 
     def test_insert_on_conflict_no_handler(self):
         with self.assertRaises(QueryException):
-            query = str(
-                PostgreSQLQuery.into(self.table_abc)
-                .insert(1)
-                .on_conflict(self.table_abc.id)
-            )
+            query = str(PostgreSQLQuery.into(self.table_abc).insert(1).on_conflict(self.table_abc.id))
 
     def test_insert_on_conflict_two_handlers_do_nothing(self):
         with self.assertRaises(QueryException):
@@ -365,33 +280,18 @@ class PostgresInsertIntoOnConflictTests(unittest.TestCase):
 
     def test_non_insert_on_conflict_do_nothing(self):
         with self.assertRaises(QueryException):
-            query = (
-                PostgreSQLQuery.update(self.table_abc)
-                .set("foo", "bar")
-                .on_conflict("id")
-                .do_nothing()
-            )
+            query = PostgreSQLQuery.update(self.table_abc).set("foo", "bar").on_conflict("id").do_nothing()
 
     def test_non_insert_on_conflict_do_update(self):
         with self.assertRaises(QueryException):
             query = (
-                PostgreSQLQuery.update(self.table_abc)
-                .set("foo", "bar")
-                .on_conflict("id")
-                .do_update(["name"], ["m"])
+                PostgreSQLQuery.update(self.table_abc).set("foo", "bar").on_conflict("id").do_update(["name"], ["m"])
             )
 
     def test_insert_on_fieldless_conflict_do_nothing(self):
-        query = (
-            PostgreSQLQuery.into(self.table_abc)
-            .insert(1)
-            .on_conflict(None)
-            .do_nothing()
-        )
+        query = PostgreSQLQuery.into(self.table_abc).insert(1).on_conflict(None).do_nothing()
 
-        self.assertEqual(
-            'INSERT INTO "abc" VALUES (1) ON CONFLICT DO NOTHING', str(query)
-        )
+        self.assertEqual('INSERT INTO "abc" VALUES (1) ON CONFLICT DO NOTHING', str(query))
 
     def test_insert_on_fieldless_conflict_do_update_field(self):
         with self.assertRaises(QueryException):
@@ -406,159 +306,170 @@ class PostgresInsertIntoOnConflictTests(unittest.TestCase):
         table_bcd = Table('bcd')
         query = (
             PostgreSQLQuery.into(self.table_abc)
-                .insert(self.table_abc.fname, self.table_abc.lname)
-                .select(table_bcd.fname, table_bcd.lname)
-                .from_(table_bcd)
-                .on_conflict(self.table_abc.id, self.table_abc.sub_id)
-                .do_update(self.table_abc.fname, 1)
-                .do_update(self.table_abc.lname, table_bcd.lname)
-                .do_update(self.table_abc.cname,
-                           Case().when(self.table_abc.cname.eq('cname'), 'new_name').else_(self.table_abc.cname))
+            .insert(self.table_abc.fname, self.table_abc.lname)
+            .select(table_bcd.fname, table_bcd.lname)
+            .from_(table_bcd)
+            .on_conflict(self.table_abc.id, self.table_abc.sub_id)
+            .do_update(self.table_abc.fname, 1)
+            .do_update(self.table_abc.lname, table_bcd.lname)
+            .do_update(
+                self.table_abc.cname,
+                Case().when(self.table_abc.cname.eq('cname'), 'new_name').else_(self.table_abc.cname),
+            )
         )
 
         self.assertEqual(
             'INSERT INTO "abc" VALUES ("fname","lname") '
             'ON CONFLICT ("id", "sub_id") '
             'DO UPDATE SET "fname"=1,"lname"="bcd"."lname",'
-            '"cname"=CASE WHEN "abc"."cname"=\'cname\' THEN \'new_name\' ELSE "abc"."cname" END', str(query)
+            '"cname"=CASE WHEN "abc"."cname"=\'cname\' THEN \'new_name\' ELSE "abc"."cname" END',
+            str(query),
         )
 
     def test_on_conflict_where_empty_conflict_fields_do_nothing(self):
         with self.assertRaises(QueryException):
             (
                 PostgreSQLQuery.into(self.table_abc)
-                    .insert(1, "m")
-                    .on_conflict()
-                    .where(self.table_abc.abc.eq(0))
-                    .where(self.table_abc.cde.eq(0))
-                    .do_nothing()
+                .insert(1, "m")
+                .on_conflict()
+                .where(self.table_abc.abc.eq(0))
+                .where(self.table_abc.cde.eq(0))
+                .do_nothing()
             )
 
     def test_on_conflict_where_conflict_fields_do_nothing(self):
         qs = (
             PostgreSQLQuery.into(self.table_abc)
-                .insert(1, "m")
-                .on_conflict('id')
-                .where(self.table_abc.abc.eq(0))
-                .where(self.table_abc.cde.eq(0))
-                .do_nothing()
+            .insert(1, "m")
+            .on_conflict('id')
+            .where(self.table_abc.abc.eq(0))
+            .where(self.table_abc.cde.eq(0))
+            .do_nothing()
         )
         self.assertEqual(
-            '''INSERT INTO "abc" VALUES (1,'m') ON CONFLICT ("id") WHERE "abc"=0 AND "cde"=0 DO NOTHING''', str(qs))
+            '''INSERT INTO "abc" VALUES (1,'m') ON CONFLICT ("id") WHERE "abc"=0 AND "cde"=0 DO NOTHING''', str(qs)
+        )
 
     def test_on_conflict_where_empty_conflict_fields_do_update(self):
         with self.assertRaises(QueryException):
             (
                 PostgreSQLQuery.into(self.table_abc)
-                    .insert(1, "m")
-                    .on_conflict()
-                    .where(self.table_abc.abc.eq(0))
-                    .where(self.table_abc.cde.eq(0))
-                    .do_update('field', 'val')
+                .insert(1, "m")
+                .on_conflict()
+                .where(self.table_abc.abc.eq(0))
+                .where(self.table_abc.cde.eq(0))
+                .do_update('field', 'val')
             )
 
     def test_on_conflict_where_conflict_fields_do_update(self):
         qs = (
             PostgreSQLQuery.into(self.table_abc)
-                .insert(1, "m")
-                .on_conflict('id')
-                .where(self.table_abc.abc.eq(0))
-                .where(self.table_abc.cde.eq(0))
-                .do_update('field', 'val')
+            .insert(1, "m")
+            .on_conflict('id')
+            .where(self.table_abc.abc.eq(0))
+            .where(self.table_abc.cde.eq(0))
+            .do_update('field', 'val')
         )
         self.assertEqual(
             '''INSERT INTO "abc" VALUES (1,'m') ON CONFLICT ("id") WHERE "abc"=0 AND "cde"=0 '''
-            '''DO UPDATE SET "field"='val\'''', str(qs))
+            '''DO UPDATE SET "field"='val\'''',
+            str(qs),
+        )
 
     def test_where_and_on_conflict_where(self):
         table_bcd = Table('bcd')
 
         qs = (
             PostgreSQLQuery.into(self.table_abc)
-                .select(table_bcd.abc)
-                .from_(table_bcd)
-                .where(table_bcd.abc.eq('1'))
-                .on_conflict('id')
-                .where(self.table_abc.abc.eq(0))
-                .where(self.table_abc.cde.eq(0))
-                .do_update('field', 'val')
+            .select(table_bcd.abc)
+            .from_(table_bcd)
+            .where(table_bcd.abc.eq('1'))
+            .on_conflict('id')
+            .where(self.table_abc.abc.eq(0))
+            .where(self.table_abc.cde.eq(0))
+            .do_update('field', 'val')
         )
 
         self.assertEqual(
             'INSERT INTO "abc" SELECT "abc" FROM "bcd" WHERE "abc"=\'1\' '
-            'ON CONFLICT ("id") WHERE "abc"=0 AND "cde"=0 DO UPDATE SET "field"=\'val\'', str(qs))
+            'ON CONFLICT ("id") WHERE "abc"=0 AND "cde"=0 DO UPDATE SET "field"=\'val\'',
+            str(qs),
+        )
 
     def test_on_conflict_do_nothing_where(self):
         with self.assertRaises(QueryException):
             (
                 PostgreSQLQuery.into(self.table_abc)
-                    .insert(1, "m")
-                    .on_conflict()
-                    .do_nothing()
-                    .where(self.table_abc.abc.eq(1))
+                .insert(1, "m")
+                .on_conflict()
+                .do_nothing()
+                .where(self.table_abc.abc.eq(1))
             )
 
     def test_empty_on_conflict_do_update_where(self):
         with self.assertRaises(QueryException):
             (
                 PostgreSQLQuery.into(self.table_abc)
-                    .insert(1, "m")
-                    .on_conflict()
-                    .do_update('abc', 1)
-                    .where(self.table_abc.abc.eq(1))
+                .insert(1, "m")
+                .on_conflict()
+                .do_update('abc', 1)
+                .where(self.table_abc.abc.eq(1))
             )
 
     def test_on_conflict_do_update_where(self):
         qs = (
             PostgreSQLQuery.into(self.table_abc)
-                .insert(1, "m")
-                .on_conflict("id")
-                .do_update('abc', 1)
-                .where(self.table_abc.abc.eq(1))
+            .insert(1, "m")
+            .on_conflict("id")
+            .do_update('abc', 1)
+            .where(self.table_abc.abc.eq(1))
         )
         self.assertEqual(
-            'INSERT INTO "abc" VALUES (1,\'m\') ON CONFLICT ("id") DO UPDATE SET "abc"=1 WHERE "abc"."abc"=1', str(qs))
+            'INSERT INTO "abc" VALUES (1,\'m\') ON CONFLICT ("id") DO UPDATE SET "abc"=1 WHERE "abc"."abc"=1', str(qs)
+        )
 
     def test_on_conflict_do_update_with_excluded_where(self):
         qs = (
             PostgreSQLQuery.into(self.table_abc)
-                .insert(1, "m")
-                .on_conflict("id")
-                .do_update('abc')
-                .where(self.table_abc.abc.eq(1))
+            .insert(1, "m")
+            .on_conflict("id")
+            .do_update('abc')
+            .where(self.table_abc.abc.eq(1))
         )
         self.assertEqual(
-            'INSERT INTO "abc" VALUES (1,\'m\') ON CONFLICT ("id") DO UPDATE SET "abc"=EXCLUDED."abc" WHERE "abc"."abc"=1', str(qs))
+            'INSERT INTO "abc" VALUES (1,\'m\') ON CONFLICT ("id") DO UPDATE SET "abc"=EXCLUDED."abc" WHERE '
+            '"abc"."abc"=1',
+            str(qs),
+        )
 
     def test_on_conflict_where_complex(self):
         table_bcd = Table('bcd')
 
         qs = (
             PostgreSQLQuery.into(self.table_abc)
-                .select(table_bcd.abc)
-                .from_(table_bcd)
-                .where(table_bcd.abc.eq('1'))
-                .on_conflict('id')
-                .where(self.table_abc.abc.eq(0))
-                .where(self.table_abc.cde.eq(0))
-                .do_update('field', 'val')
-                .where(self.table_abc.id.eq(2))
-                .where(self.table_abc.sub_id.eq(3))
+            .select(table_bcd.abc)
+            .from_(table_bcd)
+            .where(table_bcd.abc.eq('1'))
+            .on_conflict('id')
+            .where(self.table_abc.abc.eq(0))
+            .where(self.table_abc.cde.eq(0))
+            .do_update('field', 'val')
+            .where(self.table_abc.id.eq(2))
+            .where(self.table_abc.sub_id.eq(3))
         )
         self.assertEqual(
             'INSERT INTO "abc" SELECT "abc" FROM "bcd" WHERE "abc"=\'1\' '
             'ON CONFLICT ("id") WHERE "abc"=0 AND "cde"=0 '
             'DO UPDATE SET "field"=\'val\' WHERE "abc"."id"=2 AND "abc"."sub_id"=3',
-            str(qs))
+            str(qs),
+        )
 
 
 class PostgresInsertIntoReturningTests(unittest.TestCase):
     table_abc = Table("abc")
 
     def test_insert_returning_one_field(self):
-        query = (
-            PostgreSQLQuery.into(self.table_abc).insert(1).returning(self.table_abc.id)
-        )
+        query = PostgreSQLQuery.into(self.table_abc).insert(1).returning(self.table_abc.id)
 
         self.assertEqual('INSERT INTO "abc" VALUES (1) RETURNING "id"', str(query))
 
@@ -568,11 +479,7 @@ class PostgresInsertIntoReturningTests(unittest.TestCase):
         self.assertEqual('INSERT INTO "abc" VALUES (1) RETURNING "id"', str(query))
 
     def test_insert_returning_all_fields(self):
-        query = (
-            PostgreSQLQuery.into(self.table_abc)
-            .insert(1)
-            .returning(self.table_abc.star)
-        )
+        query = PostgreSQLQuery.into(self.table_abc).insert(1).returning(self.table_abc.star)
 
         self.assertEqual('INSERT INTO "abc" VALUES (1) RETURNING *', str(query))
 
@@ -603,7 +510,11 @@ class PostgresInsertIntoReturningTests(unittest.TestCase):
             PostgreSQLQuery.into(self.table_abc)
             .insert(1, "a", True)
             .insert(2, "b", False)
-            .returning(self.table_abc.name, self.table_abc.star, self.table_abc.id,)
+            .returning(
+                self.table_abc.name,
+                self.table_abc.star,
+                self.table_abc.id,
+            )
         )
 
         self.assertEqual(
@@ -612,12 +523,7 @@ class PostgresInsertIntoReturningTests(unittest.TestCase):
         )
 
     def test_insert_all_columns_multi_rows_chained_returning_star_str(self):
-        query = (
-            PostgreSQLQuery.into(self.table_abc)
-            .insert(1, "a", True)
-            .insert(2, "b", False)
-            .returning("*")
-        )
+        query = PostgreSQLQuery.into(self.table_abc).insert(1, "a", True).insert(2, "b", False).returning("*")
 
         self.assertEqual(
             "INSERT INTO \"abc\" VALUES (1,'a',true),(2,'b',false) RETURNING *",
@@ -625,15 +531,9 @@ class PostgresInsertIntoReturningTests(unittest.TestCase):
         )
 
     def test_insert_all_columns_single_element_arrays(self):
-        query = (
-            PostgreSQLQuery.into(self.table_abc)
-            .insert((1, "a", True))
-            .returning(self.table_abc.star)
-        )
+        query = PostgreSQLQuery.into(self.table_abc).insert((1, "a", True)).returning(self.table_abc.star)
 
-        self.assertEqual(
-            "INSERT INTO \"abc\" VALUES (1,'a',true) RETURNING *", str(query)
-        )
+        self.assertEqual("INSERT INTO \"abc\" VALUES (1,'a',true) RETURNING *", str(query))
 
     def test_insert_returning_null(self):
         query = PostgreSQLQuery.into(self.table_abc).insert(1).returning(None)
@@ -646,19 +546,13 @@ class PostgresInsertIntoReturningTests(unittest.TestCase):
         self.assertEqual('INSERT INTO "abc" VALUES (1) RETURNING (1,2,3)', str(query))
 
     def test_insert_returning_arithmetics(self):
-        query = (
-            PostgreSQLQuery.into(self.table_abc)
-            .insert(1)
-            .returning(self.table_abc.f1 + self.table_abc.f2)
-        )
+        query = PostgreSQLQuery.into(self.table_abc).insert(1).returning(self.table_abc.f1 + self.table_abc.f2)
 
         self.assertEqual('INSERT INTO "abc" VALUES (1) RETURNING "f1"+"f2"', str(query))
 
     def test_insert_returning_aggregate(self):
         with self.assertRaises(QueryException):
-            PostgreSQLQuery.into(self.table_abc).insert(1).returning(
-                Avg(self.table_abc.views)
-            )
+            PostgreSQLQuery.into(self.table_abc).insert(1).returning(Avg(self.table_abc.views))
 
     def test_insert_returning_from_other_table(self):
         table_cba = Table("cba")
@@ -671,9 +565,7 @@ class InsertIntoOnDuplicateTests(unittest.TestCase):
 
     def test_insert_one_column(self):
         query = (
-            MySQLQuery.into(self.table_abc)
-            .insert(1)
-            .on_duplicate_key_update(self.table_abc.foo, self.table_abc.foo)
+            MySQLQuery.into(self.table_abc).insert(1).on_duplicate_key_update(self.table_abc.foo, self.table_abc.foo)
         )
         self.assertEqual(
             "INSERT INTO `abc` VALUES (1) ON DUPLICATE KEY UPDATE `foo`=`foo`",
@@ -693,9 +585,7 @@ class InsertIntoOnDuplicateTests(unittest.TestCase):
 
     def test_insert_one_column_single_element_array(self):
         query = (
-            MySQLQuery.into(self.table_abc)
-            .insert((1,))
-            .on_duplicate_key_update(self.table_abc.foo, self.table_abc.foo)
+            MySQLQuery.into(self.table_abc).insert((1,)).on_duplicate_key_update(self.table_abc.foo, self.table_abc.foo)
         )
 
         self.assertEqual(
@@ -728,11 +618,7 @@ class InsertIntoOnDuplicateTests(unittest.TestCase):
         )
 
     def test_insert_multiple_columns_on_duplicate_update_one_with_different_value(self):
-        query = (
-            MySQLQuery.into(self.table_abc)
-            .insert(1, "a")
-            .on_duplicate_key_update(self.table_abc.bar, "b")
-        )
+        query = MySQLQuery.into(self.table_abc).insert(1, "a").on_duplicate_key_update(self.table_abc.bar, "b")
 
         self.assertEqual(
             "INSERT INTO `abc` VALUES (1,'a') ON DUPLICATE KEY UPDATE `bar`='b'",
@@ -741,9 +627,7 @@ class InsertIntoOnDuplicateTests(unittest.TestCase):
 
     def test_insert_multiple_columns_on_duplicate_update_one_with_expression(self):
         query = (
-            MySQLQuery.into(self.table_abc)
-            .insert(1, 2)
-            .on_duplicate_key_update(self.table_abc.bar, 4 + F("bar"))
+            MySQLQuery.into(self.table_abc).insert(1, 2).on_duplicate_key_update(self.table_abc.bar, 4 + F("bar"))
         )  # todo sql expression? not python
 
         self.assertEqual(
@@ -757,9 +641,7 @@ class InsertIntoOnDuplicateTests(unittest.TestCase):
         query = (
             MySQLQuery.into(self.table_abc)
             .insert(1, "a")
-            .on_duplicate_key_update(
-                self.table_abc.bar, fn.Concat(self.table_abc.bar, "update")
-            )
+            .on_duplicate_key_update(self.table_abc.bar, fn.Concat(self.table_abc.bar, "update"))
         )
 
         self.assertEqual(
@@ -773,9 +655,7 @@ class InsertIntoOnDuplicateTests(unittest.TestCase):
         query = (
             MySQLQuery.into(self.table_abc)
             .insert(1, "a")
-            .on_duplicate_key_update(
-                self.table_abc.bar, fn.Concat(Values(self.table_abc.bar), "update")
-            )
+            .on_duplicate_key_update(self.table_abc.bar, fn.Concat(Values(self.table_abc.bar), "update"))
         )
 
         self.assertEqual(
@@ -840,21 +720,12 @@ class InsertIntoOnDuplicateTests(unittest.TestCase):
         )
 
     def test_insert_none_skipped(self):
-        query = (
-            MySQLQuery.into(self.table_abc)
-            .insert()
-            .on_duplicate_key_update(self.table_abc.baz, False)
-        )
+        query = MySQLQuery.into(self.table_abc).insert().on_duplicate_key_update(self.table_abc.baz, False)
 
         self.assertEqual("", str(query))
 
     def test_insert_ignore(self):
-        query = (
-            MySQLQuery.into(self.table_abc)
-            .insert(1)
-            .ignore()
-            .on_duplicate_key_update(self.table_abc.baz, False)
-        )
+        query = MySQLQuery.into(self.table_abc).insert(1).ignore().on_duplicate_key_update(self.table_abc.baz, False)
 
         self.assertEqual(
             "INSERT IGNORE INTO `abc` VALUES (1) ON DUPLICATE KEY UPDATE `baz`=false",
@@ -882,21 +753,21 @@ class InsertSelectFromTests(unittest.TestCase):
             .select(self.table_efg.fiz, self.table_efg.buz, self.table_efg.baz)
         )
 
-        self.assertEqual(
-            'INSERT INTO "abc" ' 'SELECT "fiz","buz","baz" FROM "efg"', str(query)
-        )
+        self.assertEqual('INSERT INTO "abc" ' 'SELECT "fiz","buz","baz" FROM "efg"', str(query))
 
     def test_insert_columns_from_star(self):
         query = (
             Query.into(self.table_abc)
-            .columns(self.table_abc.foo, self.table_abc.bar, self.table_abc.buz,)
+            .columns(
+                self.table_abc.foo,
+                self.table_abc.bar,
+                self.table_abc.buz,
+            )
             .from_(self.table_efg)
             .select("*")
         )
 
-        self.assertEqual(
-            'INSERT INTO "abc" ("foo","bar","buz") ' 'SELECT * FROM "efg"', str(query)
-        )
+        self.assertEqual('INSERT INTO "abc" ("foo","bar","buz") ' 'SELECT * FROM "efg"', str(query))
 
     def test_insert_columns_from_columns(self):
         query = (
@@ -907,8 +778,7 @@ class InsertSelectFromTests(unittest.TestCase):
         )
 
         self.assertEqual(
-            'INSERT INTO "abc" ("foo","bar","buz") '
-            'SELECT "fiz","buz","baz" FROM "efg"',
+            'INSERT INTO "abc" ("foo","bar","buz") ' 'SELECT "fiz","buz","baz" FROM "efg"',
             str(query),
         )
 
@@ -944,9 +814,7 @@ class InsertSubqueryTests(unittest.TestCase):
             Query.into(purchase_order_item)
             .columns(purchase_order_item.id_part, purchase_order_item.id_customer)
             .insert(
-                Query.from_(part)
-                .select(part.part_id)
-                .where(part.part_number == "FOOBAR"),
+                Query.from_(part).select(part.part_id).where(part.part_number == "FOOBAR"),
                 12345,
             )
         )
@@ -1004,8 +872,6 @@ class ReplaceTests(unittest.TestCase):
         self.assertEqual(str(query), expected_output)
 
     def test_replace_subquery(self):
-        query = Query.into(self.table_abc).replace(
-            Query.from_(self.table_def).select("f1", "f2")
-        )
+        query = Query.into(self.table_abc).replace(Query.from_(self.table_def).select("f1", "f2"))
         expected_output = 'REPLACE INTO "abc" VALUES ((SELECT "f1","f2" FROM "efg"))'
         self.assertEqual(str(query), expected_output)

--- a/pypika/tests/test_joins.py
+++ b/pypika/tests/test_joins.py
@@ -7,9 +7,9 @@ from pypika import (
     JoinType,
     MySQLQuery,
     Query,
+    SetOperationException,
     Table,
     Tables,
-    SetOperationException,
     functions as fn,
 )
 
@@ -21,16 +21,9 @@ class SelectQueryJoinTests(unittest.TestCase):
     table0, table1, hij = Tables("abc", "efg", "hij")
 
     def test_default_join_type(self):
-        query = (
-            Query.from_(self.table0)
-            .join(self.table1)
-            .on(self.table0.foo == self.table1.bar)
-            .select("*")
-        )
+        query = Query.from_(self.table0).join(self.table1).on(self.table0.foo == self.table1.bar).select("*")
 
-        self.assertEqual(
-            'SELECT * FROM "abc" JOIN "efg" ON "abc"."foo"="efg"."bar"', str(query)
-        )
+        self.assertEqual('SELECT * FROM "abc" JOIN "efg" ON "abc"."foo"="efg"."bar"', str(query))
 
     def test_inner_join(self):
         expected = 'SELECT * FROM "abc" JOIN "efg" ON "abc"."foo"="efg"."bar"'
@@ -45,12 +38,7 @@ class SelectQueryJoinTests(unittest.TestCase):
             self.assertEqual(expected, str(query))
 
         with self.subTest("join function"):
-            query = (
-                Query.from_(self.table0)
-                .inner_join(self.table1)
-                .on(self.table0.foo == self.table1.bar)
-                .select("*")
-            )
+            query = Query.from_(self.table0).inner_join(self.table1).on(self.table0.foo == self.table1.bar).select("*")
             self.assertEqual(expected, str(query))
 
     def test_left_join(self):
@@ -67,12 +55,7 @@ class SelectQueryJoinTests(unittest.TestCase):
             self.assertEqual(expected, str(query))
 
         with self.subTest("join function"):
-            query = (
-                Query.from_(self.table0)
-                .left_join(self.table1)
-                .on(self.table0.foo == self.table1.bar)
-                .select("*")
-            )
+            query = Query.from_(self.table0).left_join(self.table1).on(self.table0.foo == self.table1.bar).select("*")
             self.assertEqual(expected, str(query))
 
     def test_right_join(self):
@@ -89,18 +72,11 @@ class SelectQueryJoinTests(unittest.TestCase):
             self.assertEqual(expected, str(query))
 
         with self.subTest("join function"):
-            query = (
-                Query.from_(self.table0)
-                .right_join(self.table1)
-                .on(self.table0.foo == self.table1.bar)
-                .select("*")
-            )
+            query = Query.from_(self.table0).right_join(self.table1).on(self.table0.foo == self.table1.bar).select("*")
             self.assertEqual(expected, str(query))
 
     def test_outer_join(self):
-        expected = (
-            'SELECT * FROM "abc" FULL OUTER JOIN "efg" ON "abc"."foo"="efg"."bar"'
-        )
+        expected = 'SELECT * FROM "abc" FULL OUTER JOIN "efg" ON "abc"."foo"="efg"."bar"'
 
         with self.subTest("join with enum"):
             query = (
@@ -113,12 +89,7 @@ class SelectQueryJoinTests(unittest.TestCase):
             self.assertEqual(expected, str(query))
 
         with self.subTest("join function"):
-            query = (
-                Query.from_(self.table0)
-                .outer_join(self.table1)
-                .on(self.table0.foo == self.table1.bar)
-                .select("*")
-            )
+            query = Query.from_(self.table0).outer_join(self.table1).on(self.table0.foo == self.table1.bar).select("*")
             self.assertEqual(expected, str(query))
 
     def test_cross_join(self):
@@ -135,12 +106,7 @@ class SelectQueryJoinTests(unittest.TestCase):
             self.assertEqual(expected, str(query))
 
         with self.subTest("join function"):
-            query = (
-                Query.from_(self.table0)
-                .cross_join(self.table1)
-                .on(self.table0.foo == self.table1.bar)
-                .select("*")
-            )
+            query = Query.from_(self.table0).cross_join(self.table1).on(self.table0.foo == self.table1.bar).select("*")
             self.assertEqual(expected, str(query))
 
     def test_left_outer_join(self):
@@ -184,20 +150,12 @@ class SelectQueryJoinTests(unittest.TestCase):
 
     def test_join_on_field_single(self):
         query = Query.from_(self.table0).join(self.table1).on_field("foo").select("*")
-        self.assertEqual(
-            'SELECT * FROM "abc" JOIN "efg" ON "abc"."foo"="efg"."foo"', str(query)
-        )
+        self.assertEqual('SELECT * FROM "abc" JOIN "efg" ON "abc"."foo"="efg"."foo"', str(query))
 
     def test_join_on_field_multi(self):
-        query = (
-            Query.from_(self.table0)
-            .join(self.table1)
-            .on_field("foo", "bar")
-            .select("*")
-        )
+        query = Query.from_(self.table0).join(self.table1).on_field("foo", "bar").select("*")
         self.assertEqual(
-            'SELECT * FROM "abc" JOIN "efg" ON "abc"."foo"="efg"."foo" '
-            'AND "abc"."bar"="efg"."bar"',
+            'SELECT * FROM "abc" JOIN "efg" ON "abc"."foo"="efg"."foo" ' 'AND "abc"."bar"="efg"."bar"',
             str(query),
         )
 
@@ -223,22 +181,14 @@ class SelectQueryJoinTests(unittest.TestCase):
         self.assertEqual('SELECT * FROM "abc" JOIN "efg" USING ("id")', str(query))
 
     def test_join_using_multiple_fields(self):
-        query = (
-            Query.from_(self.table0).join(self.table1).using("foo", "bar").select("*")
-        )
+        query = Query.from_(self.table0).join(self.table1).using("foo", "bar").select("*")
 
-        self.assertEqual(
-            'SELECT * FROM "abc" JOIN "efg" USING ("foo","bar")', str(query)
-        )
+        self.assertEqual('SELECT * FROM "abc" JOIN "efg" USING ("foo","bar")', str(query))
 
     def test_join_using_with_quote_char(self):
-        query = (
-            Query.from_(self.table0).join(self.table1).using("foo", "bar").select("*")
-        )
+        query = Query.from_(self.table0).join(self.table1).using("foo", "bar").select("*")
 
-        self.assertEqual(
-            "SELECT * FROM abc JOIN efg USING (foo,bar)", query.get_sql(quote_char="")
-        )
+        self.assertEqual("SELECT * FROM abc JOIN efg USING (foo,bar)", query.get_sql(quote_char=""))
 
     def test_join_using_without_fields_raises_exception(self):
         with self.assertRaises(JoinException):
@@ -257,14 +207,15 @@ class SelectQueryJoinTests(unittest.TestCase):
         )
 
         self.assertEqual(
-            'SELECT * FROM "abc" '
-            'JOIN "efg" ON "abc"."dt"="efg"."dt"-INTERVAL \'1 WEEK\'',
+            'SELECT * FROM "abc" ' 'JOIN "efg" ON "abc"."dt"="efg"."dt"-INTERVAL \'1 WEEK\'',
             str(q),
         )
 
     def test_join_with_arithmetic_function_in_select(self):
         q = (
-            Query.from_(self.table0,)
+            Query.from_(
+                self.table0,
+            )
             .join(self.table1)
             .on(self.table0.dt == (self.table1.dt - Interval(weeks=1)))
             .select(self.table0.fiz - self.table0.buz, self.table1.star)
@@ -280,16 +231,12 @@ class SelectQueryJoinTests(unittest.TestCase):
         q = (
             Query.from_(self.table0)
             .join(self.table1, how=JoinType.right)
-            .on(
-                (self.table0.foo == self.table1.fiz)
-                & (self.table0.bar == self.table1.buz)
-            )
+            .on((self.table0.foo == self.table1.fiz) & (self.table0.bar == self.table1.buz))
             .select("*")
         )
 
         self.assertEqual(
-            'SELECT * FROM "abc" '
-            'RIGHT JOIN "efg" ON "abc"."foo"="efg"."fiz" AND "abc"."bar"="efg"."buz"',
+            'SELECT * FROM "abc" ' 'RIGHT JOIN "efg" ON "abc"."foo"="efg"."fiz" AND "abc"."bar"="efg"."buz"',
             str(q),
         )
 
@@ -297,17 +244,11 @@ class SelectQueryJoinTests(unittest.TestCase):
         table_a, table_b, table_c = Tables("a", "b", "c")
         subquery = Query.from_(table_c).select("id").limit(1)
         query = (
-            Query.from_(table_a)
-            .select("*")
-            .join(table_b)
-            .on((table_a.b_id == table_b.id) & (table_b.c_id == subquery))
+            Query.from_(table_a).select("*").join(table_b).on((table_a.b_id == table_b.id) & (table_b.c_id == subquery))
         )
 
         self.assertEqual(
-            "SELECT * "
-            'FROM "a" '
-            'JOIN "b" ON "a"."b_id"="b"."id" AND "b"."c_id"='
-            '(SELECT "id" FROM "c" LIMIT 1)',
+            "SELECT * " 'FROM "a" ' 'JOIN "b" ON "a"."b_id"="b"."id" AND "b"."c_id"=' '(SELECT "id" FROM "c" LIMIT 1)',
             str(query),
         )
 
@@ -319,17 +260,9 @@ class SelectQueryJoinTests(unittest.TestCase):
 
     def test_join_second_table_in_from_clause(self):
         table_a, table_b, table_c = Tables("a", "b", "c")
-        q = (
-            Query.from_(table_a)
-            .from_(table_b)
-            .select("*")
-            .join(table_c)
-            .on(table_b.c_id == table_c.id)
-        )
+        q = Query.from_(table_a).from_(table_b).select("*").join(table_c).on(table_b.c_id == table_c.id)
 
-        self.assertEqual(
-            "SELECT * " 'FROM "a","b" ' 'JOIN "c" ON "b"."c_id"="c"."id"', str(q)
-        )
+        self.assertEqual("SELECT * " 'FROM "a","b" ' 'JOIN "c" ON "b"."c_id"="c"."id"', str(q))
 
     def test_cross_join_on_table(self):
         table_a, table_b = Tables("a", "b")
@@ -342,9 +275,7 @@ class SelectQueryJoinTests(unittest.TestCase):
         q_a = Query.from_(table_a).select("*")
         q_b = Query.from_(table_b).select("*").join(q_a).cross().select("*")
 
-        self.assertEqual(
-            'SELECT * FROM "b" CROSS JOIN (SELECT * FROM "a") "sq0"', str(q_b)
-        )
+        self.assertEqual('SELECT * FROM "b" CROSS JOIN (SELECT * FROM "a") "sq0"', str(q_b))
 
     def test_join_on_collate(self):
         table_a, table_b = Tables("a", "b")
@@ -355,20 +286,13 @@ class SelectQueryJoinTests(unittest.TestCase):
             .join(table_b)
             .on(table_a.foo == table_b.boo, collate="utf8_general_ci")
         )
-        q2 = (
-            Query.from_(table_a)
-            .select(table_b.ouch)
-            .join(table_b)
-            .on(table_a.foo == table_b.boo)
-        )
+        q2 = Query.from_(table_a).select(table_b.ouch).join(table_b).on(table_a.foo == table_b.boo)
 
         self.assertEqual(
             'SELECT "b"."ouch" FROM "a" JOIN "b" ON "a"."foo"="b"."boo" COLLATE utf8_general_ci',
             str(q1),
         )
-        self.assertEqual(
-            'SELECT "b"."ouch" FROM "a" JOIN "b" ON "a"."foo"="b"."boo"', str(q2)
-        )
+        self.assertEqual('SELECT "b"."ouch" FROM "a" JOIN "b" ON "a"."foo"="b"."boo"', str(q2))
 
 
 class JoinBehaviorTests(unittest.TestCase):
@@ -456,49 +380,31 @@ class JoinBehaviorTests(unittest.TestCase):
 
     def test_require_condition_with_both_tables(self):
         with self.assertRaises(JoinException):
-            Query.from_(self.table_abc).join(self.table_efg).on(
-                self.table_abc.foo == self.table_hij.bar
-            )
+            Query.from_(self.table_abc).join(self.table_efg).on(self.table_abc.foo == self.table_hij.bar)
 
         with self.assertRaises(JoinException):
-            Query.from_(self.table_abc).join(self.table_efg).on(
-                self.table_hij.foo == self.table_efg.bar
-            )
+            Query.from_(self.table_abc).join(self.table_efg).on(self.table_hij.foo == self.table_efg.bar)
 
         with self.assertRaises(JoinException):
-            Query.from_(self.table_abc).join(self.table_efg).on(
-                self.table_hij.foo == self.table_klm.bar
-            )
+            Query.from_(self.table_abc).join(self.table_efg).on(self.table_hij.foo == self.table_klm.bar)
 
     def test_join_same_table(self):
         table1 = Table("abc")
         table2 = Table("abc")
-        q = (
-            Query.from_(table1)
-            .join(table2)
-            .on(table1.foo == table2.bar)
-            .select(table1.foo, table2.buz)
-        )
+        q = Query.from_(table1).join(table2).on(table1.foo == table2.bar).select(table1.foo, table2.buz)
 
         self.assertEqual(
-            'SELECT "abc"."foo","abc2"."buz" FROM "abc" '
-            'JOIN "abc" "abc2" ON "abc"."foo"="abc2"."bar"',
+            'SELECT "abc"."foo","abc2"."buz" FROM "abc" ' 'JOIN "abc" "abc2" ON "abc"."foo"="abc2"."bar"',
             str(q),
         )
 
     def test_join_same_table_with_prefixes(self):
         table1 = Table("abc").as_("x")
         table2 = Table("abc").as_("y")
-        q = (
-            Query.from_(table1)
-            .join(table2)
-            .on(table1.foo == table2.bar)
-            .select(table1.foo, table2.buz)
-        )
+        q = Query.from_(table1).join(table2).on(table1.foo == table2.bar).select(table1.foo, table2.buz)
 
         self.assertEqual(
-            'SELECT "x"."foo","y"."buz" FROM "abc" "x" '
-            'JOIN "abc" "y" ON "x"."foo"="y"."bar"',
+            'SELECT "x"."foo","y"."buz" FROM "abc" "x" ' 'JOIN "abc" "y" ON "x"."foo"="y"."bar"',
             str(q),
         )
 
@@ -548,8 +454,7 @@ class JoinBehaviorTests(unittest.TestCase):
         )
 
         self.assertEqual(
-            'SELECT "abc"."foo","efg"."buz" FROM "abc" '
-            'JOIN "efg" ON "abc"."foo"="efg"."bar"',
+            'SELECT "abc"."foo","efg"."buz" FROM "abc" ' 'JOIN "efg" ON "abc"."foo"="efg"."bar"',
             str(query2),
         )
         self.assertEqual('SELECT "foo" FROM "abc"', str(query1))
@@ -569,20 +474,14 @@ class JoinBehaviorTests(unittest.TestCase):
 
         Query.from_(self.table_abc).where(fn.Sum(self.table_efg.foo) == 0)
 
-        Query.from_(self.table_abc).select(
-            fn.Sum(self.table_abc.bar * 2) + fn.Sum(self.table_efg.foo * 2)
-        )
+        Query.from_(self.table_abc).select(fn.Sum(self.table_abc.bar * 2) + fn.Sum(self.table_efg.foo * 2))
 
         Query.from_(self.table_abc).groupby(self.table_efg.foo)
 
-        Query.from_(self.table_abc).groupby(self.table_abc.foo).having(
-            self.table_efg.bar
-        )
+        Query.from_(self.table_abc).groupby(self.table_abc.foo).having(self.table_efg.bar)
 
         subquery = (
-            Query.from_(self.table_efg)
-            .select(self.table_efg.id)
-            .where(self.table_efg.abc_id == self.table_abc.id)
+            Query.from_(self.table_efg).select(self.table_efg.id).where(self.table_efg.abc_id == self.table_abc.id)
         )
         query = Query.from_(self.table_abc).select(subquery.as_("efg_id").limit(1))
         self.assertEqual(
@@ -729,18 +628,10 @@ class JoinBehaviorTests(unittest.TestCase):
         )
 
     def test_join_query_with_setoperation(self):
-        subquery = (
-            Query.from_(self.table_abc).select("*")
-            .union(
-                Query.from_(self.table_abc).select("*")
-            ).as_("subq")
-        )
+        subquery = Query.from_(self.table_abc).select("*").union(Query.from_(self.table_abc).select("*")).as_("subq")
 
         test_query = (
-            Query.from_(self.table_abc)
-            .join(subquery)
-            .on(subquery.x == self.table_abc.id)
-            .select(self.table_abc.foo)
+            Query.from_(self.table_abc).join(subquery).on(subquery.x == self.table_abc.id).select(self.table_abc.foo)
         )
 
         self.assertEqual(
@@ -750,8 +641,9 @@ class JoinBehaviorTests(unittest.TestCase):
             'UNION '
             '(SELECT * FROM "abc")) "subq" '
             'ON "subq"."x"="abc"."id"',
-            str(test_query)
+            str(test_query),
         )
+
 
 class UnionTests(unittest.TestCase):
     table1, table2 = Tables("abc", "efg")
@@ -834,18 +726,12 @@ class UnionTests(unittest.TestCase):
         union_all_query = str((query1 * query2).orderby(query1.field("a")))
 
         self.assertEqual(
-            '(SELECT "foo" "a" FROM "abc") '
-            "UNION "
-            '(SELECT "bar" "a" FROM "efg") '
-            'ORDER BY "a"',
+            '(SELECT "foo" "a" FROM "abc") ' "UNION " '(SELECT "bar" "a" FROM "efg") ' 'ORDER BY "a"',
             union_query,
         )
 
         self.assertEqual(
-            '(SELECT "foo" "a" FROM "abc") '
-            "UNION ALL "
-            '(SELECT "bar" "a" FROM "efg") '
-            'ORDER BY "a"',
+            '(SELECT "foo" "a" FROM "abc") ' "UNION ALL " '(SELECT "bar" "a" FROM "efg") ' 'ORDER BY "a"',
             union_all_query,
         )
 
@@ -859,17 +745,11 @@ class UnionTests(unittest.TestCase):
         union_all_query = str(union_all_query.orderby(union_all_query.field("a")))
 
         self.assertEqual(
-            '(SELECT "foo" "a" FROM "abc") '
-            "UNION "
-            '(SELECT "bar" "a" FROM "efg") '
-            'ORDER BY "a"',
+            '(SELECT "foo" "a" FROM "abc") ' "UNION " '(SELECT "bar" "a" FROM "efg") ' 'ORDER BY "a"',
             union_query,
         )
         self.assertEqual(
-            '(SELECT "foo" "a" FROM "abc") '
-            "UNION ALL "
-            '(SELECT "bar" "a" FROM "efg") '
-            'ORDER BY "a"',
+            '(SELECT "foo" "a" FROM "abc") ' "UNION ALL " '(SELECT "bar" "a" FROM "efg") ' 'ORDER BY "a"',
             union_all_query,
         )
 
@@ -880,17 +760,11 @@ class UnionTests(unittest.TestCase):
         union_all_query = str((query1 * query2).orderby(query1.field("a")))
         union_query = str((query1 + query2).orderby(query1.field("a")))
         self.assertEqual(
-            '(SELECT "foo" "a" FROM "abc" "a")'
-            " UNION ALL "
-            '(SELECT "bar" "a" FROM "efg" "b")'
-            ' ORDER BY "a"',
+            '(SELECT "foo" "a" FROM "abc" "a")' " UNION ALL " '(SELECT "bar" "a" FROM "efg" "b")' ' ORDER BY "a"',
             union_all_query,
         )
         self.assertEqual(
-            '(SELECT "foo" "a" FROM "abc" "a")'
-            " UNION "
-            '(SELECT "bar" "a" FROM "efg" "b")'
-            ' ORDER BY "a"',
+            '(SELECT "foo" "a" FROM "abc" "a")' " UNION " '(SELECT "bar" "a" FROM "efg" "b")' ' ORDER BY "a"',
             union_query,
         )
 
@@ -904,17 +778,11 @@ class UnionTests(unittest.TestCase):
         union_all_query = union_all_query.orderby(union_all_query.field("a"))
 
         self.assertEqual(
-            '(SELECT "foo" "a" FROM "abc") '
-            "UNION "
-            '(SELECT "bar" "a" FROM "efg") '
-            'ORDER BY "x"."a"',
+            '(SELECT "foo" "a" FROM "abc") ' "UNION " '(SELECT "bar" "a" FROM "efg") ' 'ORDER BY "x"."a"',
             str(union_query),
         )
         self.assertEqual(
-            '(SELECT "foo" "a" FROM "abc") '
-            "UNION ALL "
-            '(SELECT "bar" "a" FROM "efg") '
-            'ORDER BY "x"."a"',
+            '(SELECT "foo" "a" FROM "abc") ' "UNION ALL " '(SELECT "bar" "a" FROM "efg") ' 'ORDER BY "x"."a"',
             str(union_all_query),
         )
 
@@ -958,14 +826,7 @@ class UnionTests(unittest.TestCase):
 class InsertQueryJoinTests(unittest.TestCase):
     def test_join_table_on_insert_query(self):
         a, b, c = Tables("a", "b", "c")
-        q = (
-            Query.into(c)
-            .from_(a)
-            .join(b)
-            .on(a.fkey_id == b.id)
-            .where(b.foo == 1)
-            .select("a.*", "b.*")
-        )
+        q = Query.into(c).from_(a).join(b).on(a.fkey_id == b.id).where(b.foo == 1).select("a.*", "b.*")
 
         self.assertEqual(
             'INSERT INTO "c" '
@@ -980,20 +841,10 @@ class InsertQueryJoinTests(unittest.TestCase):
 class UpdateQueryJoinTests(unittest.TestCase):
     def test_join_table_on_update_query(self):
         a, b = Tables("a", "b")
-        q = (
-            Query.update(a)
-            .join(b)
-            .on(a.fkey_id == b.id)
-            .where(b.foo == 1)
-            .set("adwords_batch_job_id", 1)
-        )
+        q = Query.update(a).join(b).on(a.fkey_id == b.id).where(b.foo == 1).set("adwords_batch_job_id", 1)
 
         self.assertEqual(
-            'UPDATE "a" '
-            'JOIN "b" '
-            'ON "a"."fkey_id"="b"."id" '
-            'SET "adwords_batch_job_id"=1 '
-            'WHERE "b"."foo"=1',
+            'UPDATE "a" ' 'JOIN "b" ' 'ON "a"."fkey_id"="b"."id" ' 'SET "adwords_batch_job_id"=1 ' 'WHERE "b"."foo"=1',
             str(q),
         )
 
@@ -1032,10 +883,7 @@ class IntersectTests(unittest.TestCase):
         intersect_query = str((query1.intersect(query2)).orderby(query1.field("a")))
 
         self.assertEqual(
-            '(SELECT "foo" "a" FROM "abc") '
-            "INTERSECT "
-            '(SELECT "bar" "a" FROM "efg") '
-            'ORDER BY "a"',
+            '(SELECT "foo" "a" FROM "abc") ' "INTERSECT " '(SELECT "bar" "a" FROM "efg") ' 'ORDER BY "a"',
             intersect_query,
         )
 
@@ -1046,10 +894,7 @@ class IntersectTests(unittest.TestCase):
         intersect_query = str((query1.intersect(query2)).limit(10))
 
         self.assertEqual(
-            '(SELECT "foo" "a" FROM "abc") '
-            "INTERSECT "
-            '(SELECT "bar" "a" FROM "efg") '
-            'LIMIT 10',
+            '(SELECT "foo" "a" FROM "abc") ' "INTERSECT " '(SELECT "bar" "a" FROM "efg") ' 'LIMIT 10',
             intersect_query,
         )
 
@@ -1060,10 +905,7 @@ class IntersectTests(unittest.TestCase):
         intersect_query = str((query1.intersect(query2)).offset(10))
 
         self.assertEqual(
-            '(SELECT "foo" "a" FROM "abc") '
-            "INTERSECT "
-            '(SELECT "bar" "a" FROM "efg") '
-            'OFFSET 10',
+            '(SELECT "foo" "a" FROM "abc") ' "INTERSECT " '(SELECT "bar" "a" FROM "efg") ' 'OFFSET 10',
             intersect_query,
         )
 
@@ -1111,10 +953,7 @@ class MinusTests(unittest.TestCase):
         query1 = Query.from_(self.table1).select(self.table1.foo)
         query2 = Query.from_(self.table2).select(self.table2.bar)
 
-        self.assertEqual(
-            '(SELECT "foo" FROM "abc") MINUS (SELECT "bar" FROM "efg")',
-            str(query1.minus(query2))
-        )
+        self.assertEqual('(SELECT "foo" FROM "abc") MINUS (SELECT "bar" FROM "efg")', str(query1.minus(query2)))
 
         self.assertEqual(
             '(SELECT "foo" FROM "abc") MINUS (SELECT "bar" FROM "efg")',
@@ -1151,11 +990,7 @@ class MinusTests(unittest.TestCase):
         minus_query = str(query1.minus(query2).orderby(query1.field("a")))
 
         self.assertEqual(
-            '(SELECT "foo" "a" FROM "abc") '
-            "MINUS "
-            '(SELECT "bar" "a" FROM "efg") '
-            'ORDER BY "a"',
-            minus_query
+            '(SELECT "foo" "a" FROM "abc") ' "MINUS " '(SELECT "bar" "a" FROM "efg") ' 'ORDER BY "a"', minus_query
         )
 
     def test_minus_query_with_order_by_use_minus_query_field(self):
@@ -1166,10 +1001,7 @@ class MinusTests(unittest.TestCase):
         minus_query = str(minus_query.orderby(minus_query.field("b")))
 
         self.assertEqual(
-            '(SELECT "foo" "a" FROM "abc") '
-            "MINUS "
-            '(SELECT "bar" "a" FROM "efg") '
-            'ORDER BY "b"',
+            '(SELECT "foo" "a" FROM "abc") ' "MINUS " '(SELECT "bar" "a" FROM "efg") ' 'ORDER BY "b"',
             minus_query,
         )
 
@@ -1217,10 +1049,7 @@ class ExceptOfTests(unittest.TestCase):
         query1 = Query.from_(self.table1).select(self.table1.foo)
         query2 = Query.from_(self.table2).select(self.table2.bar)
 
-        self.assertEqual(
-            '(SELECT "foo" FROM "abc") EXCEPT (SELECT "bar" FROM "efg")',
-            str(query1.except_of(query2))
-        )
+        self.assertEqual('(SELECT "foo" FROM "abc") EXCEPT (SELECT "bar" FROM "efg")', str(query1.except_of(query2)))
 
     def test_except_multiple(self):
         table3, table4 = Tables("hij", "lmn")
@@ -1244,11 +1073,7 @@ class ExceptOfTests(unittest.TestCase):
         except_query = str(query1.except_of(query2).orderby(query1.field("a")))
 
         self.assertEqual(
-            '(SELECT "foo" "a" FROM "abc") '
-            "EXCEPT "
-            '(SELECT "bar" "a" FROM "efg") '
-            'ORDER BY "a"',
-            except_query
+            '(SELECT "foo" "a" FROM "abc") ' "EXCEPT " '(SELECT "bar" "a" FROM "efg") ' 'ORDER BY "a"', except_query
         )
 
     def test_except_query_with_order_by_use_minus_query_field(self):
@@ -1259,10 +1084,7 @@ class ExceptOfTests(unittest.TestCase):
         except_query = str(except_query.orderby(except_query.field("b")))
 
         self.assertEqual(
-            '(SELECT "foo" "a" FROM "abc") '
-            "EXCEPT "
-            '(SELECT "bar" "a" FROM "efg") '
-            'ORDER BY "b"',
+            '(SELECT "foo" "a" FROM "abc") ' "EXCEPT " '(SELECT "bar" "a" FROM "efg") ' 'ORDER BY "b"',
             except_query,
         )
 

--- a/pypika/tests/test_negation.py
+++ b/pypika/tests/test_negation.py
@@ -28,6 +28,4 @@ class NegationTests(unittest.TestCase):
     def test_negate_function(self):
         q = -fn.Sum(self.table_abc.foo)
 
-        self.assertEqual(
-            '-SUM("abc"."foo")', q.get_sql(with_namespace=True, quote_char='"')
-        )
+        self.assertEqual('-SUM("abc"."foo")', q.get_sql(with_namespace=True, quote_char='"'))

--- a/pypika/tests/test_parameter.py
+++ b/pypika/tests/test_parameter.py
@@ -1,17 +1,13 @@
 import unittest
 
-from pypika import Tables, Query, Parameter
+from pypika import Parameter, Query, Tables
 
 
 class ParametrizedTests(unittest.TestCase):
     table_abc, table_efg = Tables("abc", "efg")
 
     def test_param_insert(self):
-        q = (
-            Query.into(self.table_abc)
-            .columns("a", "b", "c")
-            .insert(Parameter("?"), Parameter("?"), Parameter("?"))
-        )
+        q = Query.into(self.table_abc).columns("a", "b", "c").insert(Parameter("?"), Parameter("?"), Parameter("?"))
 
         self.assertEqual('INSERT INTO "abc" ("a","b","c") VALUES (?,?,?)', q.get_sql())
 

--- a/pypika/tests/test_pseudocolumns.py
+++ b/pypika/tests/test_pseudocolumns.py
@@ -1,9 +1,6 @@
 import unittest
 
-from pypika import (
-    Table,
-    Query,
-)
+from pypika import Query, Table
 from pypika.pseudocolumns import (
     ColumnValue,
     ObjectID,
@@ -40,19 +37,11 @@ class PseudoColumnsTest(unittest.TestCase):
         self.assertEqual("SYSDATE", SysDate)
 
     def test_can_be_used_in_a_select_statement(self):
-        query = (
-            Query.from_(self.table1)
-            .where(self.table1.is_active == 1)
-            .select(PseudoColumn("abcde"))
-        )
+        query = Query.from_(self.table1).where(self.table1.is_active == 1).select(PseudoColumn("abcde"))
 
         self.assertEqual(str(query), 'SELECT abcde FROM "table1" WHERE "is_active"=1')
 
     def test_can_be_used_in_a_where_clause(self):
-        query = (
-            Query.from_(self.table1)
-            .where(PseudoColumn("abcde") > 1)
-            .select(self.table1.is_active)
-        )
+        query = Query.from_(self.table1).where(PseudoColumn("abcde") > 1).select(self.table1.is_active)
 
         self.assertEqual(str(query), 'SELECT "is_active" FROM "table1" WHERE abcde>1')

--- a/pypika/tests/test_query.py
+++ b/pypika/tests/test_query.py
@@ -1,6 +1,6 @@
 import unittest
 
-from pypika import Case, Query, Tables, functions, Tuple
+from pypika import Case, Query, Tables, Tuple, functions
 
 
 class QueryTablesTests(unittest.TestCase):
@@ -56,16 +56,10 @@ class QueryTablesTests(unittest.TestCase):
         )
 
     def test_replace_filter_tables(self):
-        query = (
-            Query.from_(self.table_a)
-            .select(self.table_a.name)
-            .where(self.table_a.name == "Mustermann")
-        )
+        query = Query.from_(self.table_a).select(self.table_a.name).where(self.table_a.name == "Mustermann")
         query = query.replace_table(self.table_a, self.table_b)
 
-        self.assertEqual(
-            'SELECT "name" FROM "b" WHERE "name"=\'Mustermann\'', str(query)
-        )
+        self.assertEqual('SELECT "name" FROM "b" WHERE "name"=\'Mustermann\'', str(query))
 
     def test_replace_having_table(self):
         query = (
@@ -77,10 +71,7 @@ class QueryTablesTests(unittest.TestCase):
         query = query.replace_table(self.table_a, self.table_b)
 
         self.assertEqual(
-            'SELECT SUM("revenue") '
-            'FROM "b" '
-            'GROUP BY "customer" '
-            'HAVING SUM("revenue")>=1000',
+            'SELECT SUM("revenue") ' 'FROM "b" ' 'GROUP BY "customer" ' 'HAVING SUM("revenue")>=1000',
             str(query),
         )
 
@@ -104,16 +95,10 @@ class QueryTablesTests(unittest.TestCase):
         )
 
     def test_replace_orderby_table(self):
-        query = (
-            Query.from_(self.table_a)
-            .select(self.table_a.customer)
-            .orderby(self.table_a.customer)
-        )
+        query = Query.from_(self.table_a).select(self.table_a.customer).orderby(self.table_a.customer)
         query = query.replace_table(self.table_a, self.table_b)
 
-        self.assertEqual(
-            'SELECT "customer" FROM "b" ORDER BY "customer"', str(query)
-        )
+        self.assertEqual('SELECT "customer" FROM "b" ORDER BY "customer"', str(query))
 
     def test_replace_tuple_table(self):
         query = (
@@ -131,11 +116,7 @@ class QueryTablesTests(unittest.TestCase):
         )
 
     def test_is_joined(self):
-        q = (
-            Query.from_(self.table_a)
-            .join(self.table_b)
-            .on(self.table_a.foo == self.table_b.boo)
-        )
+        q = Query.from_(self.table_a).join(self.table_b).on(self.table_a.foo == self.table_b.boo)
 
         self.assertTrue(q.is_joined(self.table_b))
         self.assertFalse(q.is_joined(self.table_c))

--- a/pypika/tests/test_selects.py
+++ b/pypika/tests/test_selects.py
@@ -96,9 +96,7 @@ class SelectTests(unittest.TestCase):
         self.assertEqual('SELECT "foo" "bar" FROM "abc"', str(q))
 
     def test_select__column__single__table_alias__str(self):
-        q = Query.from_(self.table_abc.as_("fizzbuzz")).select(
-              self.table_abc.foo.as_("bar")
-        )
+        q = Query.from_(self.table_abc.as_("fizzbuzz")).select(self.table_abc.foo.as_("bar"))
 
         self.assertEqual('SELECT "foo" "bar" FROM "abc" "fizzbuzz"', str(q))
 
@@ -117,22 +115,13 @@ class SelectTests(unittest.TestCase):
 
     def test_select__columns__multi__field(self):
         q1 = Query.from_(self.table_abc).select(self.table_abc.foo, self.table_abc.bar)
-        q2 = (
-            Query.from_(self.table_abc)
-                .select(self.table_abc.foo)
-                .select(self.table_abc.bar)
-        )
+        q2 = Query.from_(self.table_abc).select(self.table_abc.foo).select(self.table_abc.bar)
 
         self.assertEqual('SELECT "foo","bar" FROM "abc"', str(q1))
         self.assertEqual('SELECT "foo","bar" FROM "abc"', str(q2))
 
     def test_select__multiple_tables(self):
-        q = (
-            Query.from_(self.table_abc)
-                .select(self.table_abc.foo)
-                .from_(self.table_efg)
-                .select(self.table_efg.bar)
-        )
+        q = Query.from_(self.table_abc).select(self.table_abc.foo).from_(self.table_efg).select(self.table_efg.bar)
 
         self.assertEqual('SELECT "abc"."foo","efg"."bar" FROM "abc","efg"', str(q))
 
@@ -140,9 +129,7 @@ class SelectTests(unittest.TestCase):
         subquery = Query.from_(self.table_abc).select("*")
         q = Query.from_(subquery).select(subquery.foo, subquery.bar)
 
-        self.assertEqual(
-              'SELECT "sq0"."foo","sq0"."bar" ' 'FROM (SELECT * FROM "abc") "sq0"', str(q)
-        )
+        self.assertEqual('SELECT "sq0"."foo","sq0"."bar" ' 'FROM (SELECT * FROM "abc") "sq0"', str(q))
 
     def test_select__multiple_subqueries(self):
         subquery0 = Query.from_(self.table_abc).select("foo")
@@ -150,10 +137,8 @@ class SelectTests(unittest.TestCase):
         q = Query.from_(subquery0).from_(subquery1).select(subquery0.foo, subquery1.bar)
 
         self.assertEqual(
-              'SELECT "sq0"."foo","sq1"."bar" '
-              'FROM (SELECT "foo" FROM "abc") "sq0",'
-              '(SELECT "bar" FROM "efg") "sq1"',
-              str(q),
+            'SELECT "sq0"."foo","sq1"."bar" ' 'FROM (SELECT "foo" FROM "abc") "sq0",' '(SELECT "bar" FROM "efg") "sq1"',
+            str(q),
         )
 
     def test_select__nested_subquery(self):
@@ -164,11 +149,11 @@ class SelectTests(unittest.TestCase):
         q = Query.from_(subquery2).select(subquery2.foo)
 
         self.assertEqual(
-              'SELECT "sq2"."foo" '
-              'FROM (SELECT "sq1"."foo" '
-              'FROM (SELECT "sq0"."foo","sq0"."bar" '
-              'FROM (SELECT * FROM "abc") "sq0") "sq1") "sq2"',
-              str(q),
+            'SELECT "sq2"."foo" '
+            'FROM (SELECT "sq1"."foo" '
+            'FROM (SELECT "sq0"."foo","sq0"."bar" '
+            'FROM (SELECT * FROM "abc") "sq0") "sq1") "sq2"',
+            str(q),
         )
 
     def test_select__no_table(self):
@@ -232,7 +217,14 @@ class SelectTests(unittest.TestCase):
         self.assertEqual('SELECT "foo" FROM "abc" FORCE INDEX ("egg","bacon")', str(q))
 
     def test_select_with_force_index_multiple_calls(self):
-        q = Query.from_("abc").select("foo").force_index("egg", ).force_index("spam")
+        q = (
+            Query.from_("abc")
+            .select("foo")
+            .force_index(
+                "egg",
+            )
+            .force_index("spam")
+        )
 
         self.assertEqual('SELECT "foo" FROM "abc" FORCE INDEX ("egg","spam")', str(q))
 
@@ -253,7 +245,14 @@ class SelectTests(unittest.TestCase):
         self.assertEqual('SELECT "foo" FROM "abc" USE INDEX ("egg","bacon")', str(q))
 
     def test_select_with_use_index_multiple_calls(self):
-        q = Query.from_("abc").select("foo").use_index("egg", ).use_index("spam")
+        q = (
+            Query.from_("abc")
+            .select("foo")
+            .use_index(
+                "egg",
+            )
+            .use_index("spam")
+        )
 
         self.assertEqual('SELECT "foo" FROM "abc" USE INDEX ("egg","spam")', str(q))
 
@@ -294,12 +293,10 @@ class SelectTests(unittest.TestCase):
         self.assertEqual(q, Query.from_("abc").select(1))
 
     def test_table_select_alias_with_offset_and_limit(self):
+        self.assertEqual(self.table_abc.select("foo")[10:10], Query.from_("abc").select("foo")[10:10])
         self.assertEqual(
-              self.table_abc.select("foo")[10:10], Query.from_("abc").select("foo")[10:10]
-        )
-        self.assertEqual(
-              self.table_abc.select(self.table_abc.foo)[10:10],
-              Query.from_("abc").select("foo")[10:10],
+            self.table_abc.select(self.table_abc.foo)[10:10],
+            Query.from_("abc").select("foo")[10:10],
         )
 
 
@@ -320,38 +317,19 @@ class WhereTests(unittest.TestCase):
         self.assertEqual('SELECT * FROM "abc" WHERE "foo"="bar" FOR UPDATE', str(q))
 
     def test_where_field_equals_where(self):
-        q = (
-            Query.from_(self.t)
-                .select("*")
-                .where(self.t.foo == 1)
-                .where(self.t.bar == self.t.baz)
-        )
+        q = Query.from_(self.t).select("*").where(self.t.foo == 1).where(self.t.bar == self.t.baz)
 
         self.assertEqual('SELECT * FROM "abc" WHERE "foo"=1 AND "bar"="baz"', str(q))
 
     def test_where_field_equals_where_not(self):
-        q = (
-            Query.from_(self.t)
-                .select("*")
-                .where((self.t.foo == 1).negate())
-                .where(self.t.bar == self.t.baz)
-        )
+        q = Query.from_(self.t).select("*").where((self.t.foo == 1).negate()).where(self.t.bar == self.t.baz)
 
-        self.assertEqual(
-              'SELECT * FROM "abc" WHERE NOT "foo"=1 AND "bar"="baz"', str(q)
-        )
+        self.assertEqual('SELECT * FROM "abc" WHERE NOT "foo"=1 AND "bar"="baz"', str(q))
 
     def test_where_field_equals_where_two_not(self):
-        q = (
-            Query.from_(self.t)
-                .select("*")
-                .where((self.t.foo == 1).negate())
-                .where((self.t.bar == self.t.baz).negate())
-        )
+        q = Query.from_(self.t).select("*").where((self.t.foo == 1).negate()).where((self.t.bar == self.t.baz).negate())
 
-        self.assertEqual(
-              'SELECT * FROM "abc" WHERE NOT "foo"=1 AND NOT "bar"="baz"', str(q)
-        )
+        self.assertEqual('SELECT * FROM "abc" WHERE NOT "foo"=1 AND NOT "bar"="baz"', str(q))
 
     def test_where_single_quote(self):
         q1 = Query.from_(self.t).select("*").where(self.t.foo == "bar'foo")
@@ -359,34 +337,19 @@ class WhereTests(unittest.TestCase):
         self.assertEqual("SELECT * FROM \"abc\" WHERE \"foo\"='bar''foo'", str(q1))
 
     def test_where_field_equals_and(self):
-        q = (
-            Query.from_(self.t)
-                .select("*")
-                .where((self.t.foo == 1) & (self.t.bar == self.t.baz))
-        )
+        q = Query.from_(self.t).select("*").where((self.t.foo == 1) & (self.t.bar == self.t.baz))
 
         self.assertEqual('SELECT * FROM "abc" WHERE "foo"=1 AND "bar"="baz"', str(q))
 
     def test_where_field_equals_or(self):
-        q = (
-            Query.from_(self.t)
-                .select("*")
-                .where((self.t.foo == 1) | (self.t.bar == self.t.baz))
-        )
+        q = Query.from_(self.t).select("*").where((self.t.foo == 1) | (self.t.bar == self.t.baz))
 
         self.assertEqual('SELECT * FROM "abc" WHERE "foo"=1 OR "bar"="baz"', str(q))
 
     def test_where_nested_conditions(self):
-        q = (
-            Query.from_(self.t)
-                .select("*")
-                .where((self.t.foo == 1) | (self.t.bar == self.t.baz))
-                .where(self.t.baz == 0)
-        )
+        q = Query.from_(self.t).select("*").where((self.t.foo == 1) | (self.t.bar == self.t.baz)).where(self.t.baz == 0)
 
-        self.assertEqual(
-              'SELECT * FROM "abc" WHERE ("foo"=1 OR "bar"="baz") AND "baz"=0', str(q)
-        )
+        self.assertEqual('SELECT * FROM "abc" WHERE ("foo"=1 OR "bar"="baz") AND "baz"=0', str(q))
 
     def test_where_field_starts_with(self):
         q = Query.from_(self.t).select(self.t.star).where(self.t.foo.like("ab%"))
@@ -439,16 +402,9 @@ class WhereTests(unittest.TestCase):
         self.assertEqual('SELECT * FROM "abc"', str(q1))
 
     def test_select_with_force_index_and_where(self):
-        q = (
-            Query.from_("abc")
-                .select("foo")
-                .where(self.t.foo == self.t.bar)
-                .force_index("egg")
-        )
+        q = Query.from_("abc").select("foo").where(self.t.foo == self.t.bar).force_index("egg")
 
-        self.assertEqual(
-              'SELECT "foo" FROM "abc" FORCE INDEX ("egg") WHERE "foo"="bar"', str(q)
-        )
+        self.assertEqual('SELECT "foo" FROM "abc" FORCE INDEX ("egg") WHERE "foo"="bar"', str(q))
 
 
 class PreWhereTests(WhereTests):
@@ -462,16 +418,9 @@ class PreWhereTests(WhereTests):
         self.assertEqual('SELECT * FROM "abc" PREWHERE "foo"="bar"', str(q2))
 
     def test_where_and_prewhere(self):
-        q = (
-            Query.from_(self.t)
-                .select("*")
-                .prewhere(self.t.foo == self.t.bar)
-                .where(self.t.foo == self.t.bar)
-        )
+        q = Query.from_(self.t).select("*").prewhere(self.t.foo == self.t.bar).where(self.t.foo == self.t.bar)
 
-        self.assertEqual(
-              'SELECT * FROM "abc" PREWHERE "foo"="bar" WHERE "foo"="bar"', str(q)
-        )
+        self.assertEqual('SELECT * FROM "abc" PREWHERE "foo"="bar" WHERE "foo"="bar"', str(q))
 
 
 class GroupByTests(unittest.TestCase):
@@ -484,11 +433,7 @@ class GroupByTests(unittest.TestCase):
         self.assertEqual('SELECT "foo" FROM "abc" GROUP BY "foo"', str(q))
 
     def test_groupby__multi(self):
-        q = (
-            Query.from_(self.t)
-                .groupby(self.t.foo, self.t.bar)
-                .select(self.t.foo, self.t.bar)
-        )
+        q = Query.from_(self.t).groupby(self.t.foo, self.t.bar).select(self.t.foo, self.t.bar)
 
         self.assertEqual('SELECT "foo","bar" FROM "abc" GROUP BY "foo","bar"', str(q))
 
@@ -498,42 +443,24 @@ class GroupByTests(unittest.TestCase):
         self.assertEqual('SELECT "foo",COUNT(*) FROM "abc" GROUP BY "foo"', str(q))
 
     def test_groupby__count_field(self):
-        q = (
-            Query.from_(self.t)
-                .groupby(self.t.foo)
-                .select(self.t.foo, fn.Count(self.t.bar))
-        )
+        q = Query.from_(self.t).groupby(self.t.foo).select(self.t.foo, fn.Count(self.t.bar))
 
         self.assertEqual('SELECT "foo",COUNT("bar") FROM "abc" GROUP BY "foo"', str(q))
 
     def test_groupby__count_distinct(self):
-        q = (
-            Query.from_(self.t)
-                .groupby(self.t.foo)
-                .select(self.t.foo, fn.Count("*").distinct())
-        )
+        q = Query.from_(self.t).groupby(self.t.foo).select(self.t.foo, fn.Count("*").distinct())
 
-        self.assertEqual(
-              'SELECT "foo",COUNT(DISTINCT *) FROM "abc" GROUP BY "foo"', str(q)
-        )
+        self.assertEqual('SELECT "foo",COUNT(DISTINCT *) FROM "abc" GROUP BY "foo"', str(q))
 
     def test_groupby__sum_distinct(self):
-        q = (
-            Query.from_(self.t)
-                .groupby(self.t.foo)
-                .select(self.t.foo, fn.Sum(self.t.bar).distinct())
-        )
+        q = Query.from_(self.t).groupby(self.t.foo).select(self.t.foo, fn.Sum(self.t.bar).distinct())
 
-        self.assertEqual(
-              'SELECT "foo",SUM(DISTINCT "bar") FROM "abc" GROUP BY "foo"', str(q)
-        )
+        self.assertEqual('SELECT "foo",SUM(DISTINCT "bar") FROM "abc" GROUP BY "foo"', str(q))
 
     def test_groupby__str(self):
         q = Query.from_("abc").groupby("foo").select("foo", fn.Count("*").distinct())
 
-        self.assertEqual(
-              'SELECT "foo",COUNT(DISTINCT *) FROM "abc" GROUP BY "foo"', str(q)
-        )
+        self.assertEqual('SELECT "foo",COUNT(DISTINCT *) FROM "abc" GROUP BY "foo"', str(q))
 
     def test_groupby__int(self):
         q = Query.from_("abc").groupby(1).select("foo", fn.Count("*").distinct())
@@ -544,17 +471,15 @@ class GroupByTests(unittest.TestCase):
         bar = self.t.bar.as_("bar01")
         q = Query.from_(self.t).select(fn.Sum(self.t.foo), bar).groupby(bar)
 
-        self.assertEqual(
-              'SELECT SUM("foo"),"bar" "bar01" FROM "abc" GROUP BY "bar01"', str(q)
-        )
+        self.assertEqual('SELECT SUM("foo"),"bar" "bar01" FROM "abc" GROUP BY "bar01"', str(q))
 
     def test_groupby__no_alias(self):
         bar = self.t.bar.as_("bar01")
         q = Query.from_(self.t).select(fn.Sum(self.t.foo), bar).groupby(bar)
 
         self.assertEqual(
-              'SELECT SUM("foo"),"bar" "bar01" FROM "abc" GROUP BY "bar"',
-              q.get_sql(groupby_alias=False),
+            'SELECT SUM("foo"),"bar" "bar01" FROM "abc" GROUP BY "bar"',
+            q.get_sql(groupby_alias=False),
         )
 
     def test_groupby__no_alias_platforms(self):
@@ -562,9 +487,7 @@ class GroupByTests(unittest.TestCase):
         for query_cls in [MSSQLQuery, OracleQuery]:
             q = query_cls.from_(self.t).select(fn.Sum(self.t.foo), bar).groupby(bar)
 
-            self.assertEqual(
-                  'SELECT SUM("foo"),"bar" "bar01" FROM "abc" GROUP BY "bar"', str(q)
-            )
+            self.assertEqual('SELECT SUM("foo"),"bar" "bar01" FROM "abc" GROUP BY "bar"', str(q))
 
     def test_groupby__alias_platforms(self):
         bar = self.t.bar.as_("bar01")
@@ -579,68 +502,48 @@ class GroupByTests(unittest.TestCase):
         ]:
             q = query_cls.from_(self.t).select(fn.Sum(self.t.foo), bar).groupby(bar)
 
-            quote_char = (
-                query_cls._builder().QUOTE_CHAR
-                if isinstance(query_cls._builder().QUOTE_CHAR, str)
-                else '"'
-            )
+            quote_char = query_cls._builder().QUOTE_CHAR if isinstance(query_cls._builder().QUOTE_CHAR, str) else '"'
 
             self.assertEqual(
-                  "SELECT "
-                  "SUM({quote_char}foo{quote_char}),"
-                  "{quote_char}bar{quote_char}{as_keyword}{quote_char}bar01{quote_char} "
-                  "FROM {quote_char}abc{quote_char} "
-                  "GROUP BY {quote_char}bar01{quote_char}"
-                      .format(
-                        as_keyword=' AS ' if query_cls is ClickHouseQuery else ' ',
-                        quote_char=quote_char
-                  ),
-                  str(q),
+                "SELECT "
+                "SUM({quote_char}foo{quote_char}),"
+                "{quote_char}bar{quote_char}{as_keyword}{quote_char}bar01{quote_char} "
+                "FROM {quote_char}abc{quote_char} "
+                "GROUP BY {quote_char}bar01{quote_char}".format(
+                    as_keyword=' AS ' if query_cls is ClickHouseQuery else ' ', quote_char=quote_char
+                ),
+                str(q),
             )
 
     def test_groupby__alias_with_join(self):
         table1 = Table("table1", alias="t1")
         bar = table1.bar.as_("bar01")
-        q = (
-            Query.from_(self.t)
-                .join(table1)
-                .on(self.t.id == table1.t_ref)
-                .select(fn.Sum(self.t.foo), bar)
-                .groupby(bar)
-        )
+        q = Query.from_(self.t).join(table1).on(self.t.id == table1.t_ref).select(fn.Sum(self.t.foo), bar).groupby(bar)
 
         self.assertEqual(
-              'SELECT SUM("abc"."foo"),"t1"."bar" "bar01" FROM "abc" '
-              'JOIN "table1" "t1" ON "abc"."id"="t1"."t_ref" '
-              'GROUP BY "bar01"',
-              str(q),
+            'SELECT SUM("abc"."foo"),"t1"."bar" "bar01" FROM "abc" '
+            'JOIN "table1" "t1" ON "abc"."id"="t1"."t_ref" '
+            'GROUP BY "bar01"',
+            str(q),
         )
 
     def test_groupby_with_case_uses_the_alias(self):
         q = (
             Query.from_(self.t)
-                .select(
-                  fn.Sum(self.t.foo).as_("bar"),
-                  Case()
-                      .when(self.t.fname == "Tom", "It was Tom")
-                      .else_("It was someone else.")
-                      .as_("who_was_it"),
+            .select(
+                fn.Sum(self.t.foo).as_("bar"),
+                Case().when(self.t.fname == "Tom", "It was Tom").else_("It was someone else.").as_("who_was_it"),
             )
-                .groupby(
-                  Case()
-                      .when(self.t.fname == "Tom", "It was Tom")
-                      .else_("It was someone else.")
-                      .as_("who_was_it")
-            )
+            .groupby(Case().when(self.t.fname == "Tom", "It was Tom").else_("It was someone else.").as_("who_was_it"))
         )
 
         self.assertEqual(
-              'SELECT SUM("foo") "bar",'
-              "CASE WHEN \"fname\"='Tom' THEN 'It was Tom' "
-              "ELSE 'It was someone else.' END \"who_was_it\" "
-              'FROM "abc" '
-              'GROUP BY "who_was_it"',
-              str(q),
+            'SELECT SUM("foo") "bar",'
+            "CASE WHEN \"fname\"='Tom' THEN 'It was Tom' "
+            "ELSE 'It was someone else.' END \"who_was_it\" "
+            'FROM "abc" '
+            'GROUP BY "who_was_it"',
+            str(q),
         )
 
     def test_mysql_query_uses_backtick_quote_chars(self):
@@ -679,16 +582,9 @@ class GroupByTests(unittest.TestCase):
         self.assertEqual('SELECT "foo" FROM "abc" GROUP BY "foo" WITH TOTALS', str(q))
 
     def test_groupby__multi_with_totals(self):
-        q = (
-            Query.from_(self.t)
-                .groupby(self.t.foo, self.t.bar)
-                .select(self.t.foo, self.t.bar)
-                .with_totals()
-        )
+        q = Query.from_(self.t).groupby(self.t.foo, self.t.bar).select(self.t.foo, self.t.bar).with_totals()
 
-        self.assertEqual(
-              'SELECT "foo","bar" FROM "abc" GROUP BY "foo","bar" WITH TOTALS', str(q)
-        )
+        self.assertEqual('SELECT "foo","bar" FROM "abc" GROUP BY "foo","bar" WITH TOTALS', str(q))
 
 
 class HavingTests(unittest.TestCase):
@@ -697,115 +593,101 @@ class HavingTests(unittest.TestCase):
     def test_having_greater_than(self):
         q = (
             Query.from_(self.table_abc)
-                .select(self.table_abc.foo, fn.Sum(self.table_abc.bar))
-                .groupby(self.table_abc.foo)
-                .having(fn.Sum(self.table_abc.bar) > 1)
+            .select(self.table_abc.foo, fn.Sum(self.table_abc.bar))
+            .groupby(self.table_abc.foo)
+            .having(fn.Sum(self.table_abc.bar) > 1)
         )
 
         self.assertEqual(
-              'SELECT "foo",SUM("bar") FROM "abc" GROUP BY "foo" HAVING SUM("bar")>1',
-              str(q),
+            'SELECT "foo",SUM("bar") FROM "abc" GROUP BY "foo" HAVING SUM("bar")>1',
+            str(q),
         )
 
     def test_having_and(self):
         q = (
             Query.from_(self.table_abc)
-                .select(self.table_abc.foo, fn.Sum(self.table_abc.bar))
-                .groupby(self.table_abc.foo)
-                .having(
-                  (fn.Sum(self.table_abc.bar) > 1) & (fn.Sum(self.table_abc.bar) < 100)
-            )
+            .select(self.table_abc.foo, fn.Sum(self.table_abc.bar))
+            .groupby(self.table_abc.foo)
+            .having((fn.Sum(self.table_abc.bar) > 1) & (fn.Sum(self.table_abc.bar) < 100))
         )
 
         self.assertEqual(
-              'SELECT "foo",SUM("bar") FROM "abc" GROUP BY "foo" HAVING SUM("bar")>1 AND SUM("bar")<100',
-              str(q),
+            'SELECT "foo",SUM("bar") FROM "abc" GROUP BY "foo" HAVING SUM("bar")>1 AND SUM("bar")<100',
+            str(q),
         )
 
     def test_having_join_and_equality(self):
         q = (
             Query.from_(self.table_abc)
-                .join(self.table_efg)
-                .on(self.table_abc.foo == self.table_efg.foo)
-                .select(self.table_abc.foo, fn.Sum(self.table_efg.bar), self.table_abc.buz)
-                .groupby(self.table_abc.foo)
-                .having(self.table_abc.buz == "fiz")
-                .having(fn.Sum(self.table_efg.bar) > 100)
+            .join(self.table_efg)
+            .on(self.table_abc.foo == self.table_efg.foo)
+            .select(self.table_abc.foo, fn.Sum(self.table_efg.bar), self.table_abc.buz)
+            .groupby(self.table_abc.foo)
+            .having(self.table_abc.buz == "fiz")
+            .having(fn.Sum(self.table_efg.bar) > 100)
         )
 
         self.assertEqual(
-              'SELECT "abc"."foo",SUM("efg"."bar"),"abc"."buz" FROM "abc" '
-              'JOIN "efg" ON "abc"."foo"="efg"."foo" '
-              'GROUP BY "abc"."foo" '
-              'HAVING "abc"."buz"=\'fiz\' AND SUM("efg"."bar")>100',
-              str(q),
+            'SELECT "abc"."foo",SUM("efg"."bar"),"abc"."buz" FROM "abc" '
+            'JOIN "efg" ON "abc"."foo"="efg"."foo" '
+            'GROUP BY "abc"."foo" '
+            'HAVING "abc"."buz"=\'fiz\' AND SUM("efg"."bar")>100',
+            str(q),
         )
 
     def test_mysql_query_uses_backtick_quote_chars(self):
         q = (
             MySQLQuery.from_(self.table_abc)
-                .select(self.table_abc.foo)
-                .groupby(self.table_abc.foo)
-                .having(self.table_abc.buz == "fiz")
+            .select(self.table_abc.foo)
+            .groupby(self.table_abc.foo)
+            .having(self.table_abc.buz == "fiz")
         )
-        self.assertEqual(
-              "SELECT `foo` FROM `abc` GROUP BY `foo` HAVING `buz`='fiz'", str(q)
-        )
+        self.assertEqual("SELECT `foo` FROM `abc` GROUP BY `foo` HAVING `buz`='fiz'", str(q))
 
     def test_vertica_query_uses_double_quote_chars(self):
         q = (
             VerticaQuery.from_(self.table_abc)
-                .select(self.table_abc.foo)
-                .groupby(self.table_abc.foo)
-                .having(self.table_abc.buz == "fiz")
+            .select(self.table_abc.foo)
+            .groupby(self.table_abc.foo)
+            .having(self.table_abc.buz == "fiz")
         )
-        self.assertEqual(
-              'SELECT "foo" FROM "abc" GROUP BY "foo" HAVING "buz"=\'fiz\'', str(q)
-        )
+        self.assertEqual('SELECT "foo" FROM "abc" GROUP BY "foo" HAVING "buz"=\'fiz\'', str(q))
 
     def test_mssql_query_uses_double_quote_chars(self):
         q = (
             MSSQLQuery.from_(self.table_abc)
-                .select(self.table_abc.foo)
-                .groupby(self.table_abc.foo)
-                .having(self.table_abc.buz == "fiz")
+            .select(self.table_abc.foo)
+            .groupby(self.table_abc.foo)
+            .having(self.table_abc.buz == "fiz")
         )
-        self.assertEqual(
-              'SELECT "foo" FROM "abc" GROUP BY "foo" HAVING "buz"=\'fiz\'', str(q)
-        )
+        self.assertEqual('SELECT "foo" FROM "abc" GROUP BY "foo" HAVING "buz"=\'fiz\'', str(q))
 
     def test_oracle_query_uses_double_quote_chars(self):
         q = (
             OracleQuery.from_(self.table_abc)
-                .select(self.table_abc.foo)
-                .groupby(self.table_abc.foo)
-                .having(self.table_abc.buz == "fiz")
+            .select(self.table_abc.foo)
+            .groupby(self.table_abc.foo)
+            .having(self.table_abc.buz == "fiz")
         )
-        self.assertEqual(
-              'SELECT "foo" FROM "abc" GROUP BY "foo" HAVING "buz"=\'fiz\'', str(q)
-        )
+        self.assertEqual('SELECT "foo" FROM "abc" GROUP BY "foo" HAVING "buz"=\'fiz\'', str(q))
 
     def test_postgres_query_uses_double_quote_chars(self):
         q = (
             PostgreSQLQuery.from_(self.table_abc)
-                .select(self.table_abc.foo)
-                .groupby(self.table_abc.foo)
-                .having(self.table_abc.buz == "fiz")
+            .select(self.table_abc.foo)
+            .groupby(self.table_abc.foo)
+            .having(self.table_abc.buz == "fiz")
         )
-        self.assertEqual(
-              'SELECT "foo" FROM "abc" GROUP BY "foo" HAVING "buz"=\'fiz\'', str(q)
-        )
+        self.assertEqual('SELECT "foo" FROM "abc" GROUP BY "foo" HAVING "buz"=\'fiz\'', str(q))
 
     def test_redshift_query_uses_double_quote_chars(self):
         q = (
             RedshiftQuery.from_(self.table_abc)
-                .select(self.table_abc.foo)
-                .groupby(self.table_abc.foo)
-                .having(self.table_abc.buz == "fiz")
+            .select(self.table_abc.foo)
+            .groupby(self.table_abc.foo)
+            .having(self.table_abc.buz == "fiz")
         )
-        self.assertEqual(
-              'SELECT "foo" FROM "abc" GROUP BY "foo" HAVING "buz"=\'fiz\'', str(q)
-        )
+        self.assertEqual('SELECT "foo" FROM "abc" GROUP BY "foo" HAVING "buz"=\'fiz\'', str(q))
 
 
 class OrderByTests(unittest.TestCase):
@@ -817,11 +699,7 @@ class OrderByTests(unittest.TestCase):
         self.assertEqual('SELECT "foo" FROM "abc" ORDER BY "foo"', str(q))
 
     def test_orderby_multi_fields(self):
-        q = (
-            Query.from_(self.t)
-                .orderby(self.t.foo, self.t.bar)
-                .select(self.t.foo, self.t.bar)
-        )
+        q = Query.from_(self.t).orderby(self.t.foo, self.t.bar).select(self.t.foo, self.t.bar)
 
         self.assertEqual('SELECT "foo","bar" FROM "abc" ORDER BY "foo","bar"', str(q))
 
@@ -845,17 +723,15 @@ class OrderByTests(unittest.TestCase):
         q = Query.from_(self.t).select(fn.Sum(self.t.foo), bar).orderby(bar)
 
         self.assertEqual(
-              'SELECT SUM("foo"),"bar" "bar01" FROM "abc" ORDER BY "bar"',
-              q.get_sql(orderby_alias=False),
+            'SELECT SUM("foo"),"bar" "bar01" FROM "abc" ORDER BY "bar"',
+            q.get_sql(orderby_alias=False),
         )
 
     def test_orderby_alias(self):
         bar = self.t.bar.as_("bar01")
         q = Query.from_(self.t).select(fn.Sum(self.t.foo), bar).orderby(bar)
 
-        self.assertEqual(
-              'SELECT SUM("foo"),"bar" "bar01" FROM "abc" ORDER BY "bar01"', q.get_sql()
-        )
+        self.assertEqual('SELECT SUM("foo"),"bar" "bar01" FROM "abc" ORDER BY "bar01"', q.get_sql())
 
 
 class AliasTests(unittest.TestCase):
@@ -928,65 +804,42 @@ class AliasTests(unittest.TestCase):
         self.assertEqual('"foo"="fiz"', str(c))
 
     def test_ignored_in_field_inside_case(self):
-        q = Query.from_(self.t).select(
-              Case().when(self.t.foo == 1, "a").else_(self.t.bar.as_('"buz"'))
-        )
+        q = Query.from_(self.t).select(Case().when(self.t.foo == 1, "a").else_(self.t.bar.as_('"buz"')))
 
-        self.assertEqual(
-              'SELECT CASE WHEN "foo"=1 THEN \'a\' ELSE "bar" END FROM "abc"', str(q)
-        )
+        self.assertEqual('SELECT CASE WHEN "foo"=1 THEN \'a\' ELSE "bar" END FROM "abc"', str(q))
 
     def test_case_using_as(self):
-        q = Query.from_(self.t).select(
-              Case().when(self.t.foo == 1, "a").else_("b").as_("bar")
-        )
+        q = Query.from_(self.t).select(Case().when(self.t.foo == 1, "a").else_("b").as_("bar"))
 
         self.assertEqual(
-              'SELECT CASE WHEN "foo"=1 THEN \'a\' ELSE \'b\' END "bar" FROM "abc"',
-              str(q),
+            'SELECT CASE WHEN "foo"=1 THEN \'a\' ELSE \'b\' END "bar" FROM "abc"',
+            str(q),
         )
 
     def test_case_using_constructor_param(self):
-        q = Query.from_(self.t).select(
-              Case(alias="bar").when(self.t.foo == 1, "a").else_("b")
-        )
+        q = Query.from_(self.t).select(Case(alias="bar").when(self.t.foo == 1, "a").else_("b"))
 
         self.assertEqual(
-              'SELECT CASE WHEN "foo"=1 THEN \'a\' ELSE \'b\' END "bar" FROM "abc"',
-              str(q),
+            'SELECT CASE WHEN "foo"=1 THEN \'a\' ELSE \'b\' END "bar" FROM "abc"',
+            str(q),
         )
 
     def test_select__multiple_tables(self):
         table_abc, table_efg = Table("abc", alias="q0"), Table("efg", alias="q1")
 
-        q = (
-            Query.from_(table_abc)
-                .select(table_abc.foo)
-                .from_(table_efg)
-                .select(table_efg.bar)
-        )
+        q = Query.from_(table_abc).select(table_abc.foo).from_(table_efg).select(table_efg.bar)
 
-        self.assertEqual(
-              'SELECT "q0"."foo","q1"."bar" FROM "abc" "q0","efg" "q1"', str(q)
-        )
+        self.assertEqual('SELECT "q0"."foo","q1"."bar" FROM "abc" "q0","efg" "q1"', str(q))
 
     def test_use_aliases_in_groupby_and_orderby(self):
         table_abc = Table("abc", alias="q0")
 
         my_foo = table_abc.foo.as_("my_foo")
-        q = (
-            Query.from_(table_abc)
-                .select(my_foo, table_abc.bar)
-                .groupby(my_foo)
-                .orderby(my_foo)
-        )
+        q = Query.from_(table_abc).select(my_foo, table_abc.bar).groupby(my_foo).orderby(my_foo)
 
         self.assertEqual(
-              'SELECT "q0"."foo" "my_foo","q0"."bar" '
-              'FROM "abc" "q0" '
-              'GROUP BY "my_foo" '
-              'ORDER BY "my_foo"',
-              str(q),
+            'SELECT "q0"."foo" "my_foo","q0"."bar" ' 'FROM "abc" "q0" ' 'GROUP BY "my_foo" ' 'ORDER BY "my_foo"',
+            str(q),
         )
 
     def test_table_with_schema_and_alias(self):
@@ -1007,227 +860,197 @@ class SubqueryTests(unittest.TestCase):
     def test_where__in(self):
         q = (
             Query.from_(self.table_abc)
-                .select("*")
-                .where(
-                  self.table_abc.foo.isin(
-                        Query.from_(self.table_efg)
-                            .select(self.table_efg.foo)
-                            .where(self.table_efg.bar == 0)
-                  )
+            .select("*")
+            .where(
+                self.table_abc.foo.isin(
+                    Query.from_(self.table_efg).select(self.table_efg.foo).where(self.table_efg.bar == 0)
+                )
             )
         )
 
         self.assertEqual(
-              'SELECT * FROM "abc" WHERE "foo" IN (SELECT "foo" FROM "efg" WHERE "bar"=0)',
-              str(q),
+            'SELECT * FROM "abc" WHERE "foo" IN (SELECT "foo" FROM "efg" WHERE "bar"=0)',
+            str(q),
         )
 
     def test_where__in_nested(self):
-        q = (
-            Query.from_(self.table_abc)
-                .select("*")
-                .where(self.table_abc.foo)
-                .isin(self.table_efg.select("*"))
-        )
+        q = Query.from_(self.table_abc).select("*").where(self.table_abc.foo).isin(self.table_efg.select("*"))
 
-        self.assertEqual(
-              'SELECT * FROM "abc" WHERE "foo" IN (SELECT * FROM "efg")', str(q)
-        )
+        self.assertEqual('SELECT * FROM "abc" WHERE "foo" IN (SELECT * FROM "efg")', str(q))
 
     def test_join(self):
         subquery = Query.from_("efg").select("fiz", "buz").where(F("buz") == 0)
 
         q = (
             Query.from_(self.table_abc)
-                .join(subquery)
-                .on(self.table_abc.bar == subquery.buz)
-                .select(self.table_abc.foo, subquery.fiz)
+            .join(subquery)
+            .on(self.table_abc.bar == subquery.buz)
+            .select(self.table_abc.foo, subquery.fiz)
         )
 
         self.assertEqual(
-              'SELECT "abc"."foo","sq0"."fiz" FROM "abc" '
-              'JOIN (SELECT "fiz","buz" FROM "efg" WHERE "buz"=0) "sq0" '
-              'ON "abc"."bar"="sq0"."buz"',
-              str(q),
+            'SELECT "abc"."foo","sq0"."fiz" FROM "abc" '
+            'JOIN (SELECT "fiz","buz" FROM "efg" WHERE "buz"=0) "sq0" '
+            'ON "abc"."bar"="sq0"."buz"',
+            str(q),
         )
 
     def test_select_subquery(self):
-        subq = (
-            Query.from_(self.table_efg).select("fizzbuzz").where(self.table_efg.id == 1)
-        )
+        subq = Query.from_(self.table_efg).select("fizzbuzz").where(self.table_efg.id == 1)
 
         q = Query.from_(self.table_abc).select("foo", "bar").select(subq)
 
         self.assertEqual(
-              'SELECT "foo","bar",(SELECT "fizzbuzz" FROM "efg" WHERE "id"=1) '
-              'FROM "abc"',
-              str(q),
+            'SELECT "foo","bar",(SELECT "fizzbuzz" FROM "efg" WHERE "id"=1) ' 'FROM "abc"',
+            str(q),
         )
 
     def test_select_subquery_with_alias(self):
-        subq = (
-            Query.from_(self.table_efg).select("fizzbuzz").where(self.table_efg.id == 1)
-        )
+        subq = Query.from_(self.table_efg).select("fizzbuzz").where(self.table_efg.id == 1)
 
         q = Query.from_(self.table_abc).select("foo", "bar").select(subq.as_("sq"))
 
         self.assertEqual(
-              'SELECT "foo","bar",(SELECT "fizzbuzz" FROM "efg" WHERE "id"=1) "sq" '
-              'FROM "abc"',
-              str(q),
+            'SELECT "foo","bar",(SELECT "fizzbuzz" FROM "efg" WHERE "id"=1) "sq" ' 'FROM "abc"',
+            str(q),
         )
 
     def test_where__equality(self):
         subquery = Query.from_("efg").select("fiz").where(F("buz") == 0)
         query = (
             Query.from_(self.table_abc)
-                .select(self.table_abc.foo, self.table_abc.bar)
-                .where(self.table_abc.bar == subquery)
+            .select(self.table_abc.foo, self.table_abc.bar)
+            .where(self.table_abc.bar == subquery)
         )
 
         self.assertEqual(
-              'SELECT "foo","bar" FROM "abc" '
-              'WHERE "bar"=(SELECT "fiz" FROM "efg" WHERE "buz"=0)',
-              str(query),
+            'SELECT "foo","bar" FROM "abc" ' 'WHERE "bar"=(SELECT "fiz" FROM "efg" WHERE "buz"=0)',
+            str(query),
         )
 
     def test_select_from_nested_query(self):
         subquery = Query.from_(self.table_abc).select(
-              self.table_abc.foo,
-              self.table_abc.bar,
-              (self.table_abc.fizz + self.table_abc.buzz).as_("fizzbuzz"),
+            self.table_abc.foo,
+            self.table_abc.bar,
+            (self.table_abc.fizz + self.table_abc.buzz).as_("fizzbuzz"),
         )
 
-        query = Query.from_(subquery).select(
-              subquery.foo, subquery.bar, subquery.fizzbuzz
-        )
+        query = Query.from_(subquery).select(subquery.foo, subquery.bar, subquery.fizzbuzz)
 
         self.assertEqual(
-              'SELECT "sq0"."foo","sq0"."bar","sq0"."fizzbuzz" '
-              "FROM ("
-              'SELECT "foo","bar","fizz"+"buzz" "fizzbuzz" '
-              'FROM "abc"'
-              ') "sq0"',
-              str(query),
+            'SELECT "sq0"."foo","sq0"."bar","sq0"."fizzbuzz" '
+            "FROM ("
+            'SELECT "foo","bar","fizz"+"buzz" "fizzbuzz" '
+            'FROM "abc"'
+            ') "sq0"',
+            str(query),
         )
 
     def test_select_from_nested_query_with_join(self):
         subquery1 = (
             Query.from_(self.table_abc)
-                .select(
-                  self.table_abc.foo,
-                  fn.Sum(self.table_abc.fizz + self.table_abc.buzz).as_("fizzbuzz"),
+            .select(
+                self.table_abc.foo,
+                fn.Sum(self.table_abc.fizz + self.table_abc.buzz).as_("fizzbuzz"),
             )
-                .groupby(self.table_abc.foo)
+            .groupby(self.table_abc.foo)
         )
 
         subquery2 = Query.from_(self.table_efg).select(
-              self.table_efg.foo.as_("foo_two"), self.table_efg.bar,
+            self.table_efg.foo.as_("foo_two"),
+            self.table_efg.bar,
         )
 
         query = (
             Query.from_(subquery1)
-                .select(subquery1.foo, subquery1.fizzbuzz)
-                .join(subquery2)
-                .on(subquery1.foo == subquery2.foo_two)
-                .select(subquery2.foo_two, subquery2.bar)
+            .select(subquery1.foo, subquery1.fizzbuzz)
+            .join(subquery2)
+            .on(subquery1.foo == subquery2.foo_two)
+            .select(subquery2.foo_two, subquery2.bar)
         )
 
         self.assertEqual(
-              "SELECT "
-              '"sq0"."foo","sq0"."fizzbuzz",'
-              '"sq1"."foo_two","sq1"."bar" '
-              "FROM ("
-              "SELECT "
-              '"foo",SUM("fizz"+"buzz") "fizzbuzz" '
-              'FROM "abc" '
-              'GROUP BY "foo"'
-              ') "sq0" JOIN ('
-              "SELECT "
-              '"foo" "foo_two","bar" '
-              'FROM "efg"'
-              ') "sq1" ON "sq0"."foo"="sq1"."foo_two"',
-              str(query),
+            "SELECT "
+            '"sq0"."foo","sq0"."fizzbuzz",'
+            '"sq1"."foo_two","sq1"."bar" '
+            "FROM ("
+            "SELECT "
+            '"foo",SUM("fizz"+"buzz") "fizzbuzz" '
+            'FROM "abc" '
+            'GROUP BY "foo"'
+            ') "sq0" JOIN ('
+            "SELECT "
+            '"foo" "foo_two","bar" '
+            'FROM "efg"'
+            ') "sq1" ON "sq0"."foo"="sq1"."foo_two"',
+            str(query),
         )
 
     def test_from_subquery_without_alias(self):
         subquery = Query.from_(self.table_efg).select(
-              self.table_efg.base_id.as_("x"), self.table_efg.fizz, self.table_efg.buzz
+            self.table_efg.base_id.as_("x"), self.table_efg.fizz, self.table_efg.buzz
         )
 
-        test_query = Query.from_(subquery).select(
-              subquery.x, subquery.fizz, subquery.buzz
-        )
+        test_query = Query.from_(subquery).select(subquery.x, subquery.fizz, subquery.buzz)
 
         self.assertEqual(
-              'SELECT "sq0"."x","sq0"."fizz","sq0"."buzz" '
-              "FROM ("
-              'SELECT "base_id" "x","fizz","buzz" FROM "efg"'
-              ') "sq0"',
-              str(test_query),
+            'SELECT "sq0"."x","sq0"."fizz","sq0"."buzz" '
+            "FROM ("
+            'SELECT "base_id" "x","fizz","buzz" FROM "efg"'
+            ') "sq0"',
+            str(test_query),
         )
 
     def test_join_query_with_alias(self):
         subquery = (
             Query.from_(self.table_efg)
-                .select(
-                  self.table_efg.base_id.as_("x"),
-                  self.table_efg.fizz,
-                  self.table_efg.buzz,
+            .select(
+                self.table_efg.base_id.as_("x"),
+                self.table_efg.fizz,
+                self.table_efg.buzz,
             )
-                .as_("subq")
+            .as_("subq")
         )
 
-        test_query = Query.from_(subquery).select(
-              subquery.x, subquery.fizz, subquery.buzz
-        )
+        test_query = Query.from_(subquery).select(subquery.x, subquery.fizz, subquery.buzz)
 
         self.assertEqual(
-              'SELECT "subq"."x","subq"."fizz","subq"."buzz" '
-              "FROM ("
-              'SELECT "base_id" "x","fizz","buzz" FROM "efg"'
-              ') "subq"',
-              str(test_query),
+            'SELECT "subq"."x","subq"."fizz","subq"."buzz" '
+            "FROM ("
+            'SELECT "base_id" "x","fizz","buzz" FROM "efg"'
+            ') "subq"',
+            str(test_query),
         )
 
     def test_with(self):
         sub_query = Query.from_(self.table_efg).select("fizz")
-        test_query = (
-            Query.with_(sub_query, "an_alias")
-                .from_(AliasedQuery("an_alias"))
-                .select("*")
-        )
+        test_query = Query.with_(sub_query, "an_alias").from_(AliasedQuery("an_alias")).select("*")
 
         self.assertEqual(
-              'WITH an_alias AS (SELECT "fizz" FROM "efg") SELECT * FROM an_alias',
-              str(test_query),
+            'WITH an_alias AS (SELECT "fizz" FROM "efg") SELECT * FROM an_alias',
+            str(test_query),
         )
 
     def test_join_with_with(self):
         sub_query = Query.from_(self.table_efg).select("fizz")
         test_query = (
             Query.with_(sub_query, "an_alias")
-                .from_(self.table_abc)
-                .join(AliasedQuery("an_alias"))
-                .on(AliasedQuery("an_alias").fizz == self.table_abc.buzz)
-                .select("*")
+            .from_(self.table_abc)
+            .join(AliasedQuery("an_alias"))
+            .on(AliasedQuery("an_alias").fizz == self.table_abc.buzz)
+            .select("*")
         )
         self.assertEqual(
-              'WITH an_alias AS (SELECT "fizz" FROM "efg") '
-              'SELECT * FROM "abc" JOIN an_alias ON "an_alias"."fizz"="abc"."buzz"',
-              str(test_query),
+            'WITH an_alias AS (SELECT "fizz" FROM "efg") '
+            'SELECT * FROM "abc" JOIN an_alias ON "an_alias"."fizz"="abc"."buzz"',
+            str(test_query),
         )
 
     def test_select_from_with_returning(self):
         sub_query = PostgreSQLQuery.into(self.table_abc).insert(1).returning('*')
-        test_query = (
-            Query.with_(sub_query, "an_alias")
-                .from_(AliasedQuery("an_alias"))
-                .select("*")
-        )
+        test_query = Query.with_(sub_query, "an_alias").from_(AliasedQuery("an_alias")).select("*")
         self.assertEqual(
-            'WITH an_alias AS (INSERT INTO "abc" VALUES (1) RETURNING *) SELECT * FROM an_alias',
-            str(test_query)
+            'WITH an_alias AS (INSERT INTO "abc" VALUES (1) RETURNING *) SELECT * FROM an_alias', str(test_query)
         )
 
 
@@ -1236,16 +1059,9 @@ class QuoteTests(unittest.TestCase):
         t1 = Table("table1", alias="t1")
         t2 = Table("table2", alias="t2")
 
-        query = (
-            Query.from_(t1)
-                .join(t2)
-                .on(t1.Value.between(t2.start, t2.end))
-                .select(t1.value)
-        )
+        query = Query.from_(t1).join(t2).on(t1.Value.between(t2.start, t2.end)).select(t1.value)
 
         self.assertEqual(
-              "SELECT t1.value FROM table1 t1 "
-              "JOIN table2 t2 ON t1.Value "
-              "BETWEEN t2.start AND t2.end",
-              query.get_sql(quote_char=None),
+            "SELECT t1.value FROM table1 t1 " "JOIN table2 t2 ON t1.Value " "BETWEEN t2.start AND t2.end",
+            query.get_sql(quote_char=None),
         )

--- a/pypika/tests/test_tables.py
+++ b/pypika/tests/test_tables.py
@@ -1,14 +1,6 @@
 import unittest
 
-from pypika import (
-    Database,
-    Dialects,
-    Schema,
-    SQLLiteQuery,
-    Table,
-    Tables,
-    Query,
-)
+from pypika import Database, Dialects, Query, SQLLiteQuery, Schema, Table, Tables
 
 __author__ = "Timothy Heys"
 __email__ = "theys@kayak.com"
@@ -23,9 +15,7 @@ class TableStructureTests(unittest.TestCase):
     def test_table_with_alias(self):
         table = Table("test_table").as_("my_table")
 
-        self.assertEqual(
-            '"test_table" "my_table"', table.get_sql(with_alias=True, quote_char='"')
-        )
+        self.assertEqual('"test_table" "my_table"', table.get_sql(with_alias=True, quote_char='"'))
 
     def test_schema_table_attr(self):
         table = Schema("x_schema").test_table

--- a/pypika/tests/test_terms.py
+++ b/pypika/tests/test_terms.py
@@ -1,29 +1,23 @@
 from unittest import TestCase
 
 from pypika import Query, Table
-from pypika.terms import AtTimezone, Field
+from pypika.terms import AtTimezone
 
 
 class AtTimezoneTests(TestCase):
     def test_when_interval_not_specified(self):
         query = Query.from_("customers").select(AtTimezone("date", "US/Eastern"))
-        self.assertEqual(
-            'SELECT "date" AT TIME ZONE \'US/Eastern\' FROM "customers"', str(query)
-        )
+        self.assertEqual('SELECT "date" AT TIME ZONE \'US/Eastern\' FROM "customers"', str(query))
 
     def test_when_interval_specified(self):
-        query = Query.from_("customers").select(
-            AtTimezone("date", "-06:00", interval=True)
-        )
+        query = Query.from_("customers").select(AtTimezone("date", "-06:00", interval=True))
         self.assertEqual(
             'SELECT "date" AT TIME ZONE INTERVAL \'-06:00\' FROM "customers"',
             str(query),
         )
 
     def test_when_alias_specified(self):
-        query = Query.from_("customers").select(
-            AtTimezone("date", "US/Eastern", alias="alias1")
-        )
+        query = Query.from_("customers").select(AtTimezone("date", "US/Eastern", alias="alias1"))
         self.assertEqual(
             'SELECT "date" AT TIME ZONE \'US/Eastern\' "alias1" FROM "customers"',
             str(query),

--- a/pypika/tests/test_tuples.py
+++ b/pypika/tests/test_tuples.py
@@ -22,9 +22,7 @@ class TupleTests(unittest.TestCase):
             .where(Tuple(self.table_abc.foo, self.table_abc.bar) == Tuple(1, 2))
         )
 
-        self.assertEqual(
-            'SELECT "foo","bar" FROM "abc" ' 'WHERE ("foo","bar")=(1,2)', str(q)
-        )
+        self.assertEqual('SELECT "foo","bar" FROM "abc" ' 'WHERE ("foo","bar")=(1,2)', str(q))
 
     def test_tuple_equality_tuple_on_left(self):
         q = (
@@ -33,9 +31,7 @@ class TupleTests(unittest.TestCase):
             .where(Tuple(self.table_abc.foo, self.table_abc.bar) == (1, 2))
         )
 
-        self.assertEqual(
-            'SELECT "foo","bar" FROM "abc" ' 'WHERE ("foo","bar")=(1,2)', str(q)
-        )
+        self.assertEqual('SELECT "foo","bar" FROM "abc" ' 'WHERE ("foo","bar")=(1,2)', str(q))
 
     def test_tuple_equality_tuple_on_right(self):
         q = (
@@ -45,24 +41,17 @@ class TupleTests(unittest.TestCase):
         )
 
         # Order is reversed due to lack of right equals method
-        self.assertEqual(
-            'SELECT "foo","bar" FROM "abc" ' 'WHERE (1,2)=("foo","bar")', str(q)
-        )
+        self.assertEqual('SELECT "foo","bar" FROM "abc" ' 'WHERE (1,2)=("foo","bar")', str(q))
 
     def test_tuple_in_using_python_tuples(self):
         q = (
             Query.from_(self.table_abc)
             .select(self.table_abc.foo, self.table_abc.bar)
-            .where(
-                Tuple(self.table_abc.foo, self.table_abc.bar).isin(
-                    [(1, 1), (2, 2), (3, 3)]
-                )
-            )
+            .where(Tuple(self.table_abc.foo, self.table_abc.bar).isin([(1, 1), (2, 2), (3, 3)]))
         )
 
         self.assertEqual(
-            'SELECT "foo","bar" FROM "abc" '
-            'WHERE ("foo","bar") IN ((1,1),(2,2),(3,3))',
+            'SELECT "foo","bar" FROM "abc" ' 'WHERE ("foo","bar") IN ((1,1),(2,2),(3,3))',
             str(q),
         )
 
@@ -70,16 +59,11 @@ class TupleTests(unittest.TestCase):
         q = (
             Query.from_(self.table_abc)
             .select(self.table_abc.foo, self.table_abc.bar)
-            .where(
-                Tuple(self.table_abc.foo, self.table_abc.bar).isin(
-                    [Tuple(1, 1), Tuple(2, 2), Tuple(3, 3)]
-                )
-            )
+            .where(Tuple(self.table_abc.foo, self.table_abc.bar).isin([Tuple(1, 1), Tuple(2, 2), Tuple(3, 3)]))
         )
 
         self.assertEqual(
-            'SELECT "foo","bar" FROM "abc" '
-            'WHERE ("foo","bar") IN ((1,1),(2,2),(3,3))',
+            'SELECT "foo","bar" FROM "abc" ' 'WHERE ("foo","bar") IN ((1,1),(2,2),(3,3))',
             str(q),
         )
 
@@ -87,16 +71,11 @@ class TupleTests(unittest.TestCase):
         q = (
             Query.from_(self.table_abc)
             .select(self.table_abc.foo, self.table_abc.bar)
-            .where(
-                Tuple(self.table_abc.foo, self.table_abc.bar).isin(
-                    [(1, 1), Tuple(2, 2), (3, 3)]
-                )
-            )
+            .where(Tuple(self.table_abc.foo, self.table_abc.bar).isin([(1, 1), Tuple(2, 2), (3, 3)]))
         )
 
         self.assertEqual(
-            'SELECT "foo","bar" FROM "abc" '
-            'WHERE ("foo","bar") IN ((1,1),(2,2),(3,3))',
+            'SELECT "foo","bar" FROM "abc" ' 'WHERE ("foo","bar") IN ((1,1),(2,2),(3,3))',
             str(q),
         )
 
@@ -106,11 +85,7 @@ class TupleTests(unittest.TestCase):
             .join(self.table_efg)
             .on(self.table_abc.foo == self.table_efg.bar)
             .select("*")
-            .where(
-                Tuple(self.table_abc.foo, self.table_efg.bar).isin(
-                    [(1, 1), Tuple(2, 2), (3, 3)]
-                )
-            )
+            .where(Tuple(self.table_abc.foo, self.table_efg.bar).isin([(1, 1), Tuple(2, 2), (3, 3)]))
         )
 
         self.assertEqual(
@@ -171,8 +146,6 @@ class BracketTests(unittest.TestCase):
         self.assertEqual('SELECT ("foo"/2)/2 FROM "abc"', str(q))
 
     def test_arithmetic_with_brackets_and_alias(self):
-        q = Query.from_(self.table_abc).select(
-            Bracket(self.table_abc.foo / 2).as_("alias")
-        )
+        q = Query.from_(self.table_abc).select(Bracket(self.table_abc.foo / 2).as_("alias"))
 
         self.assertEqual('SELECT ("foo"/2) "alias" FROM "abc"', str(q))

--- a/pypika/tests/test_updates.py
+++ b/pypika/tests/test_updates.py
@@ -1,6 +1,6 @@
 import unittest
 
-from pypika import Table, Query, PostgreSQLQuery, AliasedQuery, SQLLiteQuery
+from pypika import AliasedQuery, PostgreSQLQuery, Query, SQLLiteQuery, Table
 
 __author__ = "Timothy Heys"
 __email__ = "theys@kayak.com"
@@ -69,7 +69,7 @@ class UpdateTests(unittest.TestCase):
         self.assertEqual(
             'UPDATE "abc" SET "lname"="from_table"."long_name" FROM "from_table" '
             'WHERE "abc"."fname"="from_table"."full_name"',
-            str(q)
+            str(q),
         )
 
     def test_update_with_statement(self):
@@ -89,7 +89,7 @@ class UpdateTests(unittest.TestCase):
             'WITH an_alias AS (SELECT "fizz" FROM "efg") '
             'UPDATE "abc" SET "lname"="an_alias"."long_name" FROM an_alias '
             'WHERE "abc"."comp"="an_alias"."alias_comp"',
-            str(q)
+            str(q),
         )
 
 
@@ -97,16 +97,9 @@ class PostgresUpdateTests(unittest.TestCase):
     table_abc = Table("abc")
 
     def test_update_returning_str(self):
-        q = (
-            PostgreSQLQuery.update(self.table_abc)
-            .where(self.table_abc.foo == 0)
-            .set("foo", "bar")
-            .returning("id")
-        )
+        q = PostgreSQLQuery.update(self.table_abc).where(self.table_abc.foo == 0).set("foo", "bar").returning("id")
 
-        self.assertEqual(
-            'UPDATE "abc" SET "foo"=\'bar\' WHERE "foo"=0 RETURNING "abc"."id"', str(q)
-        )
+        self.assertEqual('UPDATE "abc" SET "foo"=\'bar\' WHERE "foo"=0 RETURNING "abc"."id"', str(q))
 
     def test_update_returning(self):
         q = (
@@ -116,9 +109,7 @@ class PostgresUpdateTests(unittest.TestCase):
             .returning(self.table_abc.id)
         )
 
-        self.assertEqual(
-            'UPDATE "abc" SET "foo"=\'bar\' WHERE "foo"=0 RETURNING "abc"."id"', str(q)
-        )
+        self.assertEqual('UPDATE "abc" SET "foo"=\'bar\' WHERE "foo"=0 RETURNING "abc"."id"', str(q))
 
     def test_update_returning_from_different_tables(self):
         table_bcd = Table('bcd')

--- a/pypika/utils.py
+++ b/pypika/utils.py
@@ -1,4 +1,4 @@
-from typing import Optional, List, Any, Type, Callable
+from typing import Any, Callable, List, Optional, Type
 
 __author__ = "Timothy Heys"
 __email__ = "theys@kayak.com"
@@ -77,9 +77,7 @@ def ignore_copy(func: Callable) -> Callable:
             "__setstate__",
             "__getnewargs__",
         ]:
-            raise AttributeError(
-                  "'%s' object has no attribute '%s'" % (self.__class__.__name__, name)
-            )
+            raise AttributeError("'%s' object has no attribute '%s'" % (self.__class__.__name__, name))
 
         return func(self, name)
 
@@ -105,13 +103,18 @@ def format_quotes(value: Any, quote_char: Optional[str]) -> str:
     return "{quote}{value}{quote}".format(value=value, quote=quote_char or "")
 
 
-def format_alias_sql(sql: str, alias: Optional[str], quote_char: Optional[str] = None, alias_quote_char: Optional[str] = None, as_keyword: bool = False, **kwargs: Any) -> str:
+def format_alias_sql(
+    sql: str,
+    alias: Optional[str],
+    quote_char: Optional[str] = None,
+    alias_quote_char: Optional[str] = None,
+    as_keyword: bool = False,
+    **kwargs: Any,
+) -> str:
     if alias is None:
         return sql
     return "{sql}{_as}{alias}".format(
-          sql=sql,
-          _as=' AS ' if as_keyword else ' ',
-          alias=format_quotes(alias, alias_quote_char or quote_char)
+        sql=sql, _as=' AS ' if as_keyword else ' ', alias=format_quotes(alias, alias_quote_char or quote_char)
     )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.black]
+line-length = 120
+skip-string-normalization = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,22 @@
 [tool.black]
 line-length = 120
 skip-string-normalization = true
+target-version = ['py35', 'py36', 'py37', 'py38']
+exclude = '''
+(
+  /(
+      \.eggs         # exclude a few common directories in the
+    | \.git          # root of the project
+    | \.hg
+    | \.mypy_cache
+    | \.tox
+    | \.venv
+    | _build
+    | buck-out
+    | build
+    | dist
+    | docs
+  )/
+  | setup.py
+)
+'''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.black]
 line-length = 120
 skip-string-normalization = true
-target-version = ['py35', 'py36', 'py37', 'py38']
+target-version = ['py36', 'py37', 'py38']
 exclude = '''
 (
   /(

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,3 +9,6 @@ tox==3.14.3
 tox-venv==0.4.0
 tox-gh-actions==0.3.0
 coverage==5.1
+
+# Formatting
+black==20.8b1

--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,7 @@ def version():
         for node in (n for n in t.body if isinstance(n, ast.Assign)):
             if len(node.targets) == 1:
                 name = node.targets[0]
-                if isinstance(name, ast.Name) and \
-                      name.id in ('__version__', '__version_info__', 'VERSION'):
+                if isinstance(name, ast.Name) and name.id in ('__version__', '__version_info__', 'VERSION'):
                     v = node.value
                     if isinstance(v, ast.Str):
                         return v.s

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35,py36,py37,py38,py39,pypy3
+envlist = py36,py37,py38,py39,pypy3
 [testenv]
 deps = -r requirements-dev.txt
 commands =
@@ -7,7 +7,6 @@ commands =
     coverage report
 [gh-actions]
 python =
-    3.5: py35
     3.6: py36
     3.7: py37
     3.8: py38


### PR DESCRIPTION
* Dropped Python 3.5 support (out of support end of September and latest Black does not support it).
* Added latest Black version to requirements and Github Actions
* Changed Licence to use correct year