### PR TITLE
support python 3.14 by using ast.Constant instead of ast.Str/ast.Num

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ def version():
                 if isinstance(name, ast.Name) and name.id in ('__version__', '__version_info__', 'VERSION'):
                     v = node.value
                     if isinstance(v, ast.Constant):
-                        return v.value
+                        return str(v.value)
 
                     if isinstance(v, ast.Tuple):
                         r = []


### PR DESCRIPTION
This PR updates `setup.py` to replace deprecated `ast.Str` and `ast.Num` with `ast.Constant`
Fixes issue #847
