### PR TITLE
Vertica alias fix

### DIFF
--- a/pypika/dialects.py
+++ b/pypika/dialects.py
@@ -258,6 +258,8 @@ class VerticaQueryBuilder(QueryBuilder):
         self._hint = label
 
     def get_sql(self, *args: Any, **kwargs: Any) -> str:
+        kwargs['groupby_alias'] = False
+        kwargs['orderby_alias'] = False
         sql = super().get_sql(*args, **kwargs)
 
         if self._hint is not None:


### PR DESCRIPTION
Vertica requires **no** aliases in the `GROUP BY` and `ORDER BY` clauses. The current implementation does not do that.