### PR TITLE
fix cross join test and add docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -478,6 +478,22 @@ Example of a join using `USING`
 
     SELECT "history".* FROM "history" JOIN "customers" USING "customer_id" WHERE "customers"."id"=5
 
+Example of a cross join
+~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: python
+
+    history, customers = Tables('history', 'meta')
+    q = Query \
+        .from_(history) \
+        .cross_join(meta) \
+        .cross() \
+        .select(history.star)
+
+.. code-block:: sql
+
+    SELECT "history".* FROM "history" CROSS JOIN "meta"
+
 
 Example of a correlated subquery in the `SELECT`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/pypika/tests/test_joins.py
+++ b/pypika/tests/test_joins.py
@@ -111,20 +111,15 @@ class SelectQueryJoinTests(unittest.TestCase):
             self.assertEqual(expected, str(query))
 
     def test_cross_join(self):
-        expected = 'SELECT * FROM "abc" CROSS JOIN "efg" ON "abc"."foo"="efg"."bar"'
+        expected = 'SELECT * FROM "abc" CROSS JOIN "efg"'
 
         with self.subTest("join with enum"):
-            query = (
-                Query.from_(self.table0)
-                .join(self.table1, how=JoinType.cross)
-                .on(self.table0.foo == self.table1.bar)
-                .select("*")
-            )
+            query = Query.from_(self.table0).join(self.table1, how=JoinType.cross).cross().select("*")
 
             self.assertEqual(expected, str(query))
 
         with self.subTest("join function"):
-            query = Query.from_(self.table0).cross_join(self.table1).on(self.table0.foo == self.table1.bar).select("*")
+            query = Query.from_(self.table0).cross_join(self.table1).cross().select("*")
             self.assertEqual(expected, str(query))
 
     def test_left_outer_join(self):


### PR DESCRIPTION
Fixes the cross join test (cross joins don't have an on clause) and adds documentation that you need to use .cross() after a cross_join().