### PR TITLE
fix postgres do update with EXCLUDED keyword

### DIFF
--- a/pypika/dialects.py
+++ b/pypika/dialects.py
@@ -349,7 +349,7 @@ class PostgreQueryBuilder(QueryBuilder):
         else:
             raise QueryException("Unsupported update_field")
 
-        if update_value:
+        if update_value is not None:
             self._on_conflict_do_updates.append((field, ValueWrapper(update_value)))
         else:
             self._on_conflict_do_updates.append((field, None))


### PR DESCRIPTION
Current `PostgreSQLQuery` `do_update` will invoke `EXCLUDED` keyword when value 0 is provided.
This commit will fix `do_update` so that it only invoke when `update_value` is `None`

Propose fix for: #504