### PR TITLE
Fix groupby_alias specified multiple times in kwargs when subqueries are used

### DIFF
--- a/pypika/dialects.py
+++ b/pypika/dialects.py
@@ -276,7 +276,10 @@ class OracleQueryBuilder(QueryBuilder):
         super().__init__(dialect=Dialects.ORACLE, **kwargs)
 
     def get_sql(self, *args: Any, **kwargs: Any) -> str:
-        return super().get_sql(*args, groupby_alias=False, **kwargs)
+        # Oracle does not support group by a field alias
+        # Note: set directly in kwargs as they are re-used down the tree in the case of subqueries!
+        kwargs['groupby_alias'] = False
+        return super().get_sql(*args, **kwargs)
 
 
 class OracleQuery(Query):
@@ -577,7 +580,10 @@ class MSSQLQueryBuilder(QueryBuilder):
         return querystring
 
     def get_sql(self, *args: Any, **kwargs: Any) -> str:
-        return super().get_sql(*args, groupby_alias=False, **kwargs)
+        # MSSQL does not support group by a field alias.
+        # Note: set directly in kwargs as they are re-used down the tree in the case of subqueries!
+        kwargs['groupby_alias'] = False
+        return super().get_sql(*args, **kwargs)
 
     def _top_sql(self) -> str:
         if self._top:

--- a/pypika/tests/dialects/test_oracle.py
+++ b/pypika/tests/dialects/test_oracle.py
@@ -1,0 +1,21 @@
+import unittest
+
+from pypika import OracleQuery, Table
+from pypika.analytics import Count
+
+
+class SelectTests(unittest.TestCase):
+    def test_groupby_alias_False_does_not_group_by_alias_with_standard_query(self):
+        t = Table('table1')
+        col = t.abc.as_('a')
+        q = OracleQuery.from_(t).select(col, Count('*')).groupby(col)
+
+        self.assertEqual('SELECT abc a,COUNT(\'*\') FROM table1 GROUP BY abc', str(q))
+
+    def test_groupby_alias_False_does_not_group_by_alias_when_subqueries_are_present(self):
+        t = Table('table1')
+        subquery = OracleQuery.from_(t).select(t.abc)
+        col = subquery.abc.as_('a')
+        q = OracleQuery.from_(subquery).select(col, Count('*')).groupby(col)
+
+        self.assertEqual('SELECT sq0.abc a,COUNT(\'*\') FROM (SELECT abc FROM table1) sq0 GROUP BY sq0.abc', str(q))


### PR DESCRIPTION
Affects Oracle and MSSQL query builders only.