### PR TITLE
fix field with alias

### DIFF
--- a/pypika/terms.py
+++ b/pypika/terms.py
@@ -314,7 +314,7 @@ class ValueWrapper(Term):
 class JSON(Term):
     table = None
 
-    def __init__(self, value: Any, alias: Optional[str] = None) -> None:
+    def __init__(self, value: Any = None, alias: Optional[str] = None) -> None:
         super().__init__(alias)
         self.value = value
 
@@ -458,7 +458,7 @@ class Field(Criterion, JSON):
     def __init__(
         self, name: str, alias: Optional[str] = None, table: Optional[Union[str, "Selectable"]] = None
     ) -> None:
-        super().__init__(alias)
+        super().__init__(alias=alias)
         self.name = name
         self.table = table
 

--- a/pypika/tests/test_terms.py
+++ b/pypika/tests/test_terms.py
@@ -1,7 +1,18 @@
 from unittest import TestCase
 
-from pypika import Query, Table
+from pypika import Query, Table, Field
 from pypika.terms import AtTimezone
+
+
+class FieldAliasTests(TestCase):
+    t = Table("test", alias="crit")
+
+    def test_when_alias_specified(self):
+        c1 = Field("foo", alias="bar")
+        self.assertEqual('bar', str(c1.alias))
+
+        c1 = Field("foo").as_("bar")
+        self.assertEqual('bar', str(c1.alias))
 
 
 class AtTimezoneTests(TestCase):


### PR DESCRIPTION
try to fix usage Field("foo", alias="bar")

bug introduced by https://github.com/kayak/pypika/commit/b218ba39371313037bc2268a1ba79d5e8ddf14e9#diff-54340751c88780ef96f3ba11bb105a16d92a43a583141992cc7e4162507ac013R428

