### PR TITLE
Add the glob matching comparator (used in SQLite)

### DIFF
--- a/pypika/enums.py
+++ b/pypika/enums.py
@@ -33,6 +33,7 @@ class Matching(Comparator):
     regex = " REGEX "
     bin_regex = " REGEX BINARY "
     as_of = " AS OF "
+    glob = " GLOB "
 
 
 class Boolean(Comparator):

--- a/pypika/terms.py
+++ b/pypika/terms.py
@@ -142,6 +142,9 @@ class Term(Node):
     def ne(self, other: Any) -> "BasicCriterion":
         return self != other
 
+    def glob(self, expr: str) -> "BasicCriterion":
+        return BasicCriterion(Matching.glob, self, self.wrap_constant(expr))
+
     def like(self, expr: str) -> "BasicCriterion":
         return BasicCriterion(Matching.like, self, self.wrap_constant(expr))
 

--- a/pypika/tests/test_criterions.py
+++ b/pypika/tests/test_criterions.py
@@ -575,6 +575,13 @@ class LikeTests(unittest.TestCase):
         self.assertEqual("\"foo\" NOT ILIKE 'a_b%c'", str(c1))
         self.assertEqual('"like"."foo" NOT ILIKE \'a_b%c\'', str(c2))
 
+    def test_glob_single_chars_and_various_chars(self):
+        c1 = Field("foo").glob("a_b*")
+        c2 = Field("foo", table=self.t).glob("a_b*")
+
+        self.assertEqual("\"foo\" GLOB 'a_b*'", str(c1))
+        self.assertEqual('"like"."foo" GLOB \'a_b*\'', str(c2))
+
 
 class ComplexCriterionTests(unittest.TestCase):
     table_abc, table_efg = Table("abc", alias="cx0"), Table("efg", alias="cx1")


### PR DESCRIPTION
SQLite has a `GLOB` operator. It is a case-sensitive version of the `LIKE` operator. 

Documentation here:
https://sqlite.org/lang_expr.html
https://stackoverflow.com/questions/37508793/whats-the-difference-between-like-and-glob-in-sqlite

relevant quote:
> The GLOB operator is similar to LIKE but uses the Unix file globbing syntax for its wildcards. Also, GLOB is case sensitive, unlike LIKE.
