### PR TITLE
Change Case class to inherit from Criterion

### DIFF
--- a/pypika/terms.py
+++ b/pypika/terms.py
@@ -1050,7 +1050,7 @@ class ArithmeticExpression(Term):
         return arithmetic_sql
 
 
-class Case(Term):
+class Case(Criterion):
     def __init__(self, alias: Optional[str] = None) -> None:
         super().__init__(alias=alias)
         self._cases = []

--- a/pypika/tests/test_selects.py
+++ b/pypika/tests/test_selects.py
@@ -473,6 +473,26 @@ class WhereTests(unittest.TestCase):
 
         self.assertEqual('SELECT "foo" FROM "abc" FORCE INDEX ("egg") WHERE "foo"="bar"', str(q))
 
+    def test_where_with_multiple_wheres_using_and_case(self):
+        case_stmt = Case().when(self.t.foo == 'bar', 1).else_(0)
+        query = Query.from_(self.t).select(case_stmt).where(case_stmt & self.t.blah.isin(['test']))
+
+        self.assertEqual(
+            'SELECT CASE WHEN "foo"=\'bar\' THEN 1 ELSE 0 END FROM "abc" WHERE CASE WHEN "foo"=\'bar\' THEN 1 ELSE 0 '
+            'END AND "blah" IN (\'test\')',
+            str(query),
+        )
+
+    def test_where_with_multiple_wheres_using_or_case(self):
+        case_stmt = Case().when(self.t.foo == 'bar', 1).else_(0)
+        query = Query.from_(self.t).select(case_stmt).where(case_stmt | self.t.blah.isin(['test']))
+
+        self.assertEqual(
+            'SELECT CASE WHEN "foo"=\'bar\' THEN 1 ELSE 0 END FROM "abc" WHERE CASE WHEN "foo"=\'bar\' THEN 1 ELSE 0 '
+            'END OR "blah" IN (\'test\')',
+            str(query),
+        )
+
 
 class PreWhereTests(WhereTests):
     t = Table("abc")


### PR DESCRIPTION
* This allows CASE statements to be used in where clauses when the where clause contains a Case instance and subsequent instances derived from Criterion