### PR TITLE
add getitem notation

### DIFF
--- a/pypika/tests/test_criterions.py
+++ b/pypika/tests/test_criterions.py
@@ -382,16 +382,6 @@ class BetweenTests(unittest.TestCase):
         self.assertEqual('COALESCE("foo",0) BETWEEN 0 AND 1', str(c1))
         self.assertEqual('COALESCE("btw"."foo",0) BETWEEN 0 AND 1', str(c2))
 
-    def test_get_item_only_works_with_slice(self):
-        with self.assertRaises(TypeError):
-            Field("foo")[0]
-
-        with self.assertRaises(TypeError):
-            Field("foo")[date(2000, 1, 1)]
-
-        with self.assertRaises(TypeError):
-            Field("foo")[datetime(2000, 1, 1, 0, 0, 0)]
-
 
 class IsInTests(unittest.TestCase):
     t = Table("abc", alias="isin")

--- a/pypika/tests/test_terms.py
+++ b/pypika/tests/test_terms.py
@@ -38,6 +38,13 @@ class FieldHashingTests(TestCase):
     def test_non_tabled_ne_fields_differently_hashed(self):
         self.assertTrue(hash(Field(name="A")) != hash(Field(name="B")))
 
+    def test_get_item(self):
+        c = Field("foo")
+        self.assertEqual(str(c['a']), "\"foo\"['a']")
+        self.assertEqual(str(c[1]), "\"foo\"[1]")
+        self.assertEqual(str(c[1]['a']), "\"foo\"[1]['a']")
+        self.assertEqual(str(Field("foo", alias="bar")[0].as_("y")), '"foo"[0] "y"')
+
 
 class AtTimezoneTests(TestCase):
     def test_when_interval_not_specified(self):


### PR DESCRIPTION
presto, hive, spark all use bracket notation for map access

field['foo'] etc