### PR TITLE
Add final keyword for clickhouse queries

### DIFF
--- a/pypika/dialects.py
+++ b/pypika/dialects.py
@@ -801,7 +801,10 @@ class ClickHouseQueryBuilder(QueryBuilder):
         selectable = ",".join(clause.get_sql(subquery=True, with_alias=True, **kwargs) for clause in self._from)
         if self._delete_from:
             return " {selectable} DELETE".format(selectable=selectable)
-        return f" FROM {selectable} FINAL" if self._final else f" FROM {selectable}".format(selectable=selectable)
+        elif self._final:
+            return f" FROM {selectable} FINAL"
+        else:
+            return f" FROM {selectable}"
 
 
     def _set_sql(self, **kwargs: Any) -> str:

--- a/pypika/dialects.py
+++ b/pypika/dialects.py
@@ -781,6 +781,15 @@ class ClickHouseQuery(Query):
 class ClickHouseQueryBuilder(QueryBuilder):
     QUERY_CLS = ClickHouseQuery
 
+    
+    def __init__(self, **kwargs) -> None:
+        super().__init__(self, as_keyword=True)
+        self._final = False
+    
+    @builder
+    def final_(self) -> None:
+        self._final = True
+
     @staticmethod
     def _delete_sql(**kwargs: Any) -> str:
         return 'ALTER TABLE'
@@ -792,7 +801,8 @@ class ClickHouseQueryBuilder(QueryBuilder):
         selectable = ",".join(clause.get_sql(subquery=True, with_alias=True, **kwargs) for clause in self._from)
         if self._delete_from:
             return " {selectable} DELETE".format(selectable=selectable)
-        return " FROM {selectable}".format(selectable=selectable)
+        return f" FROM {selectable} FINAL" if self._final else f" FROM {selectable}".format(selectable=selectable)
+
 
     def _set_sql(self, **kwargs: Any) -> str:
         return " UPDATE {set}".format(

--- a/pypika/dialects.py
+++ b/pypika/dialects.py
@@ -787,7 +787,7 @@ class ClickHouseQueryBuilder(QueryBuilder):
         self._final = False
     
     @builder
-    def final_(self) -> None:
+    def final(self) -> None:
         self._final = True
 
     @staticmethod

--- a/pypika/tests/dialects/test_clickhouse.py
+++ b/pypika/tests/dialects/test_clickhouse.py
@@ -12,6 +12,11 @@ class ClickHouseQueryTests(TestCase):
         t = Table('abc')
         query = ClickHouseQuery.from_(t).select(t.foo.as_('f1'), t.bar.as_('f2'))
         self.assertEqual(str(query), 'SELECT "foo" AS "f1","bar" AS "f2" FROM "abc"')
+    
+    def test_use_FINAL_keyword(self):
+        t = Table('abc')
+        query = ClickHouseQuery.from_(t).final_().select(t.foo, t.bar, t.baz)
+        self.assertEqual(str(query), 'SELECT "foo","bar","baz" FROM "abc" FINAL')
 
 
 class ClickHouseDeleteTests(TestCase):

--- a/pypika/tests/dialects/test_clickhouse.py
+++ b/pypika/tests/dialects/test_clickhouse.py
@@ -15,7 +15,7 @@ class ClickHouseQueryTests(TestCase):
     
     def test_use_FINAL_keyword(self):
         t = Table('abc')
-        query = ClickHouseQuery.from_(t).final_().select(t.foo, t.bar, t.baz)
+        query = ClickHouseQuery.from_(t).final().select(t.foo, t.bar, t.baz)
         self.assertEqual(str(query), 'SELECT "foo","bar","baz" FROM "abc" FINAL')
 
 


### PR DESCRIPTION
Due to requiring the FINAL Keyword in Clickhouse i decided to implement it. Implemented:
* FINAL Keyword for the Clickhouse dialect.
* Added a Constructor to the ClickhouseQuery Builder Class to enable a flag.
* Added a final method setting the final flag.
* Changed the serialization of the FOR Statement for the ClickhouseQueryBuilder.