### PR TITLE
Implement STRUCT with optional field names

### DIFF
--- a/pypika/__init__.py
+++ b/pypika/__init__.py
@@ -85,6 +85,7 @@ from pypika.terms import (
     Rollup,
     Tuple,
     CustomFunction,
+    Struct,
 )
 
 # noinspection PyUnresolvedReferences

--- a/pypika/terms.py
+++ b/pypika/terms.py
@@ -654,6 +654,21 @@ class Array(Tuple):
         return format_alias_sql(sql, self.alias, **kwargs)
 
 
+class Struct(Criterion):
+    def __init__(self, *values: Any, field_names: List[str] = None) -> None:
+        super().__init__()
+        if field_names is None:
+            self.terms = [self.wrap_constant(value) for value in values]
+        elif len(field_names) == len(values):
+            self.terms = [self.wrap_constant(value).as_(name) for value, name in zip(values, field_names)]
+        else:
+            raise Exception("field_names must have the same length as the number of fields")
+
+    def get_sql(self, **kwargs: Any) -> str:
+        sql = "STRUCT({})".format(",".join([term.get_sql(as_keyword=True) for term in self.terms]))
+        return format_alias_sql(sql, self.alias, **kwargs)
+
+
 class Bracket(Tuple):
     def __init__(self, term: Any) -> None:
         super().__init__(term)

--- a/pypika/tests/test_tuples.py
+++ b/pypika/tests/test_tuples.py
@@ -8,6 +8,7 @@ from pypika import (
     Table,
     Tables,
     Tuple,
+    Struct,
 )
 from pypika.functions import Coalesce, NullIf, Sum
 from pypika.terms import Field
@@ -146,6 +147,20 @@ class ArrayTests(unittest.TestCase):
 
         q = Query.from_(tb).select(Array(tb.col).as_("different_name"))
         self.assertEqual(str(q), 'SELECT ["col"] "different_name" FROM "tb"')
+
+
+class StructTests(unittest.TestCase):
+    table_abc, table_efg = Tables("abc", "efg")
+
+    def test_struct_general(self):
+        query = Query.from_(self.table_abc).select(Struct(1, "a", ["b", 2, 3]))
+
+        self.assertEqual("SELECT STRUCT(1,'a',['b',2,3]) FROM \"abc\"", str(query))
+
+    def test_struct_with_field_names(self):
+        query = Query.from_(self.table_abc).select(Struct(1, "a", ["b", 2, 3], field_names=["col1", "col2", "col3"]))
+
+        self.assertEqual("SELECT STRUCT(1 AS col1,'a' AS col2,['b',2,3] AS col3) FROM \"abc\"", str(query))
 
 
 class BracketTests(unittest.TestCase):


### PR DESCRIPTION
This PR implements the ability to create STRUCT with optional field names, i.e. `STRUCT(expr1 [AS field_name] [, ... ])`. Does not implement typed STRUCT, e.g. `STRUCT<INT64>`
. Partially resolve #591.

**Examples** (included as unit tests):

```python
Query.from_(Table('abc')).select(Struct(1, "a", ["b", 2, 3]))
>>> SELECT STRUCT(1,'a',['b',2,3]) FROM "abc"

Query.from_(Table('abc')).select(Struct(1, "a", ["b", 2, 3], field_names=["col1", "col2", "col3"]))
>>> SELECT STRUCT(1 AS col1,'a' AS col2,['b',2,3] AS col3) FROM "abc"
```


**Discussion points:**
1. Do you suggest a different API to specify `field_names`? Perhaps next to the value itself? 
2. Even though #591 mentions BigQuery, but I think STRUCT is ANSI SQL. I'm open to moving STRUCT to inside BigQuery dialect.