### PR TITLE
Test tabled fields dict key collision

### DIFF
--- a/pypika/terms.py
+++ b/pypika/terms.py
@@ -264,7 +264,7 @@ class Term(Node):
         return self.get_sql(quote_char='"', secondary_quote_char="'")
 
     def __hash__(self) -> int:
-        return hash(self.get_sql(with_alias=True))
+        return hash(self.get_sql(with_alias=True, with_namespace=True))
 
     def get_sql(self, **kwargs: Any) -> str:
         raise NotImplementedError()

--- a/pypika/tests/test_terms.py
+++ b/pypika/tests/test_terms.py
@@ -16,15 +16,27 @@ class FieldAliasTests(TestCase):
 
 
 class FieldHashingTests(TestCase):
-    def test_tabled_fields_dict_has_no_collisions(self):
+    def test_tabled_eq_fields_equally_hashed(self):
+        client_name1 = Field(name="name", table=Table("clients"))
+        client_name2 = Field(name="name", table=Table("clients"))
+        self.assertTrue(hash(client_name1) == hash(client_name2))
+
+    def test_tabled_ne_fields_differently_hashed(self):
         customer_name = Field(name="name", table=Table("customers"))
         client_name = Field(name="name", table=Table("clients"))
-        name_fields = {
-            customer_name: "Jason",
-            client_name: "Jacob",
-        }
+        self.assertTrue(hash(customer_name) != hash(client_name))
 
-        self.assertTrue(len(name_fields.keys()) == 2)
+    def test_non_tabled_aliased_eq_fields_equally_hashed(self):
+        self.assertTrue(hash(Field(name="A", alias="my_a")) == hash(Field(name="A", alias="my_a")))
+
+    def test_non_tabled_aliased_ne_fields_differently_hashed(self):
+        self.assertTrue(hash(Field(name="A", alias="my_a1")) != hash(Field(name="A", alias="my_a2")))
+
+    def test_non_tabled_eq_fields_equally_hashed(self):
+        self.assertTrue(hash(Field(name="A")) == hash(Field(name="A")))
+
+    def test_non_tabled_ne_fields_differently_hashed(self):
+        self.assertTrue(hash(Field(name="A")) != hash(Field(name="B")))
 
 
 class AtTimezoneTests(TestCase):

--- a/pypika/tests/test_terms.py
+++ b/pypika/tests/test_terms.py
@@ -15,6 +15,18 @@ class FieldAliasTests(TestCase):
         self.assertEqual('bar', str(c1.alias))
 
 
+class FieldHashingTests(TestCase):
+    def test_tabled_fields_dict_has_no_collisions(self):
+        customer_name = Field(name="name", table=Table("customers"))
+        client_name = Field(name="name", table=Table("clients"))
+        name_fields = {
+            customer_name: "Jason",
+            client_name: "Jacob",
+        }
+
+        self.assertTrue(len(name_fields.keys()) == 2)
+
+
 class AtTimezoneTests(TestCase):
     def test_when_interval_not_specified(self):
         query = Query.from_("customers").select(AtTimezone("date", "US/Eastern"))


### PR DESCRIPTION
`pypika.Field` inherits its `__hash__` from `Term` defined as 
```python
hash(self.get_sql(with_alias=True))
```
However for tabled `Fields` e.g.
```python
fld1 = Field("name", table=Table("tname1"))
fld2 = Field("name", table=Table("tname2"))
fld1.get_sql(with_alias=True) == fld2.get_sql(with_alias=True) == "name"
```
And thus the `__hash__` function would return the same result making Field not suited for being a key in a dictionary.
