### PR TITLE
Remove quotes from Snowflake CREATE/DROP queries

### DIFF
--- a/pypika/dialects.py
+++ b/pypika/dialects.py
@@ -8,6 +8,7 @@ from pypika.queries import (
     Query,
     QueryBuilder,
     Table,
+    DropQueryBuilder,
 )
 from pypika.terms import ArithmeticExpression, Criterion, EmptyCriterion, Field, Function, Star, Term, ValueWrapper
 from pypika.utils import (
@@ -25,6 +26,14 @@ class SnowflakeQuery(Query):
     def _builder(cls, **kwargs: Any) -> "SnowflakeQueryBuilder":
         return SnowflakeQueryBuilder(**kwargs)
 
+    @classmethod
+    def create_table(cls, table: Union[str, Table]) -> "SnowflakeCreateQueryBuilder":
+        return SnowflakeCreateQueryBuilder().create_table(table)
+
+    @classmethod
+    def drop_table(cls, table: Union[str, Table]) -> "SnowflakeDropQueryBuilder":
+        return SnowflakeDropQueryBuilder().drop_table(table)
+
 
 class SnowflakeQueryBuilder(QueryBuilder):
     QUOTE_CHAR = None
@@ -34,6 +43,22 @@ class SnowflakeQueryBuilder(QueryBuilder):
 
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(dialect=Dialects.SNOWFLAKE, **kwargs)
+
+
+class SnowflakeCreateQueryBuilder(CreateQueryBuilder):
+    QUOTE_CHAR = None
+    QUERY_CLS = SnowflakeQuery
+
+    def __init__(self) -> None:
+        super().__init__(dialect=Dialects.SNOWFLAKE)
+
+
+class SnowflakeDropQueryBuilder(DropQueryBuilder):
+    QUOTE_CHAR = None
+    QUERY_CLS = SnowflakeQuery
+
+    def __init__(self) -> None:
+        super().__init__(dialect=Dialects.SNOWFLAKE)
 
 
 class MySQLQuery(Query):

--- a/pypika/tests/dialects/test_snowflake.py
+++ b/pypika/tests/dialects/test_snowflake.py
@@ -3,6 +3,7 @@ import unittest
 from pypika import (
     Tables,
     functions as fn,
+    Column,
 )
 from pypika.dialects import SnowflakeQuery
 
@@ -47,3 +48,11 @@ class QuoteTests(unittest.TestCase):
             "SELECT * " 'FROM (SELECT b FROM abc) sq0 ' 'JOIN (SELECT b FROM efg) sq1 ' "ON sq0.b=sq1.b",
             q.get_sql(),
         )
+
+    def test_dont_use_double_quotes_on_create_queries(self):
+        q = SnowflakeQuery.create_table(self.table_abc).columns(Column("id", "INT"))
+        self.assertEqual("CREATE TABLE abc (id INT)", q.get_sql())
+
+    def test_dont_use_double_quotes_on_drop_queries(self):
+        q = SnowflakeQuery.drop_table(self.table_abc)
+        self.assertEqual("DROP TABLE abc", q.get_sql())


### PR DESCRIPTION
For consistency with SELECT queries generated by the Snowflake dialect.