### PR TITLE
Added NOT GLOB operator

### DIFF
--- a/pypika/enums.py
+++ b/pypika/enums.py
@@ -34,6 +34,7 @@ class Matching(Comparator):
     bin_regex = " REGEX BINARY "
     as_of = " AS OF "
     glob = " GLOB "
+    not_glob = " NOT GLOB "
 
 
 class Boolean(Comparator):

--- a/pypika/terms.py
+++ b/pypika/terms.py
@@ -145,6 +145,9 @@ class Term(Node):
     def glob(self, expr: str) -> "BasicCriterion":
         return BasicCriterion(Matching.glob, self, self.wrap_constant(expr))
 
+    def not_glob(self, expr: str) -> "BasicCriterion":
+        return BasicCriterion(Matching.not_glob, self, self.wrap_constant(expr))
+
     def like(self, expr: str) -> "BasicCriterion":
         return BasicCriterion(Matching.like, self, self.wrap_constant(expr))
 

--- a/pypika/tests/test_criterions.py
+++ b/pypika/tests/test_criterions.py
@@ -582,6 +582,13 @@ class LikeTests(unittest.TestCase):
         self.assertEqual("\"foo\" GLOB 'a_b*'", str(c1))
         self.assertEqual('"like"."foo" GLOB \'a_b*\'', str(c2))
 
+    def test_not_glob_single_chars_and_various_chars(self):
+        c1 = Field("foo").not_glob("a_b*")
+        c2 = Field("foo", table=self.t).not_glob("a_b*")
+
+        self.assertEqual("\"foo\" NOT GLOB 'a_b*'", str(c1))
+        self.assertEqual('"like"."foo" NOT GLOB \'a_b*\'', str(c2))
+
 
 class ComplexCriterionTests(unittest.TestCase):
     table_abc, table_efg = Table("abc", alias="cx0"), Table("efg", alias="cx1")


### PR DESCRIPTION
According to:
https://sqlite.org/lang_expr.html

> Both GLOB and LIKE may be preceded by the NOT keyword to invert the sense of the test

In a previous PR, I had added `GLOB`. In this one, I'm adding `NOT GLOB`