### PR TITLE
DOC fix typo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -510,9 +510,9 @@ Example of a correlated subquery in the `SELECT`
 Unions
 """"""
 
-Both ``UNION`` and ``UNION ALL`` are supported. ``UNION DISTINCT`` is synonomous with "UNION`` so and |Brand| does not
+Both ``UNION`` and ``UNION ALL`` are supported. ``UNION DISTINCT`` is synonomous with "UNION`` so |Brand| does not
 provide a separate function for it.  Unions require that queries have the same number of ``SELECT`` clauses so
-trying to cast a unioned query to string will through a ``SetOperationException`` if the column sizes are mismatched.
+trying to cast a unioned query to string will throw a ``SetOperationException`` if the column sizes are mismatched.
 
 To create a union query, use either the ``Query.union()`` method or `+` operator with two query instances. For a
 union all, use ``Query.union_all()`` or the `*` operator.
@@ -534,7 +534,7 @@ Intersect
 """""""""
 
 ``INTERSECT`` is supported. Intersects require that queries have the same number of ``SELECT`` clauses so
-trying to cast a intersected query to string with through a ``SetOperationException`` if the column sizes are mismatched.
+trying to cast a intersected query to string will throw a ``SetOperationException`` if the column sizes are mismatched.
 
 To create a intersect query, use the ``Query.intersect()`` method.
 
@@ -557,7 +557,7 @@ Minus
 """""
 
 ``MINUS`` is supported. Minus require that queries have the same number of ``SELECT`` clauses so
-trying to cast a minus query to string with through a ``SetOperationException`` if the column sizes are mismatched.
+trying to cast a minus query to string will throw a ``SetOperationException`` if the column sizes are mismatched.
 
 To create a minus query, use either the ``Query.minus()`` method or `-` operator with two query instances.
 
@@ -588,7 +588,7 @@ EXCEPT
 """"""
 
 ``EXCEPT`` is supported. Minus require that queries have the same number of ``SELECT`` clauses so
-trying to cast a except query to string with through a ``SetOperationException`` if the column sizes are mismatched.
+trying to cast a except query to string will throw a ``SetOperationException`` if the column sizes are mismatched.
 
 To create a except query, use the ``Query.except_of()`` method.
 

--- a/README.rst
+++ b/README.rst
@@ -104,7 +104,7 @@ An alias for the table can be given using the ``.as_`` function on ``pypika.Tabl
 
 .. code-block:: sql
 
-    Table('x_view_customers').as_('customers')
+    customers = Table('x_view_customers').as_('customers')
     q = Query.from_(customers).select(customers.id, customers.phone)
 
 .. code-block:: sql
@@ -512,7 +512,7 @@ Unions
 
 Both ``UNION`` and ``UNION ALL`` are supported. ``UNION DISTINCT`` is synonomous with "UNION`` so and |Brand| does not
 provide a separate function for it.  Unions require that queries have the same number of ``SELECT`` clauses so
-trying to cast a unioned query to string with through a ``SetOperationException`` if the column sizes are mismatched.
+trying to cast a unioned query to string will through a ``SetOperationException`` if the column sizes are mismatched.
 
 To create a union query, use either the ``Query.union()`` method or `+` operator with two query instances. For a
 union all, use ``Query.union_all()`` or the `*` operator.


### PR DESCRIPTION
Fixing 2 typos:

1. Code block on Table Alias missing a variable declaration
2. English typo in UNION doc