### PR TITLE
Fix: Allow the usage of `frozenset` in the `isin(...)` and `notin(...)` functions

### DIFF
--- a/pypika/terms.py
+++ b/pypika/terms.py
@@ -184,12 +184,12 @@ class Term(Node):
     def all_(self) -> "All":
         return All(self)
 
-    def isin(self, arg: Union[list, tuple, set, "Term"]) -> "ContainsCriterion":
-        if isinstance(arg, (list, tuple, set)):
+    def isin(self, arg: Union[list, tuple, set, frozenset, "Term"]) -> "ContainsCriterion":
+        if isinstance(arg, (list, tuple, set, frozenset)):
             return ContainsCriterion(self, Tuple(*[self.wrap_constant(value) for value in arg]))
         return ContainsCriterion(self, arg)
 
-    def notin(self, arg: Union[list, tuple, set, "Term"]) -> "ContainsCriterion":
+    def notin(self, arg: Union[list, tuple, set, frozenset, "Term"]) -> "ContainsCriterion":
         return self.isin(arg).negate()
 
     def bin_regex(self, pattern: str) -> "BasicCriterion":

--- a/pypika/tests/test_criterions.py
+++ b/pypika/tests/test_criterions.py
@@ -438,6 +438,12 @@ class IsInTests(unittest.TestCase):
         self.assertEqual('COALESCE("foo",0) IN (0,1)', str(c1))
         self.assertEqual('COALESCE("isin"."foo",0) IN (0,1)', str(c2))
 
+        for t in (list, tuple, set, frozenset):
+            c_type = fn.Coalesce(Field("foo"), 0).isin(t([0, 1]))
+            self.assertEqual('COALESCE("foo",0) IN (0,1)', str(c_type))
+
+        self.assertRaises(AttributeError, lambda: str(fn.Coalesce(Field("foo"), 0).isin('SHOULD_FAIL')))
+
     def test__in_unicode(self):
         c1 = Field("foo").isin([u"a", u"b"])
         c2 = Field("foo", table=self.t).isin([u"a", u"b"])


### PR DESCRIPTION
This merge request should allow users to use `.isin(...)` and `.notin(...)` functions with `frozenset` as an argument.

Current behavior throws an error as in this minimal reproducible example:

```py
>>> from pypika import Table, Query
>>> best_customers = frozenset([1, 2, 3])
>>> customers = Table('customers')
>>> Query.from_(customers).select(customers.id, customers.name).where(customers.id.isin(best_customers))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/REDACTED_PATH_TO_PYTHON/python3.11/site-packages/pypika/utils.py", line 50, in _copy
    result = func(self_copy, *args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/REDACTED_PATH_TO_PYTHON/python3.11/site-packages/pypika/queries.py", line 930, in where
    if not self._validate_table(criterion):
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/REDACTED_PATH_TO_PYTHON/python3.11/site-packages/pypika/queries.py", line 1155, in _validate_table
    for field in term.fields_():
                 ^^^^^^^^^^^^^^
  File "/REDACTED_PATH_TO_PYTHON/python3.11/site-packages/pypika/terms.py", line 57, in fields_
    return set(self.find_(Field))
               ^^^^^^^^^^^^^^^^^
  File "/REDACTED_PATH_TO_PYTHON/python3.11/site-packages/pypika/terms.py", line 37, in find_
    return [node for node in self.nodes_() if isinstance(node, type)]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/REDACTED_PATH_TO_PYTHON/python3.11/site-packages/pypika/terms.py", line 37, in <listcomp>
    return [node for node in self.nodes_() if isinstance(node, type)]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/REDACTED_PATH_TO_PYTHON/python3.11/site-packages/pypika/terms.py", line 795, in nodes_
    yield from self.container.nodes_()
               ^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'frozenset' object has no attribute 'nodes_'
>>> 
```