### PR TITLE
Fix OracleQuery Dialect Quote Char

### DIFF
--- a/pypika/dialects.py
+++ b/pypika/dialects.py
@@ -270,6 +270,8 @@ class VerticaQuery(Query):
 
 
 class OracleQueryBuilder(QueryBuilder):
+    QUOTE_CHAR = None
+
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(dialect=Dialects.ORACLE, **kwargs)
 


### PR DESCRIPTION
Oracle SQL query breaks when double quoted

A quoted identifier begins and ends with double quotation marks (").
If you name a schema object using a quoted identifier,
then you must use the double quotation marks whenever you refer to that object.
Thus it makes sense that the user will double quote the identifier
him/herself.

A nonquoted identifier is not surrounded by any punctuation.

See https://docs.oracle.com/database/121/SQLRF/sql_elements008.htm

Addresses https://github.com/kayak/pypika/issues/394#issuecomment-616012215
Addresses #298 for OracleQuery