### PR TITLE
Make MySQL queries wrap set operations with parens

### DIFF
--- a/pypika/dialects.py
+++ b/pypika/dialects.py
@@ -87,7 +87,7 @@ class MySQLQueryBuilder(QueryBuilder):
     QUERY_CLS = MySQLQuery
 
     def __init__(self, **kwargs: Any) -> None:
-        super().__init__(dialect=Dialects.MYSQL, wrap_set_operation_queries=False, **kwargs)
+        super().__init__(dialect=Dialects.MYSQL, **kwargs)
         self._duplicate_updates = []
         self._ignore_duplicates = False
         self._modifiers = []

--- a/pypika/tests/test_joins.py
+++ b/pypika/tests/test_joins.py
@@ -845,15 +845,6 @@ class UnionTests(unittest.TestCase):
         with self.assertRaises(SetOperationException):
             str(query1 + query2)
 
-    def test_mysql_query_does_not_wrap_unioned_queries_with_params(self):
-        query1 = MySQLQuery.from_(self.table1).select(self.table1.foo)
-        query2 = Query.from_(self.table2).select(self.table2.bar)
-
-        self.assertEqual(
-            "SELECT `foo` FROM `abc` UNION SELECT `bar` FROM `efg`",
-            str(query1 + query2),
-        )
-
     def test_union_as_subquery(self):
         abc, efg = Tables("abc", "efg")
         hij = Query.from_(abc).select(abc.t).union(Query.from_(efg).select(efg.t))
@@ -968,15 +959,6 @@ class IntersectTests(unittest.TestCase):
         with self.assertRaises(SetOperationException):
             str(query1.intersect(query2))
 
-    def test_mysql_query_does_not_wrap_intersected_queries_with_params(self):
-        query1 = MySQLQuery.from_(self.table1).select(self.table1.foo)
-        query2 = Query.from_(self.table2).select(self.table2.bar)
-
-        self.assertEqual(
-            "SELECT `foo` FROM `abc` INTERSECT SELECT `bar` FROM `efg`",
-            str(query1.intersect(query2)),
-        )
-
     def test_intersect_as_subquery(self):
         abc, efg = Tables("abc", "efg")
         hij = Query.from_(abc).select(abc.t).intersect(Query.from_(efg).select(efg.t))
@@ -1063,15 +1045,6 @@ class MinusTests(unittest.TestCase):
 
         with self.assertRaises(SetOperationException):
             str(query1.minus(query2))
-
-    def test_mysql_query_does_not_wrap_minus_queries_with_params(self):
-        query1 = MySQLQuery.from_(self.table1).select(self.table1.foo)
-        query2 = Query.from_(self.table2).select(self.table2.bar)
-
-        self.assertEqual(
-            "SELECT `foo` FROM `abc` MINUS SELECT `bar` FROM `efg`",
-            str(query1 - query2),
-        )
 
     def test_minus_as_subquery(self):
         abc, efg = Tables("abc", "efg")

--- a/pypika/tests/test_joins.py
+++ b/pypika/tests/test_joins.py
@@ -845,6 +845,15 @@ class UnionTests(unittest.TestCase):
         with self.assertRaises(SetOperationException):
             str(query1 + query2)
 
+    def test_mysql_query_wraps_unioned_queries(self):
+        query1 = MySQLQuery.from_(self.table1).select(self.table1.foo)
+        query2 = Query.from_(self.table2).select(self.table2.bar)
+
+        self.assertEqual(
+            "(SELECT `foo` FROM `abc`) UNION (SELECT `bar` FROM `efg`)",
+            str(query1 + query2),
+        )
+
     def test_union_as_subquery(self):
         abc, efg = Tables("abc", "efg")
         hij = Query.from_(abc).select(abc.t).union(Query.from_(efg).select(efg.t))
@@ -959,6 +968,15 @@ class IntersectTests(unittest.TestCase):
         with self.assertRaises(SetOperationException):
             str(query1.intersect(query2))
 
+    def test_mysql_query_wraps_intersected_queries(self):
+        query1 = MySQLQuery.from_(self.table1).select(self.table1.foo)
+        query2 = Query.from_(self.table2).select(self.table2.bar)
+
+        self.assertEqual(
+            "(SELECT `foo` FROM `abc`) INTERSECT (SELECT `bar` FROM `efg`)",
+            str(query1.intersect(query2)),
+        )
+
     def test_intersect_as_subquery(self):
         abc, efg = Tables("abc", "efg")
         hij = Query.from_(abc).select(abc.t).intersect(Query.from_(efg).select(efg.t))
@@ -1045,6 +1063,15 @@ class MinusTests(unittest.TestCase):
 
         with self.assertRaises(SetOperationException):
             str(query1.minus(query2))
+
+    def test_mysql_query_wraps_minus_queries(self):
+        query1 = MySQLQuery.from_(self.table1).select(self.table1.foo)
+        query2 = Query.from_(self.table2).select(self.table2.bar)
+
+        self.assertEqual(
+            "(SELECT `foo` FROM `abc`) MINUS (SELECT `bar` FROM `efg`)",
+            str(query1 - query2),
+        )
 
     def test_minus_as_subquery(self):
         abc, efg = Tables("abc", "efg")


### PR DESCRIPTION
Add parens around set operations for MySQL. Fixes https://github.com/kayak/pypika/issues/773. 

Note that I removed the tests for checking no parens for MySQL, since adding back the parens brings the behavior in line with the default. I assume the tests are for checking that the behavior is not default. Let me know if the tests should be added back.