### PR TITLE
Added possibility to specify queries in limit clause

### DIFF
--- a/pypika/queries.py
+++ b/pypika/queries.py
@@ -665,7 +665,7 @@ class _SetOperation(Selectable, Term):
         return " OFFSET {offset}".format(offset=self._offset)
 
     def _limit_sql(self) -> str:
-        return " LIMIT {limit}".format(limit=self._limit)
+        return " LIMIT ({limit})".format(limit=self._limit)
 
 
 class QueryBuilder(Selectable, Term):
@@ -1524,7 +1524,7 @@ class QueryBuilder(Selectable, Term):
         return " OFFSET {offset}".format(offset=self._offset)
 
     def _limit_sql(self) -> str:
-        return " LIMIT {limit}".format(limit=self._limit)
+        return " LIMIT ({limit})".format(limit=self._limit)
 
     def _set_sql(self, **kwargs: Any) -> str:
         return " SET {set}".format(


### PR DESCRIPTION
Currently there is no possibility to specify subqueries in limit clause.

I've encountered this issue while trying to make query with limit specified in percentage. For this i needed to make subquery in limit clause. But i have found out that in QueryBuilder 'LIMIT' doesn't surround it's argument with parenthesis and respectively such a query doesn't work in DBMS.

All i've made for this to function properly - added parenthesis around 'LIMIT' argument.