### PR TITLE
fix: remove 'ValueError' from return union for 'wrap_constant'

### DIFF
--- a/pypika/terms.py
+++ b/pypika/terms.py
@@ -59,7 +59,7 @@ class Term(Node):
     @staticmethod
     def wrap_constant(
         val, wrapper_cls: Optional[Type["Term"]] = None
-    ) -> Union[ValueError, NodeT, "LiteralValue", "Array", "Tuple", "ValueWrapper"]:
+    ) -> Union[NodeT, "LiteralValue", "Array", "Tuple", "ValueWrapper"]:
         """
         Used for wrapping raw inputs such as numbers in Criterions and Operator.
 


### PR DESCRIPTION
This removes the `ValueError` from the union in the return type of `Term.wrap_constant`.