### PR TITLE
Fix PostgreSQLQueryBuilder returning clause code causing Py3.9 test failures

### DIFF
--- a/pypika/tests/test_deletes.py
+++ b/pypika/tests/test_deletes.py
@@ -1,13 +1,18 @@
 import unittest
 
-from pypika import Table, Query, PostgreSQLQuery, SYSTEM_TIME
+from pypika import PostgreSQLQuery, Query, SYSTEM_TIME, Table
 
 __author__ = "Timothy Heys"
 __email__ = "theys@kayak.com"
 
+from pypika.terms import Star
+
 
 class DeleteTests(unittest.TestCase):
-    table_abc = Table("abc")
+    @classmethod
+    def setUpClass(cls) -> None:
+        super().setUpClass()
+        cls.table_abc = Table("abc")
 
     def test_omit_where(self):
         q = Query.from_("abc").delete()
@@ -45,7 +50,10 @@ class DeleteTests(unittest.TestCase):
 
 
 class PostgresDeleteTests(unittest.TestCase):
-    table_abc = Table("abc")
+    @classmethod
+    def setUpClass(cls) -> None:
+        super().setUpClass()
+        cls.table_abc = Table("abc")
 
     def test_delete_returning(self):
         q1 = (
@@ -66,3 +74,13 @@ class PostgresDeleteTests(unittest.TestCase):
         )
 
         self.assertEqual('DELETE FROM "abc" WHERE "foo"="bar" RETURNING "id"', str(q1))
+
+    def test_delete_returning_star(self):
+        q1 = (
+            PostgreSQLQuery.from_(self.table_abc)
+            .where(self.table_abc.foo == self.table_abc.bar)
+            .delete()
+            .returning(Star())
+        )
+
+        self.assertEqual('DELETE FROM "abc" WHERE "foo"="bar" RETURNING *', str(q1))

--- a/pypika/tests/test_updates.py
+++ b/pypika/tests/test_updates.py
@@ -1,9 +1,11 @@
 import unittest
 
-from pypika import Table, Query, PostgreSQLQuery, AliasedQuery, SQLLiteQuery, SYSTEM_TIME
+from pypika import AliasedQuery, PostgreSQLQuery, Query, SQLLiteQuery, SYSTEM_TIME, Table
 
 __author__ = "Timothy Heys"
 __email__ = "theys@kayak.com"
+
+from pypika.terms import Star
 
 
 class UpdateTests(unittest.TestCase):
@@ -144,6 +146,11 @@ class PostgresUpdateTests(unittest.TestCase):
         self.assertEqual(
             'UPDATE "abc" SET "lname"="bcd"."long_name" FROM "bcd" RETURNING "abc"."id","bcd"."fname"', str(q)
         )
+
+    def test_update_returning_star(self):
+        q = PostgreSQLQuery.update(self.table_abc).where(self.table_abc.foo == 0).set("foo", "bar").returning(Star())
+
+        self.assertEqual('UPDATE "abc" SET "foo"=\'bar\' WHERE "foo"=0 RETURNING *', str(q))
 
 
 class SQLLiteUpdateTests(unittest.TestCase):


### PR DESCRIPTION
This PR fixes the Python 3.9 test failures in the Github Actions CI. 

This was previously passing due to this statement: `if field.table not in {self._insert_table, self._update_table} and term not in self._from`, specifically the second statement. In my Python 3.6 environment, the Term `__eq__` method was called, always returning a truthy value (as this returns a BasicCriterion object, intended for query building). In Python 3.9, this is not called (I couldn't find anything in the release notes though). Therefore, I have rewritten this to check if the field's table is one of the base and join tables.

FYI @abondar 