### PR TITLE
Fix: PostgreSQLQueryBuilder returns invalid query with no columns to update #832

### DIFF
--- a/pypika/dialects.py
+++ b/pypika/dialects.py
@@ -661,6 +661,9 @@ class PostgreSQLQueryBuilder(QueryBuilder):
 
         querystring = super(PostgreSQLQueryBuilder, self).get_sql(with_alias, subquery, **kwargs)
 
+        if querystring == '':
+            return ''
+
         querystring += self._on_conflict_sql(**kwargs)
         querystring += self._on_conflict_action_sql(**kwargs)
 

--- a/pypika/tests/test_inserts.py
+++ b/pypika/tests/test_inserts.py
@@ -467,6 +467,11 @@ class PostgresInsertIntoOnConflictTests(unittest.TestCase):
             str(qs),
         )
 
+    def test_on_conflict_no_inserts(self):
+        query = PostgreSQLQuery.into(self.table_abc).on_conflict("id").do_nothing()
+
+        self.assertEqual('', str(query))
+
 
 class PostgresInsertIntoReturningTests(unittest.TestCase):
     table_abc = Table("abc")
@@ -566,6 +571,11 @@ class PostgresInsertIntoReturningTests(unittest.TestCase):
         table_cba = Table("cba")
         with self.assertRaises(QueryException):
             PostgreSQLQuery.into(self.table_abc).insert(1).returning(table_cba.id)
+
+    def test_insert_returning_no_inserts(self):
+        query = PostgreSQLQuery.into(self.table_abc).returning(self.table_abc.star)
+
+        self.assertEqual('', str(query))
 
 
 class InsertIntoOnDuplicateTests(unittest.TestCase):

--- a/pypika/tests/test_updates.py
+++ b/pypika/tests/test_updates.py
@@ -152,6 +152,11 @@ class PostgresUpdateTests(unittest.TestCase):
 
         self.assertEqual('UPDATE "abc" SET "foo"=\'bar\' WHERE "foo"=0 RETURNING *', str(q))
 
+    def test_update_returning_no_updates(self):
+        q = PostgreSQLQuery.update(self.table_abc).returning(self.table_abc.star)
+
+        self.assertEqual('', str(q))
+
 
 class SQLLiteUpdateTests(unittest.TestCase):
     table_abc = Table("abc")


### PR DESCRIPTION
Fix for issue #832