### PR TITLE
Accept EmptyCriterion for HAVING filtering

### DIFF
--- a/pypika/queries.py
+++ b/pypika/queries.py
@@ -933,7 +933,10 @@ class QueryBuilder(Selectable, Term):
             self._wheres = criterion
 
     @builder
-    def having(self, criterion: Term) -> "QueryBuilder":
+    def having(self, criterion: Union[Term, EmptyCriterion]) -> "QueryBuilder":
+        if isinstance(criterion, EmptyCriterion):
+            return
+
         if self._havings:
             self._havings &= criterion
         else:

--- a/pypika/tests/test_selects.py
+++ b/pypika/tests/test_selects.py
@@ -468,8 +468,13 @@ class WhereTests(unittest.TestCase):
 
         self.assertEqual('SELECT * FROM "abc" WHERE "foo" RLIKE \'^b\'', str(q))
 
-    def test_ignore_empty_criterion(self):
+    def test_ignore_empty_criterion_where(self):
         q1 = Query.from_(self.t).select("*").where(EmptyCriterion())
+
+        self.assertEqual('SELECT * FROM "abc"', str(q1))
+
+    def test_ignore_empty_criterion_having(self):
+        q1 = Query.from_(self.t).select("*").having(EmptyCriterion())
 
         self.assertEqual('SELECT * FROM "abc"', str(q1))
 


### PR DESCRIPTION
Right now, if we are writing a query similar at

```
Query.from_(Table('t')).select("*").having(EmptyCriterion())
```
Or, with a real world query

```
Query.from_(Table('t')).select("*").having(Criterion.all([
   # A generator who returns nothing
]))
```

It will raise this exception.

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/guillaume/.virtualenvs/project/lib/python3.8/site-packages/pypika/queries.py", line 1188, in __repr__
    return self.__str__()
  File "/home/guillaume/.virtualenvs/project/lib/python3.8/site-packages/pypika/queries.py", line 1185, in __str__
    return self.get_sql(dialect=self.dialect)
  File "/home/guillaume/.virtualenvs/project/lib/python3.8/site-packages/pypika/queries.py", line 1322, in get_sql
    querystring += self._having_sql(**kwargs)
  File "/home/guillaume/.virtualenvs/project/lib/python3.8/site-packages/pypika/queries.py", line 1515, in _having_sql
    return " HAVING {having}".format(having=self._havings.get_sql(quote_char=quote_char, **kwargs))
TypeError: get_sql() got an unexpected keyword argument 'quote_char'
```

The following pull-request solve the issue, with identifying if we have an empty criterion or not, as we do for the where filtering