### PR TITLE
Fix: array get_sql inside Clickhouse

### DIFF
--- a/pypika/clickhouse/array.py
+++ b/pypika/clickhouse/array.py
@@ -15,7 +15,7 @@ class Array(Term):
         self._converter_cls = converter_cls
         self._converter_options = converter_options or dict()
 
-    def get_sql(self):
+    def get_sql(self, *args, **kwargs):
         if self._converter_cls:
             converted = []
             for value in self._values:


### PR DESCRIPTION
I was getting errors where get_sql in Array does not accept some arguments and query builder fails to create_sql. For example:
```
table = Table('test')
query = table.insert(Array(['test']))
print(query)
```
will result in error
```
TypeError: get_sql() got an unexpected keyword argument 'with_alias'
```