### PR TITLE
Make EmptyCriterion inherit from Criterion

### DIFF
--- a/pypika/terms.py
+++ b/pypika/terms.py
@@ -498,7 +498,7 @@ class Criterion(Term):
         raise NotImplementedError()
 
 
-class EmptyCriterion:
+class EmptyCriterion(Criterion):
     is_aggregate = None
     tables_ = set()
 


### PR DESCRIPTION
Otherwise, type checkers are confused. Plus, it makes logical sense; my assumption is this omission was just an oversight.

I can work around this temporarily with `BaseCriterion = Union[Criterion, EmptyCriterion]`, but that doesn't seem like the right long-term answer.