### PR TITLE
Add IS NOT NULL operator

### DIFF
--- a/pypika/terms.py
+++ b/pypika/terms.py
@@ -941,7 +941,6 @@ class NullCriterion(Criterion):
 
 
 class NotNullCriterion(NullCriterion):
-
     def get_sql(self, with_alias: bool = False, **kwargs: Any) -> str:
         sql = "{term} IS NOT NULL".format(
             term=self.term.get_sql(**kwargs),

--- a/pypika/terms.py
+++ b/pypika/terms.py
@@ -127,6 +127,9 @@ class Term(Node):
     def notnull(self) -> "Not":
         return self.isnull().negate()
 
+    def isnotnull(self) -> 'NotNullCriterion':
+        return NotNullCriterion(self)
+
     def bitwiseand(self, value: int) -> "BitwiseAndCriterion":
         return BitwiseAndCriterion(self, self.wrap_constant(value))
 
@@ -932,6 +935,15 @@ class NullCriterion(Criterion):
 
     def get_sql(self, with_alias: bool = False, **kwargs: Any) -> str:
         sql = "{term} IS NULL".format(
+            term=self.term.get_sql(**kwargs),
+        )
+        return format_alias_sql(sql, self.alias, **kwargs)
+
+
+class NotNullCriterion(NullCriterion):
+
+    def get_sql(self, with_alias: bool = False, **kwargs: Any) -> str:
+        sql = "{term} IS NOT NULL".format(
             term=self.term.get_sql(**kwargs),
         )
         return format_alias_sql(sql, self.alias, **kwargs)

--- a/pypika/tests/test_criterions.py
+++ b/pypika/tests/test_criterions.py
@@ -301,6 +301,13 @@ class NotTests(unittest.TestCase):
         self.assertEqual('NOT "foo" IS NULL', str(c1))
         self.assertEqual('NOT "cx0"."foo" IS NULL', str(c2))
 
+    def test_is_not_null(self):
+        c1 = Field("foo").isnotnull()
+        c2 = Field("foo", table=self.table_abc).isnotnull()
+
+        self.assertEqual('"foo" IS NOT NULL', str(c1))
+        self.assertEqual('"cx0"."foo" IS NOT NULL', str(c2))
+
     def test_not_null_with_alias(self):
         c1 = Field("foo").notnull().as_("something")
         c2 = Field("foo", table=self.table_abc).notnull().as_("something")


### PR DESCRIPTION
Hi! I'm unable to filter non-null values in CH with this syntax: `NOT "x" IS NULL`. It is invalid for CH. The correct expression is `"x" IS NOT NULL`. I added NotNullCriterion term to get things done. Thanks.