### PR TITLE
Introduce HASH join

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -412,7 +412,7 @@ All join types are supported by |Brand|.
         .inner_join(join_table) \
         .outer_join(join_table) \
         .cross_join(join_table) \
-        .hash_join(join_table) \ # for google spanner, https://cloud.google.com/spanner/docs/query-execution-operators#hash-join
+        .hash_join(join_table) \
         ...
 
 See the list of join types here ``pypika.enums.JoinTypes``

--- a/README.rst
+++ b/README.rst
@@ -412,7 +412,7 @@ All join types are supported by |Brand|.
         .inner_join(join_table) \
         .outer_join(join_table) \
         .cross_join(join_table) \
-        .hash_join(join_table) \ #for google spanner, https://cloud.google.com/spanner/docs/query-execution-operators#hash-join
+        .hash_join(join_table) \ # for google spanner, https://cloud.google.com/spanner/docs/query-execution-operators#hash-join
         ...
 
 See the list of join types here ``pypika.enums.JoinTypes``

--- a/README.rst
+++ b/README.rst
@@ -412,6 +412,7 @@ All join types are supported by |Brand|.
         .inner_join(join_table) \
         .outer_join(join_table) \
         .cross_join(join_table) \
+        .hash_join(join_table) \ #for google spanner, https://cloud.google.com/spanner/docs/query-execution-operators#hash-join
         ...
 
 See the list of join types here ``pypika.enums.JoinTypes``

--- a/pypika/enums.py
+++ b/pypika/enums.py
@@ -57,6 +57,7 @@ class JoinType(Enum):
     right_outer = "RIGHT OUTER"
     full_outer = "FULL OUTER"
     cross = "CROSS"
+    hash = "HASH"
 
 
 class SetOperation(Enum):

--- a/pypika/queries.py
+++ b/pypika/queries.py
@@ -995,6 +995,9 @@ class QueryBuilder(Selectable, Term):
     def cross_join(self, item: Union[Table, "QueryBuilder", AliasedQuery]) -> "Joiner":
         return self.join(item, JoinType.cross)
 
+    def hash_join(self, item: Union[Table, "QueryBuilder", AliasedQuery]) -> "Joiner":
+        return self.join(item, JoinType.hash)
+
     @builder
     def limit(self, limit: int) -> "QueryBuilder":
         self._limit = limit

--- a/pypika/tests/test_joins.py
+++ b/pypika/tests/test_joins.py
@@ -76,6 +76,23 @@ class SelectQueryJoinTests(unittest.TestCase):
             query = Query.from_(self.table0).right_join(self.table1).on(self.table0.foo == self.table1.bar).select("*")
             self.assertEqual(expected, str(query))
 
+    def test_hash_join(self):
+        expected = 'SELECT * FROM "abc" HASH JOIN "efg" ON "abc"."foo"="efg"."bar"'
+
+        with self.subTest("join with enum"):
+            query = (
+                Query.from_(self.table0)
+                .join(self.table1, how=JoinType.hash)
+                .on(self.table0.foo == self.table1.bar)
+                .select("*")
+            )
+
+            self.assertEqual(expected, str(query))
+
+        with self.subTest("join function"):
+            query = Query.from_(self.table0).hash_join(self.table1).on(self.table0.foo == self.table1.bar).select("*")
+            self.assertEqual(expected, str(query))
+
     def test_outer_join(self):
         expected = 'SELECT * FROM "abc" FULL OUTER JOIN "efg" ON "abc"."foo"="efg"."bar"'
 


### PR DESCRIPTION
Add hash join for google spanner, furhter documentation can be found here.
https://cloud.google.com/spanner/docs/query-execution-operators#hash-join