### PR TITLE
Order nulls last options

### DIFF
--- a/pypika/enums.py
+++ b/pypika/enums.py
@@ -46,6 +46,8 @@ class Boolean(Comparator):
 class Order(Enum):
     asc = "ASC"
     desc = "DESC"
+    asc_nulls_last = "ASC NULLS LAST"
+    desc_nulls_last = "DESC NULLS LAST"
 
 
 class JoinType(Enum):


### PR DESCRIPTION
Is there a better way to add this support? I was looking for an `Order.desc.nulls_last` originally