### PR TITLE
Added value wrapping for column defaults

### DIFF
--- a/pypika/queries.py
+++ b/pypika/queries.py
@@ -275,12 +275,12 @@ class Column:
         column_name: str,
         column_type: Optional[str] = None,
         nullable: Optional[bool] = None,
-        default: Optional[Term] = None,
+        default: Optional[Union[Any, Term]] = None,
     ) -> None:
         self.name = column_name
         self.type = column_type
         self.nullable = nullable
-        self.default = default
+        self.default = default if default is None or isinstance(default, Term) else ValueWrapper(default)
 
     def get_name_sql(self, **kwargs: Any) -> str:
         quote_char = kwargs.get("quote_char")

--- a/pypika/tests/test_create.py
+++ b/pypika/tests/test_create.py
@@ -23,6 +23,13 @@ class CreateTableTests(unittest.TestCase):
 
             self.assertEqual('CREATE TABLE "abc" ("a" INT DEFAULT 42,"b" VARCHAR(100) DEFAULT \'foo\')', str(q))
 
+        with self.subTest("with unwrapped defaults"):
+            a = Column("a", "INT", default=42)
+            b = Column("b", "VARCHAR(100)", default="foo")
+            q = Query.create_table(self.new_table).columns(a, b)
+
+            self.assertEqual('CREATE TABLE "abc" ("a" INT DEFAULT 42,"b" VARCHAR(100) DEFAULT \'foo\')', str(q))
+
         with self.subTest("with period for"):
             a = Column("id", "INT")
             b = Column("valid_from", "DATETIME")


### PR DESCRIPTION
I think this is the change you wanted @mikeengland 

Before this column defaults had to be a `Term`, meaning that a simple value had to be wrapped. e.g.

```python
a = Column("a", "INT", default=ValueWrapper(42))
```

This change will wrap non `None` `Term`s

```python
a = Column("a", "INT", default=42)
```
