### PR TITLE
fix pseudocolumns in orderby

### DIFF
--- a/pypika/terms.py
+++ b/pypika/terms.py
@@ -1447,6 +1447,7 @@ class PseudoColumn(Term):
     """
 
     def __init__(self, name: str) -> None:
+        super().__init__(alias=None)
         self.name = name
 
     def get_sql(self, **kwargs: Any) -> str:

--- a/pypika/tests/test_pseudocolumns.py
+++ b/pypika/tests/test_pseudocolumns.py
@@ -45,3 +45,7 @@ class PseudoColumnsTest(unittest.TestCase):
         query = Query.from_(self.table1).where(PseudoColumn("abcde") > 1).select(self.table1.is_active)
 
         self.assertEqual(str(query), 'SELECT "is_active" FROM "table1" WHERE abcde>1')
+
+    def test_can_be_used_in_orderby(self):
+        query = Query.from_(self.table1).select(self.table1.abcde.as_("some_name")).orderby(PseudoColumn("some_name"))
+        self.assertEqual(str(query), 'SELECT "abcde" "some_name" FROM "table1" ORDER BY some_name')


### PR DESCRIPTION
Before fix `AttributeError: 'PseudoColumn' object has no attribute 'alias'` was raised.