### PR TITLE
Support UUID values

### DIFF
--- a/pypika/terms.py
+++ b/pypika/terms.py
@@ -1,5 +1,6 @@
 import inspect
 import re
+import uuid
 from datetime import date
 from enum import Enum
 from typing import Any, Iterable, Iterator, List, Optional, Sequence, Set, TYPE_CHECKING, Type, TypeVar, Union
@@ -351,6 +352,8 @@ class ValueWrapper(Term):
             return format_quotes(value, quote_char)
         if isinstance(self.value, bool):
             return str.lower(str(self.value))
+        if isinstance(self.value, uuid.UUID):
+            return format_quotes(str(self.value), quote_char)
         if self.value is None:
             return "null"
         return str(self.value)

--- a/pypika/tests/test_data_types.py
+++ b/pypika/tests/test_data_types.py
@@ -1,4 +1,5 @@
 import unittest
+import uuid
 
 from pypika.terms import ValueWrapper
 
@@ -6,3 +7,9 @@ from pypika.terms import ValueWrapper
 class StringTests(unittest.TestCase):
     def test_inline_string_concatentation(self):
         self.assertEqual("'it''s'", ValueWrapper("it's").get_sql())
+
+
+class UuidTests(unittest.TestCase):
+    def test_uuid_string_generation(self):
+        id = uuid.uuid4()
+        self.assertEqual("'{}'".format(id), ValueWrapper(id).get_sql())


### PR DESCRIPTION
Addresses issue https://github.com/kayak/pypika/issues/571. This PR adds support for UUID values when generating a SQL statement. This prevents the need to manually convert any UUIDs into a string when building the query. 

With this change, a query such as:
`Query.into('table').insert(uuid.uuid4()).get_sql()`
will now be translated as:
`INSERT INTO "table" VALUES ('9659afa7-573d-49c3-b902-79c4d9dea831')`.