### PR TITLE
Add support for insert queries with only default values

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -857,11 +857,9 @@ Rows can be inserted into a table with default values for all columns
 
     customers = Table('customers')
 
-    q = Query.into(customers).insert_default_values()
+    q = Query.into(customers).columns(customers.id, customers.sign_up_date).insert_default_values()
 
-    # or
-
-    customers.insert_default_values()
+    # sql: INSERT INTO "customers" (id, sign_up_date) VALUES (DEFAULT,DEFAULT)
 
 Insert with constraint violation handling
 """""""""""""""""""""""""""""""""""""""""

--- a/README.rst
+++ b/README.rst
@@ -848,6 +848,21 @@ Multiple rows of data can be inserted either by chaining the ``insert`` function
     q = Query.into(customers).insert((1, 'Jane', 'Doe', 'jane@example.com'),
                                      (2, 'John', 'Doe', 'john@example.com'))
 
+Insert with default values
+""""""""""""""""""""""""""
+
+Rows can be inserted into a table with default values for all columns
+
+.. code-block:: python
+
+    customers = Table('customers')
+
+    q = Query.into(customers).insert_default_values()
+
+    # or
+
+    customers.insert_default_values()
+
 Insert with constraint violation handling
 """""""""""""""""""""""""""""""""""""""""
 

--- a/pypika/queries.py
+++ b/pypika/queries.py
@@ -845,7 +845,7 @@ class QueryBuilder(Selectable, Term):
     def insert_default_values(self) -> "QueryBuilder":
         if self._insert_table is None:
             raise AttributeError("'Query' object has no attribute '%s'" % "insert_default_values")
-        
+
         self._insert_default_values = True
 
         self._replace = False

--- a/pypika/tests/test_inserts.py
+++ b/pypika/tests/test_inserts.py
@@ -166,12 +166,12 @@ class InsertIntoTests(unittest.TestCase):
         )
 
     def test_insert_default_values(self):
-        q = Query.into(self.table_abc).insert_default_values()
-        self.assertEqual('INSERT INTO "abc" DEFAULT VALUES', str(q))
-
-    def test_insert_default_values_using_table_alias(self):
-        q = self.table_abc.insert_default_values()
-        self.assertEqual('INSERT INTO "abc" DEFAULT VALUES', str(q))
+        q = (
+            Query.into(self.table_abc)
+            .columns(self.table_abc.foo, self.table_abc.bar, self.table_abc.buz)
+            .insert_default_values()
+        )
+        self.assertEqual('INSERT INTO "abc" ("foo","bar","buz") VALUES (DEFAULT,DEFAULT,DEFAULT)', str(q))
 
 
 class PostgresInsertIntoOnConflictTests(unittest.TestCase):

--- a/pypika/tests/test_inserts.py
+++ b/pypika/tests/test_inserts.py
@@ -165,6 +165,18 @@ class InsertIntoTests(unittest.TestCase):
             'WITH sub_qs AS (SELECT "id" FROM "abc") INSERT INTO "abc" SELECT "sub_qs"."id" FROM sub_qs', str(q)
         )
 
+    def test_insert_default_values(self):
+        q = Query.into(self.table_abc).insert_default_values()
+        self.assertEqual(
+            'INSERT INTO "abc" DEFAULT VALUES', str(q)
+        )
+
+    def test_insert_default_values_using_table_alias(self):
+        q = self.table_abc.insert_default_values()
+        self.assertEqual(
+            'INSERT INTO "abc" DEFAULT VALUES', str(q)
+        )
+
 
 class PostgresInsertIntoOnConflictTests(unittest.TestCase):
     table_abc = Table("abc")

--- a/pypika/tests/test_inserts.py
+++ b/pypika/tests/test_inserts.py
@@ -173,6 +173,14 @@ class InsertIntoTests(unittest.TestCase):
         )
         self.assertEqual('INSERT INTO "abc" ("foo","bar","buz") VALUES (DEFAULT,DEFAULT,DEFAULT)', str(q))
 
+    def test_insert_default_no_columns(self):
+        with self.assertRaises(AttributeError):
+            Query.into(self.table_abc).insert_default_values()
+
+    def test_insert_default_no_table(self):
+        with self.assertRaises(AttributeError):
+            Query.insert_default_values()
+
 
 class PostgresInsertIntoOnConflictTests(unittest.TestCase):
     table_abc = Table("abc")

--- a/pypika/tests/test_inserts.py
+++ b/pypika/tests/test_inserts.py
@@ -167,15 +167,11 @@ class InsertIntoTests(unittest.TestCase):
 
     def test_insert_default_values(self):
         q = Query.into(self.table_abc).insert_default_values()
-        self.assertEqual(
-            'INSERT INTO "abc" DEFAULT VALUES', str(q)
-        )
+        self.assertEqual('INSERT INTO "abc" DEFAULT VALUES', str(q))
 
     def test_insert_default_values_using_table_alias(self):
         q = self.table_abc.insert_default_values()
-        self.assertEqual(
-            'INSERT INTO "abc" DEFAULT VALUES', str(q)
-        )
+        self.assertEqual('INSERT INTO "abc" DEFAULT VALUES', str(q))
 
 
 class PostgresInsertIntoOnConflictTests(unittest.TestCase):


### PR DESCRIPTION
Hello,

I wanted to be able to generate insert queries that made use of 'DEFAULT VALUES'; i.e `'INSERT INTO "abc" DEFAULT VALUES' `I've implemented it here. I've done my best to think of edge cases or inconsistencies but I expect there may be some corrections needed, please let me know and I'll make those changes. 