### PR TITLE
:star: Improve parameterized query support - fixes #793

### DIFF
--- a/pypika/terms.py
+++ b/pypika/terms.py
@@ -299,15 +299,12 @@ def named_placeholder_gen(idx: int) -> str:
 class Parameter(Term):
     is_aggregate = None
 
-    def __init__(self, placeholder: Union[str, int, Callable[[int], str]] = idx_placeholder_gen) -> None:
+    def __init__(self, placeholder: Union[str, int]) -> None:
         super().__init__()
         self._placeholder = placeholder
 
     @property
     def placeholder(self):
-        if callable(self._placeholder):
-            return self._placeholder(None)
-
         return self._placeholder
 
     def get_sql(self, **kwargs: Any) -> str:
@@ -322,8 +319,7 @@ class Parameter(Term):
 
 class ListParameter(Parameter):
     def __init__(self, placeholder: Union[str, int, Callable[[int], str]] = idx_placeholder_gen) -> None:
-        super().__init__()
-        self._placeholder = placeholder
+        super().__init__(placeholder=placeholder)
         self._parameters = list()
 
     @property
@@ -342,8 +338,7 @@ class ListParameter(Parameter):
 
 class DictParameter(Parameter):
     def __init__(self, placeholder: Union[str, int, Callable[[int], str]] = named_placeholder_gen) -> None:
-        super().__init__()
-        self._placeholder = placeholder
+        super().__init__(placeholder=placeholder)
         self._parameters = dict()
 
     @property

--- a/pypika/terms.py
+++ b/pypika/terms.py
@@ -654,6 +654,7 @@ class Field(Criterion, JSON):
         if isinstance(table, str):
             # avoid circular import at load time
             from pypika.queries import Table
+
             table = Table(table)
         self.table = table
 

--- a/pypika/tests/test_parameter.py
+++ b/pypika/tests/test_parameter.py
@@ -196,3 +196,11 @@ class ParametrizedTestsWithValues(unittest.TestCase):
             sql,
         )
         self.assertEqual({':buz': 'buz', 'bar': 'bar'}, parameter.get_parameters())
+
+    def test_pyformat_parameter(self):
+        q = Query.into(self.table_abc).columns("a", "b", "c").insert(1, 2.2, 'foo')
+
+        parameter = PyformatParameter()
+        sql = q.get_sql(parameter=parameter)
+        self.assertEqual('INSERT INTO "abc" ("a","b","c") VALUES (%(param1)s,%(param2)s,%(param3)s)', sql)
+        self.assertEqual({"param1": 1, "param2": 2.2, "param3": "foo"}, parameter.get_parameters())

--- a/pypika/tests/test_terms.py
+++ b/pypika/tests/test_terms.py
@@ -20,7 +20,7 @@ class FieldInitTests(TestCase):
         test_table_name = "test_table"
         field = Field(name="name", table=test_table_name)
         self.assertEqual(field.table, Table(name=test_table_name))
-    
+
 
 class FieldHashingTests(TestCase):
     def test_tabled_eq_fields_equally_hashed(self):


### PR DESCRIPTION
Fixes #793 
The implemented tests speak for themselves, but here is an extract:


```python
subquery = (
    Query.from_(self.table_efg)
    .select(self.table_efg.fiz, self.table_efg.buz)
    .where(self.table_efg.buz == 'buz')
)

q = (
    Query.from_(self.table_abc)
    .join(subquery)
    .on(self.table_abc.bar == subquery.buz)
    .select(self.table_abc.foo, subquery.fiz)
    .where(self.table_abc.bar == 'bar')
)

parameter = NamedParameter()
sql = q.get_sql(parameter=parameter)
self.assertEqual(
    'SELECT "abc"."foo","sq0"."fiz" FROM "abc" JOIN (SELECT "fiz","buz" FROM "efg" WHERE "buz"=:param1)'
    ' "sq0" ON "abc"."bar"="sq0"."buz" WHERE "abc"."bar"=:param2',
    sql,
)
self.assertEqual({'param1': 'buz', 'param2': 'bar'}, parameter.get_parameters())
```

This would allow the user to easily plug into SQLAlchemy for example:

```python
parameter = NamedParameter()
session.execute(text(q.get_sql(parameter=parameter)), **parameter.get_parameters())
```
