### PR TITLE
Add description to Tox's environments

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,13 @@
 [tox]
 envlist = py38,py39,py310,py311,pypy3
+
 [testenv]
+description = testing against {basepython}
 deps = -r requirements-dev.txt
 commands =
     coverage run
     coverage xml
+
 [gh-actions]
 python =
     3.8: py38


### PR DESCRIPTION
```
$ tox -av
...
default environments:
py36  -> testing against python3.6
py37  -> testing against python3.7
py38  -> testing against python3.8
py39  -> testing against python3.9
pypy3 -> testing against pypy3
```