### PR TITLE
Render subquery function arguments with parentheses

### DIFF
--- a/pypika/terms.py
+++ b/pypika/terms.py
@@ -1246,7 +1246,7 @@ class Function(Criterion):
 
     @staticmethod
     def get_arg_sql(arg, **kwargs):
-        return arg.get_sql(with_alias=False, **kwargs) if hasattr(arg, "get_sql") else str(arg)
+        return arg.get_sql(subquery=True, with_alias=False, **kwargs) if hasattr(arg, "get_sql") else str(arg)
 
     def get_function_sql(self, **kwargs: Any) -> str:
         special_params_sql = self.get_special_params_sql(**kwargs)


### PR DESCRIPTION
When using correlated subqueries as function arguments, they should be rendered with parentheses.

An example where this is required with JSON functions:
```sql
SELECT json_object(
    'id', T.id,
    'child', (
        SELECT json_object(
            'child_id', C.id,
            'child_attr', C.attr
        )
        FROM child C
        WHERE C.parent_id = T.id
    )
)
FROM table T
WHERE T.id = ?
```