### PR TITLE
fix: select arg type

### DIFF
--- a/pypika/queries.py
+++ b/pypika/queries.py
@@ -206,7 +206,7 @@ class Table(Selectable):
     def __hash__(self) -> int:
         return hash(str(self))
 
-    def select(self, *terms: Sequence[Union[int, float, str, bool, Term, Field]]) -> "QueryBuilder":
+    def select(self, *terms: Union[int, float, str, bool, Term, Field]) -> "QueryBuilder":
         """
         Perform a SELECT operation on the current table
 


### PR DESCRIPTION
here `terms` is already `*terms` so there is no need to add `Sequence`. adding `Sequence` means `terms` is `Tuple[Sequence[...]]`。

And it will cause a type error when `query.select(Count("1"))`