### PR TITLE
Add support of SETTINGS ClickHouse clause

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,14 @@ PyPika - Python Query Builder
 
 .. _intro_start:
 
-|BuildStatus|  |CoverageStatus|  |Codacy|  |Docs|  |PyPi|  |License|
+|License|
+
+
+Fork
+----
+
+This fork is not supported by Memfault at this time
+
 
 Abstract
 --------

--- a/pypika/dialects.py
+++ b/pypika/dialects.py
@@ -88,7 +88,7 @@ class MySQLQueryBuilder(QueryBuilder):
     QUERY_CLS = MySQLQuery
 
     def __init__(self, **kwargs: Any) -> None:
-        super().__init__(dialect=Dialects.MYSQL, wrap_set_operation_queries=False, **kwargs)
+        super().__init__(dialect=Dialects.MYSQL, **kwargs)
         self._duplicate_updates = []
         self._ignore_duplicates = False
         self._modifiers = []

--- a/pypika/dialects.py
+++ b/pypika/dialects.py
@@ -826,9 +826,16 @@ class ClickHouseQueryBuilder(QueryBuilder):
             clauses.append(f"SAMPLE {self._sample}")
         if self._sample_offset is not None:
             clauses.append(f"OFFSET {self._sample_offset}")
-        if self._settings:
-            clauses.append(f"SETTINGS {', '.join(f'{k}={v}' for k, v in sorted(self._settings.items()))}")
         return " FROM {clauses}".format(clauses=" ".join(clauses))
+
+    def _apply_pagination(self, querystring: str) -> str:
+        # For SELECTs, SETTINGS must come after LIMIT, which is added by _apply_pagination:
+        querystring = super()._apply_pagination(querystring)
+
+        if self._settings:
+            querystring += f" SETTINGS {', '.join(f'{k}={v}' for k, v in sorted(self._settings.items()))}"
+
+        return querystring
 
     def _set_sql(self, **kwargs: Any) -> str:
         return " UPDATE {set}".format(

--- a/pypika/tests/dialects/test_clickhouse.py
+++ b/pypika/tests/dialects/test_clickhouse.py
@@ -1,5 +1,6 @@
 from unittest import TestCase
 
+import pypika.terms
 from pypika import (
     ClickHouseQuery,
     Database,
@@ -25,12 +26,12 @@ class ClickHouseQueryTests(TestCase):
 
     def test_settings(self) -> None:
         t = Table('abc')
-        query1 = ClickHouseQuery.from_(t).select(t.foo).settings(foo="bar")
+        query1 = ClickHouseQuery.from_(t).select(t.foo).settings(foo="bar").limit(1)
         query2 = query1.settings(baz="qux")
         # Settings get deep-copied:
-        self.assertEqual(str(query1), 'SELECT "foo" FROM "abc" SETTINGS foo=bar')
+        self.assertEqual(str(query1), 'SELECT "foo" FROM "abc" LIMIT 1 SETTINGS foo=bar')
         # Settings are ordered alphabetically in the query string:
-        self.assertEqual(str(query2), 'SELECT "foo" FROM "abc" SETTINGS baz=qux, foo=bar')
+        self.assertEqual(str(query2), 'SELECT "foo" FROM "abc" LIMIT 1 SETTINGS baz=qux, foo=bar')
 
 class ClickHouseDeleteTests(TestCase):
     table_abc = Table("abc")

--- a/pypika/tests/dialects/test_clickhouse.py
+++ b/pypika/tests/dialects/test_clickhouse.py
@@ -29,9 +29,14 @@ class ClickHouseQueryTests(TestCase):
         query1 = ClickHouseQuery.from_(t).select(t.foo).settings(foo="bar").limit(1)
         query2 = query1.settings(baz="qux")
         # Settings get deep-copied:
-        self.assertEqual(str(query1), 'SELECT "foo" FROM "abc" LIMIT 1 SETTINGS foo=bar')
+        self.assertEqual(str(query1), 'SELECT "foo" FROM "abc" LIMIT 1 SETTINGS foo=\'bar\'')
         # Settings are ordered alphabetically in the query string:
-        self.assertEqual(str(query2), 'SELECT "foo" FROM "abc" LIMIT 1 SETTINGS baz=qux, foo=bar')
+        self.assertEqual(str(query2), 'SELECT "foo" FROM "abc" LIMIT 1 SETTINGS baz=\'qux\', foo=\'bar\'')
+
+        # Settings values can be different data types:
+        query3 = ClickHouseQuery.from_(t).select(t.foo).settings(a_str="foo", an_int=123, an_float=4.563, a_bool=True, a_map={"a": 1, "b": 2})
+        self.assertEqual(str(query3), 'SELECT "foo" FROM "abc" SETTINGS a_bool=true, a_map={\'a\': 1, \'b\': 2}, a_str=\'foo\', an_float=4.563, an_int=123')
+
 
 class ClickHouseDeleteTests(TestCase):
     table_abc = Table("abc")

--- a/pypika/tests/test_joins.py
+++ b/pypika/tests/test_joins.py
@@ -845,12 +845,12 @@ class UnionTests(unittest.TestCase):
         with self.assertRaises(SetOperationException):
             str(query1 + query2)
 
-    def test_mysql_query_does_not_wrap_unioned_queries_with_params(self):
+    def test_mysql_query_wraps_unioned_queries(self):
         query1 = MySQLQuery.from_(self.table1).select(self.table1.foo)
         query2 = Query.from_(self.table2).select(self.table2.bar)
 
         self.assertEqual(
-            "SELECT `foo` FROM `abc` UNION SELECT `bar` FROM `efg`",
+            "(SELECT `foo` FROM `abc`) UNION (SELECT `bar` FROM `efg`)",
             str(query1 + query2),
         )
 
@@ -968,12 +968,12 @@ class IntersectTests(unittest.TestCase):
         with self.assertRaises(SetOperationException):
             str(query1.intersect(query2))
 
-    def test_mysql_query_does_not_wrap_intersected_queries_with_params(self):
+    def test_mysql_query_wraps_intersected_queries(self):
         query1 = MySQLQuery.from_(self.table1).select(self.table1.foo)
         query2 = Query.from_(self.table2).select(self.table2.bar)
 
         self.assertEqual(
-            "SELECT `foo` FROM `abc` INTERSECT SELECT `bar` FROM `efg`",
+            "(SELECT `foo` FROM `abc`) INTERSECT (SELECT `bar` FROM `efg`)",
             str(query1.intersect(query2)),
         )
 
@@ -1064,12 +1064,12 @@ class MinusTests(unittest.TestCase):
         with self.assertRaises(SetOperationException):
             str(query1.minus(query2))
 
-    def test_mysql_query_does_not_wrap_minus_queries_with_params(self):
+    def test_mysql_query_wraps_minus_queries(self):
         query1 = MySQLQuery.from_(self.table1).select(self.table1.foo)
         query2 = Query.from_(self.table2).select(self.table2.bar)
 
         self.assertEqual(
-            "SELECT `foo` FROM `abc` MINUS SELECT `bar` FROM `efg`",
+            "(SELECT `foo` FROM `abc`) MINUS (SELECT `bar` FROM `efg`)",
             str(query1 - query2),
         )
 


### PR DESCRIPTION
### Summary

Clickhouse SQL has an optional [`SETTINGS` clause](settings-clause) with
`SELECT`s which can be used to configure [all kinds of options](settings).

In #1 and #2, I took a stab at implementing this, but the implementation contained a bug:
string setting values need to be single-quoted. Also, some settings require a `Map` and
some require a `Bool`. Let's support these too.

[settings-clause]: https://clickhouse.com/docs/en/sql-reference/statements/select#settings-in-select-query
[settings]: https://clickhouse.com/docs/en/operations/settings/settings

 ### Test Plan

Updated the unit test to cover the different `SETTINGS` data types.