### PR TITLE
Issue 508: Fix order of operations

### DIFF
--- a/pypika/tests/test_functions.py
+++ b/pypika/tests/test_functions.py
@@ -171,23 +171,39 @@ class ArithmeticTests(unittest.TestCase):
     def test__complex_op_add_parentheses(self):
         q1 = Q.from_("abc").select((F("a") + 1) + (F("b") - 5))
         q2 = Q.from_(self.t).select((self.t.a + 1) + (self.t.b - 5))
+        q3 = Q.from_("abc").select((F("a") / 1) + (F("b") / 5))
+        q4 = Q.from_(self.t).select((self.t.a / 1) + (self.t.b / 5))
 
         self.assertEqual('SELECT "a"+1+"b"-5 FROM "abc"', str(q1))
         self.assertEqual('SELECT "a"+1+"b"-5 FROM "abc"', str(q2))
+        self.assertEqual('SELECT "a"/1+"b"/5 FROM "abc"', str(q3))
+        self.assertEqual('SELECT "a"/1+"b"/5 FROM "abc"', str(q4))
 
     def test__complex_op_sub_parentheses(self):
         q1 = Q.from_("abc").select((F("a") + 1) - (F("b") - 5))
         q2 = Q.from_(self.t).select((self.t.a + 1) - (self.t.b - 5))
+        q3 = Q.from_("abc").select((F("a") / 1) - (F("b") / 5))
+        q4 = Q.from_(self.t).select((self.t.a / 1) - (self.t.b / 5))
 
-        self.assertEqual('SELECT "a"+1-"b"-5 FROM "abc"', str(q1))
-        self.assertEqual('SELECT "a"+1-"b"-5 FROM "abc"', str(q2))
+        self.assertEqual('SELECT "a"+1-("b"-5) FROM "abc"', str(q1))
+        self.assertEqual('SELECT "a"+1-("b"-5) FROM "abc"', str(q2))
+        self.assertEqual('SELECT "a"/1-"b"/5 FROM "abc"', str(q3))
+        self.assertEqual('SELECT "a"/1-"b"/5 FROM "abc"', str(q4))
 
     def test__complex_op_mul_parentheses(self):
         q1 = Q.from_("abc").select((F("a") + 1) * (F("b") - 5))
         q2 = Q.from_(self.t).select((self.t.a + 1) * (self.t.b - 5))
+        q3 = Q.from_("abc").select((F("a") / 1) * (F("b") - 5))
+        q4 = Q.from_(self.t).select((self.t.a / 1) * (self.t.b - 5))
+        q5 = Q.from_("abc").select((F("a") + 1) * (F("b") / 5))
+        q6 = Q.from_(self.t).select((self.t.a + 1) * (self.t.b / 5))
 
         self.assertEqual('SELECT ("a"+1)*("b"-5) FROM "abc"', str(q1))
         self.assertEqual('SELECT ("a"+1)*("b"-5) FROM "abc"', str(q2))
+        self.assertEqual('SELECT "a"/1*("b"-5) FROM "abc"', str(q3))
+        self.assertEqual('SELECT "a"/1*("b"-5) FROM "abc"', str(q4))
+        self.assertEqual('SELECT ("a"+1)*"b"/5 FROM "abc"', str(q5))
+        self.assertEqual('SELECT ("a"+1)*"b"/5 FROM "abc"', str(q6))
 
     def test__complex_op_mul_no_parentheses(self):
         q = Q.from_("abc").select(F("a") + 1 * F("b") - 5)
@@ -197,14 +213,103 @@ class ArithmeticTests(unittest.TestCase):
     def test__complex_op_div_parentheses(self):
         q1 = Q.from_("abc").select((F("a") + 1) / (F("b") - 5))
         q2 = Q.from_(self.t).select((self.t.a + 1) / (self.t.b - 5))
+        q3 = Q.from_("abc").select((F("a") / 1) / (F("b") - 5))
+        q4 = Q.from_(self.t).select((self.t.a / 1) / (self.t.b - 5))
+        q5 = Q.from_("abc").select((F("a") + 1) / (F("b") * 5))
+        q6 = Q.from_(self.t).select((self.t.a + 1) / (self.t.b * 5))
 
         self.assertEqual('SELECT ("a"+1)/("b"-5) FROM "abc"', str(q1))
         self.assertEqual('SELECT ("a"+1)/("b"-5) FROM "abc"', str(q2))
+        self.assertEqual('SELECT "a"/1/("b"-5) FROM "abc"', str(q3))
+        self.assertEqual('SELECT "a"/1/("b"-5) FROM "abc"', str(q4))
+        self.assertEqual('SELECT ("a"+1)/("b"*5) FROM "abc"', str(q5))
+        self.assertEqual('SELECT ("a"+1)/("b"*5) FROM "abc"', str(q6))
 
     def test__complex_op_div_no_parentheses(self):
         q = Q.from_("abc").select(F("a") + 1 / F("b") - 5)
 
         self.assertEqual('SELECT "a"+1/"b"-5 FROM "abc"', str(q))
+
+    def test__complex_op_exponent_parentheses(self):
+        q1 = Q.from_("abc").select(F("a") / (F("b") ** 2))
+        q2 = Q.from_(self.t).select(self.t.a / (self.t.b ** 2))
+        q3 = Q.from_("abc").select(F("a") ** (F("b") / 2))
+        q4 = Q.from_(self.t).select(self.t.a ** (self.t.b / 2))
+        q5 = Q.from_("abc").select((F("a") ** F("b")) ** 2)
+        q6 = Q.from_(self.t).select((self.t.a ** self.t.b) ** 2)
+
+        self.assertEqual('SELECT "a"/POW("b",2) FROM "abc"', str(q1))
+        self.assertEqual('SELECT "a"/POW("b",2) FROM "abc"', str(q2))
+        self.assertEqual('SELECT POW("a","b"/2) FROM "abc"', str(q3))
+        self.assertEqual('SELECT POW("a","b"/2) FROM "abc"', str(q4))
+        self.assertEqual('SELECT POW(POW("a","b"),2) FROM "abc"', str(q5))
+        self.assertEqual('SELECT POW(POW("a","b"),2) FROM "abc"', str(q6))
+
+    def test__complex_op_exponent_no_parentheses(self):
+        q1 = Q.from_("abc").select(F("a") ** F("b") ** 2)
+        q2 = Q.from_(self.t).select(self.t.a ** self.t.b ** 2)
+        q3 = Q.from_("abc").select(F("a") / F("b") ** 2)
+        q4 = Q.from_(self.t).select(self.t.a / self.t.b ** 2)
+
+        self.assertEqual('SELECT POW("a",POW("b",2)) FROM "abc"', str(q1))
+        self.assertEqual('SELECT POW("a",POW("b",2)) FROM "abc"', str(q2))
+        self.assertEqual('SELECT "a"/POW("b",2) FROM "abc"', str(q3))
+        self.assertEqual('SELECT "a"/POW("b",2) FROM "abc"', str(q4))
+
+    def test__complex_op_function_parentheses(self):
+        q1 = Q.from_("abc").select(F("a") / (fn.Sum(F("b")) / 2))
+        q2 = Q.from_("abc").select(self.t.a / (fn.Sum(self.t.b) / 2))
+        q3 = Q.from_("abc").select(fn.Sum(F("a") / (F("b") / 2)))
+        q4 = Q.from_("abc").select(fn.Sum(self.t.a / (self.t.b / 2)))
+
+        self.assertEqual('SELECT "a"/(SUM("b")/2) FROM "abc"', str(q1))
+        self.assertEqual('SELECT "a"/(SUM("b")/2) FROM "abc"', str(q2))
+        self.assertEqual('SELECT SUM("a"/("b"/2)) FROM "abc"', str(q3))
+        self.assertEqual('SELECT SUM("a"/("b"/2)) FROM "abc"', str(q4))
+
+    def test__complex_op_modulus_parentheses(self):
+        q1 = Q.from_("abc").select(F("a") / (F("b") % 2))
+        q2 = Q.from_(self.t).select(self.t.a / (self.t.b % 2))
+        q3 = Q.from_("abc").select(F("a") % (F("b") / 2))
+        q4 = Q.from_(self.t).select(self.t.a % (self.t.b / 2))
+        q5 = Q.from_("abc").select(F("a") % (F("b") % 2))
+        q6 = Q.from_("abc").select(self.t.a % (self.t.b % 2))
+
+        self.assertEqual('SELECT "a"/MOD("b",2) FROM "abc"', str(q1))
+        self.assertEqual('SELECT "a"/MOD("b",2) FROM "abc"', str(q2))
+        self.assertEqual('SELECT MOD("a","b"/2) FROM "abc"', str(q3))
+        self.assertEqual('SELECT MOD("a","b"/2) FROM "abc"', str(q4))
+        self.assertEqual('SELECT MOD("a",MOD("b",2)) FROM "abc"', str(q5))
+        self.assertEqual('SELECT MOD("a",MOD("b",2)) FROM "abc"', str(q6))
+
+    def test__complex_op_modulus_no_parentheses(self):
+        q1 = Q.from_("abc").select(F("a") % F("b") % 2)
+        q2 = Q.from_(self.t).select(self.t.a % self.t.b % 2)
+        q3 = Q.from_("abc").select(F("a") / F("b") % 2)
+        q4 = Q.from_(self.t).select(self.t.a / self.t.b % 2)
+
+        self.assertEqual('SELECT MOD(MOD("a","b"),2) FROM "abc"', str(q1))
+        self.assertEqual('SELECT MOD(MOD("a","b"),2) FROM "abc"', str(q2))
+        self.assertEqual('SELECT MOD("a"/"b",2) FROM "abc"', str(q3))
+        self.assertEqual('SELECT MOD("a"/"b",2) FROM "abc"', str(q4))
+
+    def test__complex_op_floor_parentheses(self):
+        q1 = Q.from_("abc").select(F("a") / (fn.Floor(F("b")) / 2))
+        q2 = Q.from_("abc").select(self.t.a / (fn.Floor(self.t.b) / 2))
+        q3 = Q.from_("abc").select(fn.Floor(F("a") / (F("b") / 2)))
+        q4 = Q.from_("abc").select(fn.Floor(self.t.a / (self.t.b / 2)))
+
+        self.assertEqual('SELECT "a"/(FLOOR("b")/2) FROM "abc"', str(q1))
+        self.assertEqual('SELECT "a"/(FLOOR("b")/2) FROM "abc"', str(q2))
+        self.assertEqual('SELECT FLOOR("a"/("b"/2)) FROM "abc"', str(q3))
+        self.assertEqual('SELECT FLOOR("a"/("b"/2)) FROM "abc"', str(q4))
+
+    def test__complex_op_nested_parentheses(self):
+        q1 = Q.from_("abc").select(F("a") / (F("b") / ((F("c") / 2))))
+        q2 = Q.from_("abc").select(self.t.a / (self.t.b / ((self.t.c / 2))))
+
+        self.assertEqual('SELECT "a"/("b"/("c"/2)) FROM "abc"', str(q1))
+        self.assertEqual('SELECT "a"/("b"/("c"/2)) FROM "abc"', str(q2))
 
     def test__arithmetic_equality(self):
         q1 = Q.from_("abc").select(F("a") / 2 == 2)


### PR DESCRIPTION
#508

This change ensures that the following expressions are evaluated correctly:

```
Before change:
1 / (2 * 3) --> 1 / 2 * 3
1 - (2 - 3) --> 1 - 2 - 3

After change:
1 / (2 * 3) --> 1 / (2 * 3)
1 - (2 - 3) --> 1 - (2 - 3)
```

Quick note:

A simpler fix would be to add parentheses around the left/right expressions unconditionally (well, as long as the expressions are not single items) in the following way:

```
arithmetic_sql = "{left}{operator}{right}".format(
        operator=self.operator.value,
        # If left_op/right_op is None, then the left/right expression is a single item.
        left=("({})" if left_op is not None else "{}").format(self.left.get_sql(**kwargs)),
        right=("({})" if right_op is not None else "{}").format(self.right.get_sql(**kwargs)),
)
```

However, this would result in unnecessary parentheses (example below):

`
Query.select(1 + 2 + 3) --> SELECT (1 + 2) + 3
`

Which is technically correct but the intent of the original implementation was to avoid doing this, so we should preserve that behavior.

@alec-heif @awishnick