### PR TITLE
fix: Typing hint for builder decorator

### DIFF
--- a/pypika/utils.py
+++ b/pypika/utils.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, List, Optional, Type
+from typing import Any, Callable, List, Optional, Type, TypeVar
 
 __author__ = "Timothy Heys"
 __email__ = "theys@kayak.com"
@@ -36,7 +36,9 @@ class FunctionException(Exception):
     pass
 
 
-def builder(func: Callable) -> Callable:
+C = TypeVar("C")
+
+def builder(func: C) -> C:
     """
     Decorator for wrapper "builder" functions.  These are functions on the Query class or other classes used for
     building queries which mutate the query and return self.  To make the build functions immutable, this decorator is

--- a/pypika/utils.py
+++ b/pypika/utils.py
@@ -38,6 +38,7 @@ class FunctionException(Exception):
 
 C = TypeVar("C")
 
+
 def builder(func: C) -> C:
     """
     Decorator for wrapper "builder" functions.  These are functions on the Query class or other classes used for


### PR DESCRIPTION
Maintain that the Callable type received is the same as the Callable returned.

**Additional Context for the screenshots:** tbl is a `Table` object, `frappe.qb` is a namespace that has type `MySQLQuery | PostgreSQLQuery`

### Before

![before-typing-change](https://github.com/kayak/pypika/assets/36654812/5a8458f3-7e3c-4f08-a4c1-d976fd93abdd)

### After

![after-typing-change](https://github.com/kayak/pypika/assets/36654812/1a541929-98a8-47f6-a8bb-18daeee36c31)
