### PR TITLE
Fix empty Postgres array syntax

### DIFF
--- a/pypika/terms.py
+++ b/pypika/terms.py
@@ -611,7 +611,10 @@ class Array(Tuple):
     def get_sql(self, **kwargs: Any) -> str:
         dialect = kwargs.get("dialect", None)
         values = ",".join(term.get_sql(**kwargs) for term in self.values)
-        sql = ("ARRAY[{}]" if dialect in (Dialects.POSTGRESQL, Dialects.REDSHIFT) else "[{}]").format(values)
+        if dialect in (Dialects.POSTGRESQL, Dialects.REDSHIFT):
+            sql = "ARRAY[{}]".format(values) if len(values) > 0 else "'{}'"
+        else:
+            sql = "[{}]".format(values)
         return format_alias_sql(sql, self.alias, **kwargs)
 
 

--- a/pypika/terms.py
+++ b/pypika/terms.py
@@ -611,10 +611,11 @@ class Array(Tuple):
     def get_sql(self, **kwargs: Any) -> str:
         dialect = kwargs.get("dialect", None)
         values = ",".join(term.get_sql(**kwargs) for term in self.values)
+
+        sql = "[{}]".format(values)
         if dialect in (Dialects.POSTGRESQL, Dialects.REDSHIFT):
             sql = "ARRAY[{}]".format(values) if len(values) > 0 else "'{}'"
-        else:
-            sql = "[{}]".format(values)
+
         return format_alias_sql(sql, self.alias, **kwargs)
 
 

--- a/pypika/tests/test_tuples.py
+++ b/pypika/tests/test_tuples.py
@@ -139,7 +139,7 @@ class ArrayTests(unittest.TestCase):
     def test_psql_array_general(self):
         query = PostgreSQLQuery.from_(self.table_abc).select(Array(1, Array(2, 2, 2), 3))
 
-        self.assertEqual("SELECT 'ARRAY[1,ARRAY[2,2,2],3]' FROM \"abc\"", str(query))
+        self.assertEqual("SELECT ARRAY[1,ARRAY[2,2,2],3] FROM \"abc\"", str(query))
 
     def test_render_alias_in_array_sql(self):
         tb = Table("tb")

--- a/pypika/tests/test_tuples.py
+++ b/pypika/tests/test_tuples.py
@@ -4,6 +4,7 @@ from pypika import (
     Array,
     Bracket,
     Query,
+    PostgreSQLQuery,
     Table,
     Tables,
     Tuple,
@@ -129,6 +130,16 @@ class ArrayTests(unittest.TestCase):
         query = Query.from_(self.table_abc).select(Array(1, "a", ["b", 2, 3]))
 
         self.assertEqual("SELECT [1,'a',['b',2,3]] FROM \"abc\"", str(query))
+
+    def test_empty_psql_array(self):
+        query = PostgreSQLQuery.from_(self.table_abc).select(Array())
+
+        self.assertEqual("SELECT '{}' FROM \"abc\"", str(query))
+
+    def test_psql_array_general(self):
+        query = PostgreSQLQuery.from_(self.table_abc).select(Array(1, Array(2, 2, 2), 3))
+
+        self.assertEqual("SELECT 'ARRAY[1,ARRAY[2,2,2],3]' FROM \"abc\"", str(query))
 
     def test_render_alias_in_array_sql(self):
         tb = Table("tb")


### PR DESCRIPTION
Closes #527 

Empty arrays for Postgres and Redshift are switched from `ARRAY[]` to `'{}'` so that PSQL can cast it to the right column type. This would previously give the following error: 
```
ERROR:  cannot determine type of empty array at character XXX
HINT:  Explicitly cast to the desired type, for example ARRAY[]::integer[].
```