### PR TITLE
Enclose CASE statement in parentheses

### DIFF
--- a/pypika/terms.py
+++ b/pypika/terms.py
@@ -990,10 +990,11 @@ class ArithmeticExpression(Term):
 
 
 class Case(Term):
-    def __init__(self, alias: Optional[str] = None) -> None:
+    def __init__(self, alias: Optional[str] = None, parentheses=False) -> None:
         super().__init__(alias=alias)
         self._cases = []
         self._else = None
+        self.parentheses = parentheses
 
     def nodes_(self) -> Iterator[NodeT]:
         yield self
@@ -1054,7 +1055,8 @@ class Case(Term):
         else_ = " ELSE {}".format(self._else.get_sql(**kwargs)) if self._else else ""
 
         case_sql = "CASE {cases}{else_} END".format(cases=cases, else_=else_)
-
+        if self.parentheses:
+            case_sql = "({})".format(case_sql)
         if with_alias:
             return format_alias_sql(case_sql, self.alias, **kwargs)
 

--- a/pypika/tests/test_functions.py
+++ b/pypika/tests/test_functions.py
@@ -333,6 +333,11 @@ class ConditionTests(unittest.TestCase):
             str(q),
         )
 
+    def test__case__enclosed_parentheses(self):
+        q = Q.from_("abc").select(Case(parentheses=True).when(F("foo") == 1, F("bar")).else_(F("buz")))
+
+        self.assertEqual('SELECT (CASE WHEN "foo"=1 THEN "bar" ELSE "buz" END) FROM "abc"', str(q))
+
     def test__case__no_cases(self):
         with self.assertRaises(CaseException):
             q = Q.from_("abc").select(Case())


### PR DESCRIPTION
Just as a dumb idea to deal with this problem that other users have already mentioned (#508). In my case, I need this for the `CASE` statement.