### PR TITLE
Fix Postgres array syntax for UPDATE

### DIFF
--- a/pypika/queries.py
+++ b/pypika/queries.py
@@ -1070,7 +1070,9 @@ class QueryBuilder(Selectable, Term):
     @builder
     def set(self, field: Union[Field, str], value: Any) -> "QueryBuilder":
         field = Field(field) if not isinstance(field, Field) else field
-        self._updates.append((field, self._wrapper_cls(value)))
+        if not isinstance(value, Term):
+            value = self.wrap_constant(value, wrapper_cls=self._wrapper_cls)
+        self._updates.append((field, value))
 
     def __add__(self, other: "QueryBuilder") -> _SetOperation:
         return self.union(other)

--- a/pypika/terms.py
+++ b/pypika/terms.py
@@ -476,7 +476,7 @@ class LiteralValue(Term):
 
 class NullValue(LiteralValue):
     def __init__(self, alias: Optional[str] = None) -> None:
-        super().__init__("NULL", alias)
+        super().__init__("null", alias)
 
 
 class SystemTimeValue(LiteralValue):

--- a/pypika/tests/dialects/test_postgresql.py
+++ b/pypika/tests/dialects/test_postgresql.py
@@ -20,6 +20,15 @@ class InsertTests(unittest.TestCase):
         self.assertEqual("INSERT INTO \"abc\" VALUES (1,ARRAY[1,'a',true])", str(q))
 
 
+class UpdateTests(unittest.TestCase):
+    table_abc = Table("abc")
+
+    def test_postgresquery(self):
+        q = PostgreSQLQuery.update(self.table_abc).set(1, [1, "a", True])
+
+        self.assertEqual("UPDATE \"abc\" SET \"1\"=ARRAY[1,'a',true]", str(q))
+
+
 class JSONObjectTests(unittest.TestCase):
     def test_alias_set_correctly(self):
         table = Table('jsonb_table')

--- a/pypika/tests/test_inserts.py
+++ b/pypika/tests/test_inserts.py
@@ -149,7 +149,7 @@ class InsertIntoTests(unittest.TestCase):
     def test_insert_null(self):
         query = Query.into(self.table_abc).insert(None)
 
-        self.assertEqual('INSERT INTO "abc" VALUES (NULL)', str(query))
+        self.assertEqual('INSERT INTO "abc" VALUES (null)', str(query))
 
     def test_insert_column_using_table_alias(self):
         q = self.table_abc.insert(1)
@@ -541,7 +541,7 @@ class PostgresInsertIntoReturningTests(unittest.TestCase):
     def test_insert_returning_null(self):
         query = PostgreSQLQuery.into(self.table_abc).insert(1).returning(None)
 
-        self.assertEqual('INSERT INTO "abc" VALUES (1) RETURNING NULL', str(query))
+        self.assertEqual('INSERT INTO "abc" VALUES (1) RETURNING null', str(query))
 
     def test_insert_returning_tuple(self):
         query = PostgreSQLQuery.into(self.table_abc).insert(1).returning((1, 2, 3))

--- a/pypika/tests/test_selects.py
+++ b/pypika/tests/test_selects.py
@@ -1113,7 +1113,7 @@ class AliasTests(unittest.TestCase):
     def test_null_value_with_alias(self):
         q = Query.select(NullValue().as_("abcdef"))
 
-        self.assertEqual('SELECT NULL "abcdef"', str(q))
+        self.assertEqual('SELECT null "abcdef"', str(q))
 
 
 class SubqueryTests(unittest.TestCase):


### PR DESCRIPTION
This PR should address https://github.com/kayak/pypika/issues/579 by formatting `UPDATE` queries using the same rules as `INSERT` queries. Regression tests for the new case have been added, courtesy of @vfonte91.

A side effect of this fix is that I discovered PyPika has inconsistent handling of `null` versus `NULL`. In these queries, `null` is used:

```
SELECT * FROM "abc" WHERE "foo"=null
UPDATE "abc" SET "foo"=null
```

But in these queries, `NULL` is used:

```
INSERT INTO "abc" VALUES (NULL)
INSERT INTO "abc" VALUES (1) RETURNING NULL
SELECT NULL "abcdef"
```

This is because there are two different code paths for formatting null values:

https://github.com/kayak/pypika/blob/a7b01dac790f4c6e93a961b0be26a9645fe7cf5c/pypika/terms.py#L385
https://github.com/kayak/pypika/blob/a7b01dac790f4c6e93a961b0be26a9645fe7cf5c/pypika/terms.py#L479

Both of these code paths used to return lowercase `null` circa 2018; this was changed in a seemingly unrelated commit https://github.com/kayak/pypika/commit/3bfee98bb226d4736b03473137e45e4d3e78a127.

Some other keywords (`true`, `false`) seem to be lowercase by convention in PyPika, whereas others (`SYSTEM_TIME`) seem to be uppercase by convention, so it's not entirely clear to me what the expected standardization is. On the plus side, since SQL is fully case-insensitive, it doesn't really matter too much.

In this PR, I've updated all code paths and tests to use lowercase `null`. Let me know if that's wrong.